### PR TITLE
feat: Home を C案8コンポーネント骨格に刷新（JA優先 / W-1着手）

### DIFF
--- a/src/components/home/ChallengeGrid.astro
+++ b/src/components/home/ChallengeGrid.astro
@@ -1,0 +1,43 @@
+---
+import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+
+const currentLocale = getCurrentLocale(Astro.url);
+const t = getJaTranslations();
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col gap-10 sm:gap-12">
+      <div class="flex max-w-3xl flex-col gap-4">
+        <p
+          class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
+        >
+          {t.homeChallenges.eyebrow}
+        </p>
+        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          {t.homeChallenges.title}
+        </h2>
+      </div>
+      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {
+          t.homeChallenges.items.map((item) => (
+            <li class="flex flex-col gap-3 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+              <h3 class="text-lg font-medium tracking-tight">{item.title}</h3>
+              <p class="text-base text-primary-950/70 dark:text-primary-200/70">
+                {item.description}
+              </p>
+            </li>
+          ))
+        }
+      </ul>
+      <div>
+        <a
+          href={getLocalizedUrl('/contact', currentLocale)}
+          class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+        >
+          {t.homeChallenges.cta}
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/home/FinalCta.astro
+++ b/src/components/home/FinalCta.astro
@@ -1,0 +1,39 @@
+---
+import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+
+const currentLocale = getCurrentLocale(Astro.url);
+const t = getJaTranslations();
+
+const griftUrl = 'https://griftai.org';
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col items-center gap-8 rounded-3xl bg-primary-500/10 px-6 py-16 text-center dark:bg-primary-400/10 sm:px-12 sm:py-20">
+      <div class="flex max-w-2xl flex-col gap-4">
+        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          {t.finalCta.title}
+        </h2>
+        <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+          {t.finalCta.description}
+        </p>
+      </div>
+      <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <a
+          href={griftUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+        >
+          {t.finalCta.primary}
+        </a>
+        <a
+          href={getLocalizedUrl('/contact', currentLocale)}
+          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+        >
+          {t.finalCta.secondary}
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/home/GriftBridge.astro
+++ b/src/components/home/GriftBridge.astro
@@ -1,0 +1,64 @@
+---
+import { getJaTranslations } from '../../utils/i18n';
+
+const t = getJaTranslations();
+
+const griftUrl = 'https://griftai.org';
+const mock = t.griftBridge.mock;
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="grid grid-cols-1 items-center gap-10 lg:grid-cols-2 lg:gap-16">
+      <div class="flex flex-col gap-4 sm:gap-6">
+        <p
+          class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
+        >
+          {t.griftBridge.eyebrow}
+        </p>
+        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          {t.griftBridge.title}
+        </h2>
+        <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+          {t.griftBridge.description}
+        </p>
+        <div>
+          <a
+            href={griftUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+          >
+            {t.griftBridge.cta}
+          </a>
+        </div>
+        <p class="text-sm text-primary-950/70 dark:text-primary-200/70">
+          {t.griftBridge.note}
+        </p>
+      </div>
+
+      <!-- ミニモック -->
+      <div class="rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10 sm:p-8">
+        <div class="flex flex-col gap-5">
+          <div class="rounded-2xl bg-primary-50 p-4 text-base text-primary-950 dark:bg-primary-950 dark:text-primary-200">
+            {mock.input}
+          </div>
+          <dl class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div class="flex flex-col gap-1 rounded-2xl bg-primary-50 p-4 dark:bg-primary-950">
+              <dt class="text-sm text-primary-950/70 dark:text-primary-200/70">{mock.costLabel}</dt>
+              <dd class="text-xl font-medium tracking-tight">{mock.cost}</dd>
+            </div>
+            <div class="flex flex-col gap-1 rounded-2xl bg-primary-50 p-4 dark:bg-primary-950">
+              <dt class="text-sm text-primary-950/70 dark:text-primary-200/70">{mock.durationLabel}</dt>
+              <dd class="text-xl font-medium tracking-tight">{mock.duration}</dd>
+            </div>
+            <div class="flex flex-col gap-1 rounded-2xl bg-primary-50 p-4 dark:bg-primary-950">
+              <dt class="text-sm text-primary-950/70 dark:text-primary-200/70">{mock.similarLabel}</dt>
+              <dd class="text-xl font-medium tracking-tight">{mock.similar}</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/home/KyousouPhilosophy.astro
+++ b/src/components/home/KyousouPhilosophy.astro
@@ -1,0 +1,42 @@
+---
+import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+
+const currentLocale = getCurrentLocale(Astro.url);
+const t = getJaTranslations();
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col gap-10 sm:gap-12">
+      <div class="flex max-w-3xl flex-col gap-4">
+        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          {t.kyousou.title}
+        </h2>
+        <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+          {t.kyousou.description}
+        </p>
+      </div>
+      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
+        {
+          t.kyousou.items.map((item) => (
+            <li class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+              <h3 class="text-2xl font-medium tracking-tight">{item.word}</h3>
+              <p class="text-sm font-medium text-primary-600 dark:text-primary-400">
+                {item.meaning}
+              </p>
+              <p class="text-base text-primary-950/70 dark:text-primary-200/70">{item.cor}</p>
+            </li>
+          ))
+        }
+      </ul>
+      <div>
+        <a
+          href={getLocalizedUrl('/about', currentLocale)}
+          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+        >
+          {t.kyousou.cta}
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/home/ProblemHero.astro
+++ b/src/components/home/ProblemHero.astro
@@ -1,0 +1,67 @@
+---
+import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+
+const currentLocale = getCurrentLocale(Astro.url);
+const t = getJaTranslations();
+
+// 福岡100選 2026-2027 の badge は公開可能日まで非表示（正本ガードレール）。
+const HIDDEN_TRUST_BADGES = ['福岡100選 2026-2027'];
+const trustBadges = t.homeHero.trustBadges.filter(
+  (badge) => !HIDDEN_TRUST_BADGES.includes(badge),
+);
+
+const griftUrl = 'https://griftai.org';
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col items-center gap-8 text-center sm:gap-10">
+      <p
+        class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
+      >
+        {t.homeHero.kicker}
+      </p>
+      <div class="flex max-w-3xl flex-col items-center gap-4 sm:gap-6">
+        <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
+          {t.homeHero.title}
+        </h1>
+        <p class="text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
+          {t.homeHero.subtitle}
+        </p>
+      </div>
+      <div class="flex flex-col items-center gap-4 sm:flex-row sm:flex-wrap sm:justify-center">
+        <a
+          href={griftUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+        >
+          {t.homeHero.primaryCta}
+        </a>
+        <a
+          href={getLocalizedUrl('/contact', currentLocale)}
+          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+        >
+          {t.homeHero.secondaryCta}
+        </a>
+        <a
+          href={getLocalizedUrl('/about', currentLocale)}
+          class="inline-flex items-center justify-center rounded-full px-5 py-3 text-base font-medium text-primary-950 underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200"
+        >
+          {t.homeHero.philosophyCta}
+        </a>
+      </div>
+      {
+        trustBadges.length > 0 && (
+          <ul class="flex flex-wrap items-center justify-center gap-3">
+            {trustBadges.map((badge) => (
+              <li class="rounded-full bg-primary-500/10 px-4 py-1.5 text-sm text-primary-950/70 dark:bg-primary-400/10 dark:text-primary-200/70">
+                {badge}
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    </div>
+  </div>
+</section>

--- a/src/components/home/ProofHighlights.astro
+++ b/src/components/home/ProofHighlights.astro
@@ -1,0 +1,45 @@
+---
+import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+
+const currentLocale = getCurrentLocale(Astro.url);
+const t = getJaTranslations();
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col gap-10 sm:gap-12">
+      <div class="flex max-w-3xl flex-col gap-4">
+        <p
+          class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
+        >
+          {t.proof.eyebrow}
+        </p>
+        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          {t.proof.title}
+        </h2>
+        <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+          {t.proof.description}
+        </p>
+      </div>
+      <dl class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {
+          t.proof.stats.map((stat) => (
+            <div class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+              <dt class="text-sm text-primary-950/70 dark:text-primary-200/70">{stat.label}</dt>
+              <dd class="text-3xl font-medium tracking-tight">{stat.value}</dd>
+              <p class="text-sm text-primary-950/70 dark:text-primary-200/70">{stat.note}</p>
+            </div>
+          ))
+        }
+      </dl>
+      <div>
+        <a
+          href={getLocalizedUrl('/works', currentLocale)}
+          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+        >
+          {t.proof.cta}
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/home/ProofHighlights.astro
+++ b/src/components/home/ProofHighlights.astro
@@ -27,7 +27,7 @@ const t = getJaTranslations();
             <div class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
               <dt class="text-sm text-primary-950/70 dark:text-primary-200/70">{stat.label}</dt>
               <dd class="text-3xl font-medium tracking-tight">{stat.value}</dd>
-              <p class="text-sm text-primary-950/70 dark:text-primary-200/70">{stat.note}</p>
+              <dd class="text-sm text-primary-950/70 dark:text-primary-200/70">{stat.note}</dd>
             </div>
           ))
         }

--- a/src/components/home/SecurityTrust.astro
+++ b/src/components/home/SecurityTrust.astro
@@ -1,0 +1,38 @@
+---
+import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+
+const currentLocale = getCurrentLocale(Astro.url);
+const t = getJaTranslations();
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col gap-10 sm:gap-12">
+      <div class="flex max-w-3xl flex-col gap-4">
+        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          {t.securityTrust.title}
+        </h2>
+        <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+          {t.securityTrust.description}
+        </p>
+      </div>
+      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        {
+          t.securityTrust.items.map((item) => (
+            <li class="rounded-3xl bg-primary-500/10 p-6 text-base dark:bg-primary-400/10">
+              {item}
+            </li>
+          ))
+        }
+      </ul>
+      <div>
+        <a
+          href={getLocalizedUrl('/security', currentLocale)}
+          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+        >
+          {t.securityTrust.cta}
+        </a>
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/home/ServicesReframed.astro
+++ b/src/components/home/ServicesReframed.astro
@@ -1,0 +1,27 @@
+---
+import { getJaTranslations } from '../../utils/i18n';
+
+const t = getJaTranslations();
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col gap-10 sm:gap-12">
+      <h2 class="max-w-3xl text-3xl font-medium tracking-tight sm:text-4xl">
+        {t.services2026.title}
+      </h2>
+      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        {
+          t.services2026.items.map((item) => (
+            <li class="flex flex-col gap-3 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+              <h3 class="text-lg font-medium tracking-tight">{item.name}</h3>
+              <p class="text-base text-primary-950/70 dark:text-primary-200/70">
+                {item.description}
+              </p>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  </div>
+</section>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -4,38 +4,23 @@ import { getCurrentLocale, getTranslations, getLocalizedUrl } from '../../utils/
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
 
-const links = [
-  {
-    ref: '01',
-    name: t.nav.home,
-    href: getLocalizedUrl('/', currentLocale),
-  },
-  {
-    ref: '02',
-    name: t.nav.about,
-    href: getLocalizedUrl('/about', currentLocale),
-  },
-  {
-    ref: '03',
-    name: t.nav.security,
-    href: getLocalizedUrl('/security', currentLocale),
-  },
-  {
-    ref: '04',
-    name: t.nav.products,
-    href: getLocalizedUrl('/products', currentLocale),
-  },
-  {
-    ref: '05',
-    name: t.nav.blog,
-    href: getLocalizedUrl('/blog', currentLocale),
-  },
-  {
-    ref: '06',
-    name: t.nav.contact,
-    href: getLocalizedUrl('/contact', currentLocale),
-  },
+// /works は現状 ja ルートのみ存在。C案の5言語展開までは Works ナビを ja 限定にし、
+// 非ja言語で /xx/works が 404 になるのを防ぐ（5言語 works 新設時にこのガードを外す）。
+const baseLinks = [
+  { name: t.nav.home, href: getLocalizedUrl('/', currentLocale), isExternal: false },
+  ...(currentLocale === 'ja'
+    ? [{ name: t.nav.works, href: getLocalizedUrl('/works', currentLocale), isExternal: false }]
+    : []),
+  { name: t.nav.grift, href: 'https://griftai.org', isExternal: true },
+  { name: t.nav.security, href: getLocalizedUrl('/security', currentLocale), isExternal: false },
+  { name: t.nav.about, href: getLocalizedUrl('/about', currentLocale), isExternal: false },
+  { name: t.nav.blog, href: getLocalizedUrl('/blog', currentLocale), isExternal: false },
+  { name: t.nav.contact, href: getLocalizedUrl('/contact', currentLocale), isExternal: false },
 ];
+const links = baseLinks.map((link, index) => ({
+  ...link,
+  ref: String(index + 1).padStart(2, '0'),
+}));
 ---
 
 <header
@@ -191,6 +176,8 @@ const links = [
           links.map((link) => (
             <a
               href={link.href}
+              target={link.isExternal ? '_blank' : undefined}
+              rel={link.isExternal ? 'noopener noreferrer' : undefined}
               class="group inline-flex py-6 text-3xl font-medium tracking-tight text-primary-950 transition focus-visible:outline-none dark:text-primary-200 sm:py-8 sm:text-4xl"
             >
               <div class="flex flex-1 items-center justify-between rounded-3xl group-focus-visible:outline group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-primary-950 dark:group-focus-visible:outline-primary-200">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,13 @@
 ---
-import About from '../components/home/About.astro';
-import Cta from '../components/home/Cta.astro';
-import Hero from '../components/home/Hero.astro';
-import Services from '../components/home/Services.astro';
-import Testimonials from '../components/home/Testimonials.astro';
+import ProblemHero from '../components/home/ProblemHero.astro';
+import ChallengeGrid from '../components/home/ChallengeGrid.astro';
+import GriftBridge from '../components/home/GriftBridge.astro';
+import ProofHighlights from '../components/home/ProofHighlights.astro';
+import ServicesReframed from '../components/home/ServicesReframed.astro';
+import SecurityTrust from '../components/home/SecurityTrust.astro';
+import KyousouPhilosophy from '../components/home/KyousouPhilosophy.astro';
+import FinalCta from '../components/home/FinalCta.astro';
 import Layout from '../layouts/Layout.astro';
-import Expertise from '../components/home/Expertise.astro';
 import { getCurrentLocale, getTranslations } from '../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -17,10 +19,12 @@ const t = getTranslations(currentLocale);
   description={t.meta.home.description}
   title={t.meta.home.title}
 >
-  <Hero />
-  <Services />
-  <Expertise />
-  <About />
-  <Testimonials />
-  <Cta />
+  <ProblemHero />
+  <ChallengeGrid />
+  <GriftBridge />
+  <ProofHighlights />
+  <ServicesReframed />
+  <SecurityTrust />
+  <KyousouPhilosophy />
+  <FinalCta />
 </Layout>

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -1,0 +1,20 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { getJaTranslations } from '../utils/i18n';
+
+const t = getJaTranslations();
+---
+
+<Layout
+  description={t.meta.works.description}
+  title={t.meta.works.title}
+>
+  <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+    <div class="flex flex-col gap-4 pb-16 text-center sm:pb-20">
+      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{t.works.title}</h1>
+    </div>
+    <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+      {t.works.intro}
+    </p>
+  </div>
+</Layout>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -2,7 +2,7 @@ export type Locale = 'ja' | 'en' | 'zh' | 'ko' | 'es';
 
 const translations = {
   ja: {
-    nav: { home: "Home", about: "About", products: "Products&Insights", blog: "Blog", contact: "Contact", security: "Security" },
+    nav: { home: "Home", about: "About", products: "Products&Insights", blog: "Blog", contact: "Contact", security: "Security", works: "Works", grift: "Grift" },
     hero: {
       title: "言葉を超えて、想いを届ける。",
       subtitle: "かつてトランペットで伝えた感動を、今はコードで。元音楽家が追求する「誤解のないコミュニケーション」の実現。",
@@ -424,7 +424,8 @@ const translations = {
       products: { title: "Products&Insights · Cor.inc", description: "Explore our products and insights page showcasing our innovative IT solutions and media outreach. This page offers detailed information about our product portfolio, development services, and strategic insights. Discover our cutting-edge technology solutions, read about our innovative approaches, and learn how we can help transform your digital presence. Ideal for businesses seeking comprehensive IT services and product solutions." },
       "404": { title: "Not found · Cor.inc", description: "Page not found. Please check the URL in the address bar and try again." },
       privacy: { title: "Privacy policy · Cor.inc", description: "Our privacy policy will help you understand what information is collected and how it is used." },
-      security: { title: "セキュリティ | Cor.inc", description: "Cor.株式会社の情報セキュリティ、ISMS取得に向けた体制、ローカルファーストと機密度ティアによるAI開発環境について。" }
+      security: { title: "セキュリティ | Cor.inc", description: "Cor.株式会社の情報セキュリティ、ISMS取得に向けた体制、ローカルファーストと機密度ティアによるAI開発環境について。" },
+      works: { title: "実績 | Cor.inc", description: "Cor.株式会社の実績紹介。AI受託開発、基幹DB移行、多言語AI受付、建築AI、自社プロダクトGriftなど、領域の異なる実装実績を順次公開します。" }
     },
     privacy: {
       title: "プライバシーポリシー",
@@ -454,6 +455,98 @@ const translations = {
         linkText: "お問い合わせフォーム",
         suffix: "までご連絡ください。"
       }
+    },
+    homeHero: {
+      kicker: "COR. INC. — AI × CO-CREATION",
+      title: "現場の課題を、AIで解く。",
+      subtitle: "違いをぶつけ、価値を磨き、AIで形にする。Cor.は受託開発・AI顧問・自社プロダクトGriftを通じて、事業と作り手が本来の力を発揮できる共創を実装します。",
+      primaryCta: "AI見積もりを試す",
+      secondaryCta: "課題から相談する",
+      philosophyCta: "きょうそうの思想を読む",
+      trustBadges: ["福岡100選 2026-2027", "AI駆動開発 4〜5倍生産性", "ローカルLLM × ISMS取得準備中", "OSS 18万行 / 8名貢献"]
+    },
+    homeChallenges: {
+      eyebrow: "01 / あなたの課題",
+      title: "こんな課題、一緒に解きましょう。",
+      items: [
+        { title: "老朽化した基幹システムをクラウド化したい", description: "既存DB調査、スキーマ整理、Cloud SQL移行、運用設計まで支援。" },
+        { title: "多言語対応のAI受付・チャットを導入したい", description: "音声、RAG、エージェント、施設/自治体向けの案内体験を設計。" },
+        { title: "生成AIサービスをゼロから本番化したい", description: "要件定義、UX、API、課金、CI/CD、監視まで一気通貫。" },
+        { title: "機密データを外に出さずAI活用したい", description: "ローカルLLM、承認AIツール、機密度ティアに応じた設計。" },
+        { title: "業界特化のAIツールを作りたい", description: "建築図面、間取り生成、業務固有データのAI処理など。" },
+        { title: "AI駆動開発を社内に内製化したい", description: "AI顧問、AI研修、開発プロセス設計、チーム伴走。" }
+      ],
+      cta: "無料相談する"
+    },
+    griftBridge: {
+      eyebrow: "Try Our AI / Grift",
+      title: "言葉で説明する前に、AIで試してみませんか？",
+      description: "自社AIツール Grift に、あなたの作りたいものを入力するだけ。GitHub実績と市場相場から、根拠ある参考見積もり・納期・類似実績を30秒で生成します。",
+      cta: "GriftでAI見積もりを試す",
+      note: "Griftの結果は相談前の参考見積もりです。正式な金額・納期は要件確認後に確定します。",
+      mock: {
+        input: "営業の見積書作成をAIで自動化したい",
+        costLabel: "参考コスト",
+        cost: "180万円〜",
+        durationLabel: "参考納期",
+        duration: "4週間〜",
+        similarLabel: "類似実績",
+        similar: "5件"
+      }
+    },
+    proof: {
+      eyebrow: "03 / 実証",
+      title: "自称ではなく、実装で語る。",
+      description: "AI SaaS、AIアンケート、基幹DB移行、多言語AI受付、建築AI。領域も立ち上げ方も異なる実績が、Cor.の実装力を裏付けます。",
+      stats: [
+        { label: "OSS実装", value: "182,368行", note: "Engineer Cafe Navigator" },
+        { label: "主要OSS貢献", value: "87.7%", note: "git実測コミット比率" },
+        { label: "AI駆動開発", value: "4〜5倍", note: "内部実測" },
+        { label: "実績領域", value: "5系統", note: "AI/DB/OSS/建築/自社" }
+      ],
+      cta: "実績を見る"
+    },
+    services2026: {
+      title: "事業の現場に、AIを実装する。",
+      items: [
+        { name: "AI受託開発", description: "生成AI、RAG、エージェント、画像/音声処理を使った本番システムを、要件定義から運用まで実装。" },
+        { name: "AI顧問・AI研修", description: "経営/開発/現場チームに合わせ、AI活用方針、ツール選定、業務導入、内製化を伴走。" },
+        { name: "ローカルLLM・セキュアAI", description: "機密データを外部へ不要に出さず、機密度に応じたAI運用を設計。" },
+        { name: "Grift", description: "GitHub実績と市場相場から、説明できる参考見積もりを生成する自社AIツール。" }
+      ]
+    },
+    securityTrust: {
+      title: "自由に作る。責任を持って守る。",
+      description: "Cor.は、開発者の快適さと、お客様の情報を守る責任を両立させるため、ローカルファースト、最小限のセキュリティログ、機密度ティアに基づく運用を整備しています。",
+      items: [
+        "顧問弁護士と連携し、契約・AI・個人情報・ISMS運用をレビュー",
+        "ISO/IEC 27001認証取得を目標にISMS運用を整備中",
+        "機密度ティアに応じて承認AI・会社アカウント・隔離環境を使い分け",
+        "会社支給Mac、暗号化、MDM、検知・対応型の軽量統制"
+      ],
+      cta: "セキュリティ方針を見る"
+    },
+    kyousou: {
+      title: "Cor.は、きょうそうを追い続ける。",
+      description: "迎合ではなく、衝突でもなく、互いの価値観を持ち寄り、違いを磨き合い、AIで現場の課題を形にする。それがCor.の考える「きょうそう」です。",
+      items: [
+        { word: "共創", meaning: "一緒に価値を作る", cor: "顧客・パートナー・AIと共に作る" },
+        { word: "協奏", meaning: "異なる強みが響き合う", cor: "人、AI、専門性、地域が役割を持つ" },
+        { word: "競争", meaning: "互いを磨く", cor: "イエスマンを拒み、率直に高め合う" },
+        { word: "狂想", meaning: "まだ形のない構想", cor: "妄想で終わらせずプロダクトに落とす" },
+        { word: "狂騒", meaning: "熱量・市場のざわめき", cor: "追う対象ではなく、結果として生むもの" }
+      ],
+      cta: "代表ストーリーを読む"
+    },
+    finalCta: {
+      title: "課題から、きょうそうを始めましょう。",
+      description: "Griftで参考見積もりを試すか、まだ言語化できていない課題からご相談ください。",
+      primary: "AI見積もりを試す",
+      secondary: "相談する"
+    },
+    works: {
+      title: "実績",
+      intro: "実績は順次公開予定です。"
     },
     security: {
       title: "セキュリティ",
@@ -489,7 +582,7 @@ const translations = {
     }
   },
   en: {
-    nav: { home: "Home", about: "About", products: "Products&Insights", blog: "Blog", contact: "Contact", security: "Security" },
+    nav: { home: "Home", about: "About", products: "Products&Insights", blog: "Blog", contact: "Contact", security: "Security", works: "Works", grift: "Grift" },
     hero: {
       title: "Beyond Words, Delivering Feelings.",
       subtitle: "Once expressed through trumpet, now through code. A former musician's pursuit of 'communication beyond words.'",
@@ -976,7 +1069,7 @@ const translations = {
     }
   },
   zh: {
-    nav: { home: "首页", about: "关于我们", products: "产品&洞察", blog: "博客", contact: "联系我们", security: "安全" },
+    nav: { home: "首页", about: "关于我们", products: "产品&洞察", blog: "博客", contact: "联系我们", security: "安全", works: "Works", grift: "Grift" },
     hero: {
       title: "比任何人都更快，超越地平线。",
       subtitle: "通过AI打破语言和文化壁垒，实现人们真正相互理解的社会。",
@@ -1463,7 +1556,7 @@ const translations = {
     }
   },
   ko: {
-    nav: { home: "홈", about: "회사소개", products: "제품&인사이트", blog: "블로그", contact: "문의", security: "보안" },
+    nav: { home: "홈", about: "회사소개", products: "제품&인사이트", blog: "블로그", contact: "문의", security: "보안", works: "Works", grift: "Grift" },
     hero: {
       title: "누구보다 빠르게, 지평선 너머로.",
       subtitle: "AI로 언어와 문화의 벽을 넘어 사람들이 진정으로 이해하는 사회를 실현합니다.",
@@ -1950,7 +2043,7 @@ const translations = {
     }
   },
   es: {
-    nav: { home: "Inicio", about: "Acerca de", products: "Productos&Insights", blog: "Blog", contact: "Contacto", security: "Seguridad" },
+    nav: { home: "Inicio", about: "Acerca de", products: "Productos&Insights", blog: "Blog", contact: "Contacto", security: "Seguridad", works: "Works", grift: "Grift" },
     hero: {
       title: "Más rápido que cualquiera, más allá del horizonte.",
       subtitle: "Superando las barreras del idioma y la cultura con IA para crear una sociedad donde las personas se entiendan verdaderamente.",
@@ -2440,6 +2533,12 @@ const translations = {
 
 export function getTranslations(locale: Locale) {
   return translations[locale];
+}
+
+// JA 専用の翻訳取得。Home C案コンポーネント等、現状 ja のみにコピーが存在する
+// セクションで利用する。union ではなく ja の具体型を返すため新規キーに型安全にアクセスできる。
+export function getJaTranslations() {
+  return translations.ja;
 }
 
 export function getCurrentLocale(url: URL): Locale {


### PR DESCRIPTION
## 概要
**凪沙さん(@nagi0705)のデザイン/トーン作業をアンブロックする骨格**として、Home を C案8コンポーネント構成に刷新（**JA優先**）。正本03の確定コピー + 既存デザイントークンで実装。正本 Epic #43 / #53。

> ⚠️ これは**骨格（scaffold）**です。デザインの精緻化・5言語展開は後段。凪沙さんが ja で構造を見ながら design/copy/tone を磨ける状態が目的です。

## 変更（12ファイル）
- **新規8コンポ**（`src/components/home/`）: ProblemHero / ChallengeGrid / GriftBridge / ProofHighlights / ServicesReframed / SecurityTrust / KyousouPhilosophy / FinalCta
- **`index.astro`(ja)**: 旧6コンポ→新8コンポに差し替え（**en/zh/ko/es は旧構成のまま=JA優先**）
- **Header**: C案ナビ順 Home/Works/Grift/Security/About/Blog/Contact。Grift=外部 griftai.org（target=_blank rel=noopener noreferrer）。ref動的採番。**/works は現状ja のみ存在のため Works ナビは ja 限定**（非jaの404防止／5言語展開時にガード解除）
- **i18n.ts(ja)**: home* キー群 + `getJaTranslations()` helper（新キーがja限定のためunion型回避）。全5言語 nav に works/grift
- **/works スタブ**(ja): ProofHighlights/FinalCta の導線先・404防止

## ガードレール遵守
- 福岡100選 badge **非表示**（dist grep 0・名前付き定数フィルタ）
- griftBridge **参考見積もり注記**表示 / proof stats **note併記**（実測の裏付け・架空顧客0）
- 旧事業名(TapForge等) **0** / ISMS「整備中/取得目標」のみ / 絶対表現なし
- Grift 外部リンク rel付（Header + 3 CTA）

## 検証
- `npm run build`（astro check + build）: **373ページ・0 errors**
- JA Home: 8セクション順序通り生成・実機プレビュー確認（スクショ取得済: ProblemHero / ProofHighlights）
- 非ja Home: 旧構成のまま無傷（"Beyond Words" 残存確認）
- レビュー: code-reviewer + codex（共通 HIGH = 非ja /works 404 → **Works ナビ ja限定化で解消**）

## 既知の制約 / follow-up（骨格段階・別途）
- **5言語展開**: en/zh/ko/es の Home C案化・/works・home*翻訳（要ネイティブ確認）
- **デザイン精緻化**: 凪沙さん作業（外部リンクの新規タブ視覚インジケータ、ProofHighlights の dl/p セマンティクス等の LOW 改善含む）

Refs #43, #53

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 主にマーケティング用 Astro ページと i18n の追加で、認証・データ処理は触れません。JA と他言語 Home の意図的分岐はレビュー時に確認するとよいです。
> 
> **Overview**
> **JA のトップ**を旧6コンポ（Hero/Services 等）から **C案の8セクション**（ProblemHero → ChallengeGrid → GriftBridge → ProofHighlights → ServicesReframed → SecurityTrust → KyousouPhilosophy → FinalCta）に差し替え、デザイン・コピー作業用の骨格を追加します。`en`/`zh`/`ko`/`es` の Home はこの PR では触れず旧構成のままです。
> 
> 新コンポは **`getJaTranslations()`** と JA 専用の `homeHero` / `homeChallenges` / `griftBridge` 等のキーで文言を供給。`ProblemHero` は **福岡100選バッジを定数フィルタで非表示**、Grift 向け CTA は **`griftai.org` を新規タブ + `rel=noopener noreferrer`**。
> 
> **Header** は C案順（Home / Works※ / Grift / Security / About / Blog / Contact）に並べ替え、**Works は `ja` のみ**（`/works` が JA ルートのみのため）。**`/works` スタブページ**を追加し、Proof からの導線と 404 を防ぎます。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4130e9a84e60b1bcdb8f3de8307792ebfc6875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->