### PR TITLE
feat: About を「きょうそう中心」骨格に刷新（JA優先 / W-3）

### DIFF
--- a/src/components/about/AboutHero.astro
+++ b/src/components/about/AboutHero.astro
@@ -1,0 +1,18 @@
+---
+import { getJaTranslations } from '../../utils/i18n';
+
+const t = getJaTranslations();
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex max-w-3xl flex-col gap-6">
+      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
+        {t.aboutPage.title}
+      </h1>
+      <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+        {t.aboutPage.lead}
+      </p>
+    </div>
+  </div>
+</section>

--- a/src/components/about/FounderNote.astro
+++ b/src/components/about/FounderNote.astro
@@ -1,0 +1,21 @@
+---
+import { getJaTranslations } from '../../utils/i18n';
+
+const t = getJaTranslations();
+---
+
+<section id="founder-story" class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex max-w-3xl flex-col gap-6">
+      <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+        {t.aboutPage.founderTitle}
+      </h2>
+      <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+        {t.aboutPage.founderLead}
+      </p>
+      <p class="rounded-3xl bg-primary-500/10 p-6 text-base text-primary-950/60 dark:bg-primary-400/10 dark:text-primary-200/60">
+        {t.aboutPage.founderPlaceholder}
+      </p>
+    </div>
+  </div>
+</section>

--- a/src/components/about/KyousouDefinition.astro
+++ b/src/components/about/KyousouDefinition.astro
@@ -1,0 +1,30 @@
+---
+import { getJaTranslations } from '../../utils/i18n';
+
+const t = getJaTranslations();
+---
+
+<section id="kyousou" class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col gap-10 sm:gap-12">
+      <div class="max-w-3xl">
+        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          {t.aboutPage.kyousouTitle}
+        </h2>
+      </div>
+      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
+        {
+          t.aboutPage.kyousou.map((item) => (
+            <li class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+              <h3 class="text-2xl font-medium tracking-tight">{item.word}</h3>
+              <p class="text-base text-primary-950/70 dark:text-primary-200/70">{item.usage}</p>
+            </li>
+          ))
+        }
+      </ul>
+      <p class="max-w-3xl rounded-3xl bg-primary-600/10 p-6 text-xl font-medium tracking-tight text-primary-700 dark:bg-primary-400/10 dark:text-primary-300 sm:text-2xl">
+        {t.aboutPage.kyousouAxis}
+      </p>
+    </div>
+  </div>
+</section>

--- a/src/components/about/MvvSection.astro
+++ b/src/components/about/MvvSection.astro
@@ -1,0 +1,43 @@
+---
+// MVV/Valuesは正本07案・寺田社長(CEO)承認待ちのドラフトです。
+// 最終文言の確定は寺田社長(CEO)の承認後に行ってください。
+import { getJaTranslations } from '../../utils/i18n';
+
+const t = getJaTranslations();
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div class="flex flex-col gap-10 sm:gap-12">
+      <div class="max-w-3xl">
+        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          {t.aboutPage.mvvTitle}
+        </h2>
+      </div>
+      <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <div class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+          <h3 class="text-sm font-medium uppercase tracking-wide text-primary-600 dark:text-primary-400">
+            Mission
+          </h3>
+          <p class="text-lg text-primary-950/80 dark:text-primary-200/80">{t.aboutPage.mission}</p>
+        </div>
+        <div class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+          <h3 class="text-sm font-medium uppercase tracking-wide text-primary-600 dark:text-primary-400">
+            Vision
+          </h3>
+          <p class="text-lg text-primary-950/80 dark:text-primary-200/80">{t.aboutPage.vision}</p>
+        </div>
+      </div>
+      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {
+          t.aboutPage.values.map((value) => (
+            <li class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+              <h3 class="text-xl font-medium tracking-tight">{value.title}</h3>
+              <p class="text-base text-primary-950/70 dark:text-primary-200/70">{value.description}</p>
+            </li>
+          ))
+        }
+      </ul>
+    </div>
+  </div>
+</section>

--- a/src/components/home/KyousouPhilosophy.astro
+++ b/src/components/home/KyousouPhilosophy.astro
@@ -31,7 +31,7 @@ const t = getJaTranslations();
       </ul>
       <div>
         <a
-          href={getLocalizedUrl('/about', currentLocale)}
+          href={`${getLocalizedUrl('/about', currentLocale)}#founder-story`}
           class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
         >
           {t.kyousou.cta}

--- a/src/components/home/ProblemHero.astro
+++ b/src/components/home/ProblemHero.astro
@@ -45,7 +45,7 @@ const griftUrl = 'https://griftai.org';
           {t.homeHero.secondaryCta}
         </a>
         <a
-          href={getLocalizedUrl('/about', currentLocale)}
+          href={`${getLocalizedUrl('/about', currentLocale)}#kyousou`}
           class="inline-flex items-center justify-center rounded-full px-5 py-3 text-base font-medium text-primary-950 underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200"
         >
           {t.homeHero.philosophyCta}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,23 +1,20 @@
 ---
-import Heading from '../components/about/Heading.astro';
-import Mission from '../components/about/Mission.astro';
-import FounderStory from '../components/about/FounderStory.astro';
-import Team from '../components/about/Team.astro';
-import Values from '../components/about/Values.astro';
+import AboutHero from '../components/about/AboutHero.astro';
+import KyousouDefinition from '../components/about/KyousouDefinition.astro';
+import MvvSection from '../components/about/MvvSection.astro';
+import FounderNote from '../components/about/FounderNote.astro';
 import Layout from '../layouts/Layout.astro';
-import { getCurrentLocale, getTranslations } from '../utils/i18n';
+import { getJaTranslations } from '../utils/i18n';
 
-const currentLocale = getCurrentLocale(Astro.url);
-const t = getTranslations(currentLocale);
+const t = getJaTranslations();
 ---
 
 <Layout
   description={t.meta.about.description}
   title={t.meta.about.title}
 >
-  <Heading />
-  <Mission />
-  <FounderStory />
-  <Values />
-  <Team />
+  <AboutHero />
+  <KyousouDefinition />
+  <MvvSection />
+  <FounderNote />
 </Layout>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -166,8 +166,30 @@ const translations = {
       cta: "ホームに戻る"
     },
     aboutPage: {
-      title: "About",
-      subtitle: "世界で一番「幸せ」のことを考えている企業であること、そして世界で一番本当の幸せを求めて社会を共創する企業であること。"
+      title: 'きょうそうを追い続ける。',
+      lead: 'Cor.は、誰とでも無理に分かり合う会社ではありません。自分の価値観を持つ人同士が、違いを隠さず、互いの成長を求め、AIと技術で現場の課題を形にする会社です。',
+      kyousouTitle: '「きょうそう」とは。',
+      kyousou: [
+        { word: '共創', usage: '顧客、AI、パートナーと一緒に作る' },
+        { word: '協奏', usage: '人・AI・専門性が役割を持って響き合う' },
+        { word: '競争', usage: 'イエスマンを拒み、互いを磨く' },
+        { word: '狂想', usage: 'まだ形のないアイデアを恐れない' },
+        { word: '狂騒', usage: '結果として市場に生む熱量' },
+      ],
+      kyousouAxis: 'きょうそうとは、違いを成果に変える実装態度である。',
+      mvvTitle: 'Mission / Vision / Values',
+      mission: 'きょうそうを通じて、作り手と事業の可能性を解放する。',
+      vision: '価値観の違いが、分断ではなく、より良い実装を生む社会をつくる。',
+      values: [
+        { title: '迎合しない共創', description: '相手に合わせるだけの関係は作らない。率直に問い、必要なら反論し、より良い答えを探す。' },
+        { title: '実証で語る', description: '思想だけでは終わらせない。コード、プロダクト、運用、数字で示す。' },
+        { title: '自由と責任を両立する', description: '人の力を縛らず、守るべき情報は守る。快適さと信頼を同時に設計する。' },
+        { title: '違いを磨き合う', description: '認知特性、専門性、価値観の違いを、妥協ではなく成果へ変える。' },
+        { title: '作り手の実力を解放する', description: 'AIを、人を置き換える道具ではなく、人が本来の力を出すための拡張として使う。' },
+      ],
+      founderTitle: '代表ストーリー',
+      founderLead: 'Cor.の「きょうそう」は、代表 寺田康佑の経験から生まれています。',
+      founderPlaceholder: '代表ストーリーの詳細は準備中です。',
     },
     values: {
       title: "Our Values"
@@ -419,7 +441,7 @@ const translations = {
     ],
     meta: {
       home: { title: "Cor.inc · Pioneering Collaboration Through Innovation", description: "Cor.inc specializes in Python-powered data analysis and Web & Mobile app development, creating innovative, machine learning-enhanced solutions for Innovative people who want to change the world." },
-      about: { title: "About · Cor.inc", description: "Find more our history, values, mission and more. We are a group of people who share the same values." },
+      about: { title: "About | Cor.inc", description: "Cor.株式会社が追い続ける「きょうそう」。共創・協奏・競争・狂想を通じて、作り手と事業の可能性を解放します。" },
       contact: { title: "Contact · Cor.inc", description: "Contact our team to learn more about how we can help you." },
       products: { title: "Products&Insights · Cor.inc", description: "Explore our products and insights page showcasing our innovative IT solutions and media outreach. This page offers detailed information about our product portfolio, development services, and strategic insights. Discover our cutting-edge technology solutions, read about our innovative approaches, and learn how we can help transform your digital presence. Ideal for businesses seeking comprehensive IT services and product solutions." },
       "404": { title: "Not found · Cor.inc", description: "Page not found. Please check the URL in the address bar and try again." },


### PR DESCRIPTION
## 概要
About を C案の「きょうそう中心」骨格に刷新（**JA優先**）。正本07（きょうそうMVV反映メモ）ベース。凪沙さんのデザイン作業＋寺田社長(CEO)の MVV 承認に向けた土台。正本 Epic #43 / #56。

> ⚠️ **骨格（scaffold）**です。MVV/Values/きょうそう定義は正本07の「案」＝**寺田社長(CEO)承認待ちドラフト**（MvvSection 冒頭にコメント明示）。FounderNote は準備中プレースホルダ。デザイン精緻化は凪沙さん。

## 変更（8ファイル）
- **新規4コンポ**（`src/components/about/`）: AboutHero（H1「きょうそうを追い続ける。」）/ KyousouDefinition（`#kyousou`・5表記+軸の一文）/ MvvSection（Mission/Vision/Values5項目）/ FounderNote（`#founder-story`）
- **about.astro(ja)**: 旧コンポ（音楽家ナラティブ）→新4コンポに差し替え（**en/zh/ko/es は旧構成のまま=JA優先**）
- **i18n.ts(ja)**: `aboutPage` キー群 + `getJaTranslations()` / `meta.about` を正本03確定文へ
- **Home CTA deep-link**: ProblemHero「きょうそうの思想を読む」→`/about#kyousou`、KyousouPhilosophy「代表ストーリーを読む」→`/about#founder-story`（追加アンカーを活用）

## ガードレール遵守
- 旧事業名(TapForge等)・旧ナラティブ(音楽家/トランペット/ASD) **grep 0**
- 絶対表現なし / MVV案は要CEO承認とコメント明示
- en/zh/ko/es 無傷（旧Mission "trumpet" 残存確認）

## 検証
- `npm run build`（astro check + build）: **373ページ・0 errors**
- アンカー `#kyousou`/`#founder-story` 出力確認・Home CTA から `/about#kyousou` `/about#founder-story` へ遷移（dist確認）
- 実機プレビュー: フルページ確認（スクショ取得・社長提示済）
- レビュー: code-reviewer（Approve・C/H/M 0）+ codex（CRITICAL/HIGH 0）

## follow-up（別PR起票済み）
- BlogLayout JSON-LD の `/about#terisuke` 著者リンク切れ（新Aboutで #terisuke 廃止）→ 共通アンカーへ統一

Refs #43, #56

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/i18n and presentational Astro only; MVV is explicitly draft. Main follow-up risk is the existing `#terisuke` JSON-LD link on the new JA About.
> 
> **Overview**
> **JA `/about`** is rebuilt around a 「きょうそう」 narrative: four new sections (hero, `#kyousou` definition with five readings + axis line, Mission/Vision/Values, `#founder-story` placeholder) replace the old musician/team layout. Copy lives in expanded `aboutPage` keys and `getJaTranslations()`; **en/zh/ko/es About routes are unchanged.**
> 
> **Home** philosophy CTAs now deep-link to `/about#kyousou` and `/about#founder-story`. Japanese **meta.about** title/description are updated. `MvvSection` notes that MVV/Values text is **CEO-approval draft**; founder body is “準備中” only.
> 
> **Note:** Blog JSON-LD still points at `/about#terisuke`, which this page no longer exposes (planned follow-up).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16142ac6d78da8886d186d7dd3a597d9804b562a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->