### PR TITLE
fix(blog): calculateReadingTime returns 0 for empty content

### DIFF
--- a/src/utils/__tests__/blog.test.ts
+++ b/src/utils/__tests__/blog.test.ts
@@ -36,10 +36,12 @@ describe('Blog Utilities', () => {
 
 // Helper functions to test
 function calculateReadingTime(content: string): number {
+  const trimmed = content.trim();
+  // Empty or whitespace-only content has no reading time.
+  if (!trimmed) return 0;
   const wordsPerMinute = 200;
-  const words = content.trim().split(/\s+/).length;
-  const readingTime = Math.ceil(words / wordsPerMinute);
-  return Math.max(readingTime, content.trim() ? 1 : 0);
+  const words = trimmed.split(/\s+/).length;
+  return Math.ceil(words / wordsPerMinute);
 }
 
 function formatSlug(slug: string, lang: string): string {


### PR DESCRIPTION
## 概要
既存ユニットテスト `should handle empty content`（[blog.test.ts:13-16](src/utils/__tests__/blog.test.ts)）が `calculateReadingTime('')` に `0` を期待するが、旧実装が `1` を返して失敗していたため修正。origin/develop 上の既存失敗で、本筋PRとは無関係。

## 根本原因
旧実装:
\`\`\`ts
const words = content.trim().split(/\s+/).length;
const readingTime = Math.ceil(words / wordsPerMinute);
return Math.max(readingTime, content.trim() ? 1 : 0);
\`\`\`
空文字では `''.split(/\s+/)` が `['']`（length 1）を返すため `readingTime = Math.ceil(1/200) = 1`。`Math.max(1, 0)` で `1` となり、`content.trim() ? 1 : 0` の「空なら0」の意図が打ち消されていた。

## 修正
空文字/空白のみ/改行のみは早期 `return 0`。非空入力の挙動は変更なし（`Math.ceil(words/200)` は1語以上で常に1以上のため、旧実装と数学的に同一）。

## 検証
- `npx vitest run src/utils/__tests__/blog.test.ts` → **5/5 pass**
- 境界条件: 空/空白/改行 → 0、200語 → 1、300語 → 2、1語 → 1（全て確認）
- code-reviewer / codex レビュー: CRITICAL/HIGH/MEDIUM 0件

## 補足（follow-up）
このヘルパーはテストローカル関数で、本番の読了時間（`*.astro` 内の `Math.max(1, Math.round(body.length/1000))`）とはアルゴリズムが異なる。本番ロジックの `src/utils/` への抽出は別タスク推奨（本PRスコープ外）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is a test-only helper in `blog.test.ts` with no production call sites; behavior for non-empty content stays the same.
> 
> **Overview**
> Fixes the **test-local** `calculateReadingTime` helper in `blog.test.ts` so empty or whitespace-only strings return **0** instead of **1**, matching the existing `should handle empty content` expectation.
> 
> The change trims input first, returns **0** when nothing remains, and otherwise keeps **200 WPM** with `Math.ceil(words / wordsPerMinute)`. It drops the old `Math.max(..., content.trim() ? 1 : 0)` path that treated `''.split(/\s+/)` as one word and forced a minimum of 1 minute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f07b4a569ab66e70f46301f2318223c5f87a9e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->