### PR TITLE
feat(home): C案デザインをトップに移植（土台） refs #62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -698,6 +698,70 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
       "cpu": [
@@ -707,6 +771,294 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -6113,6 +6465,198 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.3.tgz",
+      "integrity": "sha512-KF2XZ4ZdmDGGtEYmx5wpzn6u8vg7AdBHaEOvDKu8GOs7xDL/vcU2vMKtTeNe1d4dogkDdi3B9zC77jkatWBwEQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.3.tgz",
+      "integrity": "sha512-VUWeVf+V1UM54jv9M4wen9vMlIAyT69Krl9XjI8SsRxz4tdNV/7QEPlW6JASev/pYdiynUCW0pwaFquDRYdxMw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.3.tgz",
+      "integrity": "sha512-UhgZ/XVNfXQVEJrMIWeK1Laj8KbhjbIz7F4znUk7G4zeGw7TRoJxhb66uWrEsonn1+O45w//0i0Fu0wIovYdYg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.3.tgz",
+      "integrity": "sha512-Pqau7jtgJNmQ/esugfmAT1aCFy/Gxc92FOxI+3n+LbMHBheBnk41xHDhc0HeYlx9G0xP5tK4t0Koy3QGGNqypw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.3.tgz",
+      "integrity": "sha512-dxakOk66pf7KLS7VRYFO7B8WOJLecE5OPL2YOk52eriFd/yeyxt2Km5H0BjLfElokIaR+qWi33gB8MQLrdAY3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.3.tgz",
+      "integrity": "sha512-ySZTNCpbfbK8rqpKJeJR2S0g/8UqqV3QnzcuWvpI60LWxnFN91nxpSSwCbzfOXkzKfar9j5eOuOplf+klKtINg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.3.tgz",
+      "integrity": "sha512-3pVZhIzW09nzi10usAXfIGTTSTYQ141dk88vGFNCgawIzayiIzZQxEcxVtIkdvlEq2YuFsL9Wcj/h61JHHzuFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.3.tgz",
+      "integrity": "sha512-VRnkAvtIkeWuoBJeGOTrZxsNp4HogXtcaaLm8agmbYtLDOhQdpgxW6NjZZjDXbvGF+eOehGulXZ3C1TiwHY4QQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.29.3",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.3.tgz",
+      "integrity": "sha512-IszwRPu2cPnDQsZpd7/EAr0x2W7jkaWqQ1SwCVIZ/tSbZVXPLt6k8s6FkcyBjViCzvB5CW0We0QbbP7zp2aBjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -152,9 +152,17 @@ const currentLocale = getCurrentLocale(Astro.url);
     <!-- C案 fonts: Outfit (display) + Noto Sans JP (body/jp). Inter is loaded via @font-face below. -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link
-      rel="stylesheet"
+      rel="preload"
+      as="style"
       href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Noto+Sans+JP:wght@400;500;700;900&display=swap"
+      onload="this.onload=null;this.rel='stylesheet'"
     />
+    <noscript>
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Noto+Sans+JP:wght@400;500;700;900&display=swap"
+      />
+    </noscript>
     <link rel="preconnect" href="https://esm.sh" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import Footer from '../components/layout/Footer.astro';
 import Header from '../components/layout/Header.astro';
 import WebVitals from '../components/performance/WebVitals.astro';
 import { getCurrentLocale } from '../utils/i18n';
+import '../styles/global.css';
 
 interface Props {
   description: string;
@@ -148,6 +149,12 @@ const currentLocale = getCurrentLocale(Astro.url);
     <!-- Performance optimizations -->
     <link rel="preload" href="https://fonts.gstatic.com/s/inter/v13/UcCO3FwrK3iLTeHuS_fvQtMwCp50KnMw2boKoduKmMEVuLyfAZ9hiA.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- C案 fonts: Outfit (display) + Noto Sans JP (body/jp). Inter is loaded via @font-face below. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700;800;900&family=Noto+Sans+JP:wght@400;500;700;900&display=swap"
+    />
     <link rel="preconnect" href="https://esm.sh" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="dns-prefetch" href="//fonts.gstatic.com" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,26 +1,235 @@
 ---
-import About from '../components/home/About.astro';
-import Cta from '../components/home/Cta.astro';
-import Hero from '../components/home/Hero.astro';
-import Services from '../components/home/Services.astro';
-import Testimonials from '../components/home/Testimonials.astro';
 import Layout from '../layouts/Layout.astro';
-import Expertise from '../components/home/Expertise.astro';
 import { getCurrentLocale, getTranslations } from '../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
 ---
 
-
 <Layout
   description={t.meta.home.description}
   title={t.meta.home.title}
 >
-  <Hero />
-  <Services />
-  <Expertise />
-  <About />
-  <Testimonials />
-  <Cta />
+  <!-- Hero: 課題訴求 + 想いをチラ見せ -->
+  <section class="relative min-h-[88vh] flex items-center overflow-hidden bg-gradient-to-br from-cor-paper via-teal-50/50 to-cyan-50/50">
+    <!-- 装飾 -->
+    <div class="absolute inset-0 grid-bg opacity-30"></div>
+    <div class="absolute top-0 right-0 w-[36rem] h-[36rem] bg-gradient-to-br from-teal-300/20 to-cyan-300/20 rounded-full blur-3xl"></div>
+    <div class="absolute bottom-0 left-0 w-96 h-96 bg-gradient-to-br from-cor-accent/15 to-amber-200/20 rounded-full blur-3xl"></div>
+
+    <div class="relative max-w-6xl mx-auto px-6 py-20 w-full">
+      <p class="font-display text-xs tracking-[0.3em] text-teal-700 font-bold mb-8">
+        COR. INC. — AI × CO-CREATION
+      </p>
+
+      <h1 class="font-jp text-5xl sm:text-6xl md:text-7xl font-black tracking-tight leading-[1.1] mb-6 max-w-4xl">
+        現場の課題を、<br />
+        <span class="bg-gradient-to-r from-teal-700 to-cor-accent bg-clip-text text-transparent">
+          AIで解く。
+        </span>
+      </h1>
+
+      <p class="font-jp text-lg sm:text-xl text-cor-ink/60 italic mb-10 max-w-2xl leading-relaxed">
+        — 共創を通じて、<br class="sm:hidden" />誰一人取り残されない未来へ。
+      </p>
+
+      <div class="flex flex-col sm:flex-row gap-3 mb-16">
+        <a
+          href="https://griftai.org"
+          target="_blank"
+          rel="noopener"
+          class="group inline-flex items-center justify-center gap-2 px-8 py-4 bg-cor-accent text-white rounded-full font-bold hover:bg-orange-600 transition shadow-xl shadow-cor-accent/30"
+        >
+          <span class="inline-block w-2 h-2 rounded-full bg-white animate-pulse"></span>
+          まずはAI見積もりを試す
+          <svg class="w-4 h-4 group-hover:translate-x-1 transition" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </a>
+        <a
+          href="#challenges"
+          class="inline-flex items-center justify-center gap-2 px-8 py-4 bg-cor-ink text-white rounded-full font-bold hover:bg-cor-ink/90 transition"
+        >
+          課題から相談する
+        </a>
+        <a
+          href="#story"
+          class="inline-flex items-center justify-center gap-2 px-6 py-4 bg-white border border-cor-ink/15 text-cor-ink rounded-full font-bold hover:bg-cor-ink/5 transition"
+        >
+          想いを読む
+        </a>
+      </div>
+
+      <!-- バッジ群 -->
+      <div class="flex flex-wrap gap-2 text-xs">
+        <span class="px-3 py-1.5 bg-white/80 backdrop-blur border border-cor-ink/10 rounded-full">
+          AI駆動開発 4〜5倍生産性
+        </span>
+        <span class="px-3 py-1.5 bg-white/80 backdrop-blur border border-cor-ink/10 rounded-full">
+          ローカルLLM × ISMS整備中
+        </span>
+        <span class="px-3 py-1.5 bg-white/80 backdrop-blur border border-cor-ink/10 rounded-full">
+          OSS 18万行 / 8名貢献
+        </span>
+      </div>
+    </div>
+  </section>
+
+  <!-- 2カラム: 課題 × 想い -->
+  <section class="py-24 bg-white">
+    <div class="max-w-7xl mx-auto px-6">
+      <div class="grid lg:grid-cols-2 gap-12 lg:gap-20">
+        <!-- 左: 課題 -->
+        <div id="challenges">
+          <p class="text-xs tracking-widest text-cor-accent font-bold mb-4 uppercase">
+            01 / あなたの課題
+          </p>
+          <h2 class="font-jp text-3xl sm:text-4xl font-black leading-tight mb-8">
+            こんな課題、<br />
+            一緒に解きましょう。
+          </h2>
+
+          <div class="space-y-3">
+            {
+              [
+                { icon: '🏫', text: '老朽化した基幹システムをクラウド化したい' },
+                { icon: '🏢', text: '多言語対応のAI受付・チャットを導入したい' },
+                { icon: '🤖', text: '生成AIサービスをゼロから本番化したい' },
+                { icon: '🔒', text: '機密データを外に出さずにAI活用したい' },
+                { icon: '🏗', text: '業界特化のAIツールを作りたい' },
+                { icon: '📊', text: 'AI駆動開発を社内に内製化したい' },
+              ].map((c) => (
+                <a
+                  href="#"
+                  class="flex items-center gap-4 p-4 rounded-2xl border border-cor-ink/10 hover:border-cor-accent hover:bg-cor-accent-soft/30 transition group"
+                >
+                  <span class="text-2xl">{c.icon}</span>
+                  <span class="flex-1 font-jp text-cor-ink/90 group-hover:text-cor-ink font-medium">
+                    {c.text}
+                  </span>
+                  <span class="text-cor-ink/30 group-hover:text-cor-accent group-hover:translate-x-1 transition">→</span>
+                </a>
+              ))
+            }
+          </div>
+
+          <a
+            href="#contact"
+            class="mt-8 inline-flex items-center gap-2 px-6 py-3 bg-cor-accent text-white rounded-full font-bold hover:bg-orange-600 transition"
+          >
+            無料相談する →
+          </a>
+        </div>
+
+        <!-- 右: 想い -->
+        <div id="story" class="lg:border-l lg:border-cor-ink/10 lg:pl-20">
+          <p class="text-xs tracking-widest text-teal-700 font-bold mb-4 uppercase">
+            02 / 私たちの想い
+          </p>
+          <h2 class="font-jp text-3xl sm:text-4xl font-black leading-tight mb-8">
+            なぜCor.は<br />
+            この事業をしているのか。
+          </h2>
+
+          <blockquote class="border-l-4 border-teal-500 pl-6 mb-8 text-cor-ink/80 font-jp leading-relaxed italic">
+            元音楽家・営業職を経てエンジニアとして起業した私自身の特性から、<strong class="not-italic">「誤解のないコミュニケーション」をAI技術で実現する</strong>ためにCor.をしています。
+            <footer class="mt-3 text-xs text-cor-ink/50 not-italic">— 代表 寺田康佑</footer>
+          </blockquote>
+
+          <div class="space-y-6">
+            <div>
+              <p class="text-xs tracking-widest text-teal-700 font-bold mb-2">MISSION</p>
+              <p class="font-jp font-bold text-lg leading-relaxed">
+                競争ではなく共創を通じて、未来を切り拓き、幸福な社会を実現する。
+              </p>
+            </div>
+            <div>
+              <p class="text-xs tracking-widest text-teal-700 font-bold mb-2">VISION</p>
+              <p class="font-jp font-bold text-lg leading-relaxed">
+                多様な認知特性や価値観を持つ全ての人が、誤解なく互いを理解し合える世界。
+              </p>
+            </div>
+            <div>
+              <p class="text-xs tracking-widest text-teal-700 font-bold mb-2">WHY</p>
+              <p class="font-jp text-cor-ink/70 leading-relaxed">
+                <strong class="text-cor-ink">この想いがあるから、受託も自社開発も同じ軸で選びます。</strong>
+                〈誤解なき共創に資するか／作り手が本来の実力を発揮できる世界に近づくか〉が判断基準。
+              </p>
+            </div>
+          </div>
+
+          <a
+            href="#about"
+            class="mt-8 inline-flex items-center gap-2 px-6 py-3 bg-white border-2 border-cor-ink/10 text-cor-ink rounded-full font-bold hover:bg-cor-ink/5 transition"
+          >
+            代表ストーリーを読む →
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Grift体験帯 -->
+  <section class="py-24 bg-gradient-to-br from-cor-accent-soft via-orange-100/50 to-amber-50 relative overflow-hidden">
+    <div class="absolute -top-20 -right-20 w-96 h-96 bg-cor-accent/15 rounded-full blur-3xl"></div>
+    <div class="relative max-w-5xl mx-auto px-6">
+      <div class="grid md:grid-cols-2 gap-12 items-center">
+        <div>
+          <p class="text-xs tracking-widest text-cor-accent font-bold mb-4 uppercase">
+            Try Our AI / Grift
+          </p>
+          <h2 class="font-jp text-3xl sm:text-4xl font-black leading-tight mb-6">
+            言葉で説明する前に、<br />
+            <span class="text-cor-accent">AIで試してみませんか？</span>
+          </h2>
+          <p class="text-cor-ink/70 leading-relaxed mb-8">
+            自社AIツール <strong class="text-cor-ink">Grift</strong> に、あなたの作りたいものを入力するだけ。<br />
+            GitHub実績と市場相場から、根拠ある<strong class="text-cor-ink">見積もり・納期・類似実績</strong>を30秒で生成します。
+          </p>
+          <div class="flex flex-col sm:flex-row gap-3">
+            <a
+              href="https://griftai.org"
+              target="_blank"
+              rel="noopener"
+              class="inline-flex items-center justify-center gap-2 px-8 py-4 bg-cor-accent text-white rounded-full font-bold hover:bg-orange-600 transition shadow-xl shadow-cor-accent/30"
+            >
+              無料で試す →
+            </a>
+            <span class="inline-flex items-center gap-2 px-4 py-4 text-xs text-cor-ink/60">
+              <svg class="w-4 h-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path d="M5 13l4 4L19 7"/></svg>
+              登録不要・30秒
+            </span>
+          </div>
+        </div>
+        <div class="relative">
+          <div class="absolute -inset-3 bg-gradient-to-br from-cor-accent/20 to-amber-300/20 rounded-3xl blur-2xl"></div>
+          <div class="relative bg-white rounded-3xl shadow-2xl border border-cor-ink/5 p-6">
+            <div class="flex items-center gap-2 mb-4">
+              <div class="w-9 h-9 bg-gradient-to-br from-cor-accent to-orange-600 rounded-lg flex items-center justify-center text-white font-display font-black">G</div>
+              <div class="font-display font-black text-cor-ink">Grift</div>
+              <span class="ml-auto text-xs text-emerald-600 font-bold">● ONLINE</span>
+            </div>
+            <div class="bg-cor-ink/[0.03] rounded-xl p-3 mb-4 text-sm font-jp">
+              「営業の見積書作成をAIで自動化したい」
+            </div>
+            <div class="grid grid-cols-3 gap-2 mb-4">
+              <div class="bg-cor-accent-soft/60 rounded-lg p-2.5 text-center">
+                <div class="text-[10px] text-cor-ink/60">コスト</div>
+                <div class="font-display font-black text-cor-ink">¥180万〜</div>
+              </div>
+              <div class="bg-cor-accent-soft/60 rounded-lg p-2.5 text-center">
+                <div class="text-[10px] text-cor-ink/60">納期</div>
+                <div class="font-display font-black text-cor-ink">4週間〜</div>
+              </div>
+              <div class="bg-cor-accent-soft/60 rounded-lg p-2.5 text-center">
+                <div class="text-[10px] text-cor-ink/60">類似</div>
+                <div class="font-display font-black text-cor-ink">5件</div>
+              </div>
+            </div>
+            <button class="w-full py-2.5 bg-cor-ink text-white rounded-lg font-bold text-sm hover:bg-cor-ink/90 transition">
+              この見積もりで相談する →
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,7 +112,7 @@ const t = getTranslations(currentLocale);
           </div>
 
           <a
-            href="#contact"
+            href="/contact"
             class="mt-8 inline-flex items-center gap-2 px-6 py-3 bg-cor-accent text-white rounded-full font-bold hover:bg-orange-600 transition"
           >
             無料相談する →
@@ -157,7 +157,7 @@ const t = getTranslations(currentLocale);
           </div>
 
           <a
-            href="#about"
+            href="/about"
             class="mt-8 inline-flex items-center gap-2 px-6 py-3 bg-white border-2 border-cor-ink/10 text-cor-ink rounded-full font-bold hover:bg-cor-ink/5 transition"
           >
             代表ストーリーを読む →
@@ -224,9 +224,14 @@ const t = getTranslations(currentLocale);
                 <div class="font-display font-black text-cor-ink">5件</div>
               </div>
             </div>
-            <button class="w-full py-2.5 bg-cor-ink text-white rounded-lg font-bold text-sm hover:bg-cor-ink/90 transition">
+            <a
+              href="https://griftai.org"
+              target="_blank"
+              rel="noopener"
+              class="block w-full py-2.5 bg-cor-ink text-white rounded-lg font-bold text-sm text-center hover:bg-cor-ink/90 transition"
+            >
               この見積もりで相談する →
-            </button>
+            </a>
           </div>
         </div>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,63 @@
+/*
+ * C案 (option-c) custom utilities — migrated from cor-hp-mock/src/styles/global.css
+ * Tailwind v3 syntax. Colors / fonts / animations live in tailwind.config.cjs.
+ * This file holds the bespoke CSS classes that aren't expressible as config tokens.
+ */
+
+/* font-display utility adds the tracking the mock relied on */
+.font-display {
+  font-family: 'Outfit', 'Noto Sans JP', system-ui, sans-serif;
+  letter-spacing: -0.02em;
+}
+
+.font-jp {
+  font-family: 'Noto Sans JP', 'Hiragino Sans', system-ui, sans-serif;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.text-shimmer {
+  background: linear-gradient(
+    90deg,
+    currentColor 0%,
+    rgba(255, 255, 255, 0.6) 50%,
+    currentColor 100%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 4s linear infinite;
+}
+
+.grid-bg {
+  background-image:
+    linear-gradient(rgba(10, 15, 28, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(10, 15, 28, 0.04) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+.noise-bg {
+  position: relative;
+}
+
+.noise-bg::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(
+    circle at 1px 1px,
+    rgba(10, 15, 28, 0.06) 1px,
+    transparent 0
+  );
+  background-size: 4px 4px;
+  pointer-events: none;
+  opacity: 0.4;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -9,6 +9,30 @@ module.exports = {
     extend: {
       colors: {
         primary: colors.stone,
+        // C案 (option-c) design tokens
+        'cor-ink': '#0a0f1c',
+        'cor-paper': '#fafaf7',
+        'cor-accent': '#ff5a1f',
+        'cor-accent-soft': '#ffe6db',
+        'cor-teal': '#0ea5e9',
+        'cor-violet': '#7c3aed',
+      },
+      fontFamily: {
+        display: ['Outfit', 'Noto Sans JP', 'system-ui', 'sans-serif'],
+        jp: ['Noto Sans JP', 'Hiragino Sans', 'system-ui', 'sans-serif'],
+      },
+      keyframes: {
+        'float-slow': {
+          '0%, 100%': { transform: 'translateY(0) translateX(0)' },
+          '50%': { transform: 'translateY(-20px) translateX(10px)' },
+        },
+        shimmer: {
+          '0%': { backgroundPosition: '-200% 0' },
+          '100%': { backgroundPosition: '200% 0' },
+        },
+      },
+      animation: {
+        'float-slow': 'float-slow 18s ease-in-out infinite',
       },
     },
     fontFamily: {


### PR DESCRIPTION
## 概要
採用デザイン「C案」(`cor-hp-mock` の option-c) を本番リポジトリのトップに移植する**土台**。体験軸エピック #62 の起点。

## 変更内容
- C案デザイントークン（色6種 `cor-ink/cor-paper/cor-accent...`・フォント `display/jp`・カスタムCSS `grid-bg` 等）を **Tailwind v3** 設定 + 新規 `src/styles/global.css` に移植
- 日本語トップ `src/pages/index.astro` をC案Home本文に置換（旧6コンポーネントの import を撤去）
- Google Fonts（Outfit / Noto Sans JP）読み込みを追加

## 禁止表現の除去
- 「福岡100選」バッジ → 削除
- 「ISMS推進中」→「**整備中**」に修正
- 旧事業名・未取得認証・架空の声 → なし（公開トップを grep 確認済み・ヒット0）

## 確認済み
- ✅ `npm run build` 成功（367ページ）
- ✅ 他言語（en/zh/ko/es）は旧コンポーネントを温存＝壊していない
- ✅ プレビュー(localhost:4321)でC案トップ表示を目視確認

## 既知の残課題（後続エピックで対応）
- ダークモード時の見え方調整
- CTAを「主役1つ＋脇役」に整理（#64 / 体験軸3）
- ダミーリンク `href="#"` の遷移先割り当て

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> High-visibility marketing homepage and global layout styling/fonts affect every page on `Layout.astro`; no auth or data-layer changes.
> 
> **Overview**
> **Japanese homepage (`index.astro`)** is rebuilt from the C案 mock: modular home sections are removed in favor of inline hero, a two-column “challenges × story” block, and a Grift promo band with CTAs to `griftai.org`, `/contact`, and `/about`.
> 
> **Design system groundwork** adds `cor-*` colors, `display`/`jp` font families, and shimmer/float keyframes in `tailwind.config.cjs`, plus new `src/styles/global.css` utilities (`grid-bg`, `.font-display`, `.font-jp`, etc.). **`Layout.astro`** now imports that stylesheet and preloads **Outfit** and **Noto Sans JP** from Google Fonts (site-wide for pages using this layout).
> 
> `package-lock.json` gains optional platform packages for esbuild/lightningcss from dependency resolution; no application logic changes there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 191abd7676c75a458796684ab69f61f06d31a263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->