### PR TITLE
feat: Update GitHub URLs for repository migration to Cor-Incorporated

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -10,7 +10,7 @@ const bottomLinks = [
     links: [
       {
         name: 'Github',
-        href: 'https://github.com/terisuke',
+        href: 'https://github.com/Cor-Incorporated',
         isExternal: true,
       },
       {

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -105,7 +105,7 @@ const articleJsonLd = {
     "url": "https://cor-jp.com/about",
     "sameAs": [
       "https://twitter.com/cor_terisuke",
-      "https://github.com/terisuke",
+      "https://github.com/Cor-Incorporated",
       "https://www.linkedin.com/in/teradakousuke/"
     ]
   },
@@ -124,7 +124,7 @@ const articleJsonLd = {
     },
     "sameAs": [
       "https://twitter.com/cor_terisuke",
-      "https://github.com/terisuke"
+      "https://github.com/Cor-Incorporated"
     ]
   },
   "mainEntityOfPage": {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -91,7 +91,7 @@ const currentLocale = getCurrentLocale(Astro.url);
           "addressCountry": "JP"
         },
         "sameAs": [
-          "https://github.com/terisuke",
+          "https://github.com/Cor-Incorporated",
           "https://x.com/cor_terisuke",
           "https://www.linkedin.com/in/kousuketerada/",
           "https://www.facebook.com/kousuke.terada.35",


### PR DESCRIPTION
## 概要
リポジトリを @terisuke から @Cor-Incorporated に移行するための準備として、GitHub URLを更新しました。

## 変更内容
- GitHub プロフィールリンクの更新（Footer、BlogLayout、Layout コンポーネント）
- ブログ記事内のリポジトリURL更新（iikanjini、gcs-migration-project）
- i18n設定内のengineer-cafe-navigatorデモURL更新

## 影響範囲
- フッターのGitHubリンク
- ブログレイアウトのソーシャルリンク
- メインレイアウトの構造化データ
- ブログ記事内のリポジトリ参照

## テスト
- [ ] サイトのビルド確認
- [ ] リンクの動作確認
- [ ] デプロイテスト

## 関連
リポジトリ移行作業の一環として実施