### PR TITLE
fix(contact): 相談種別を旧事業→正本6区分へ（Wave1 C-4 / #49）

### DIFF
--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -93,9 +93,11 @@ const translations = {
           consultationType: "相談内容",
           consultationTypePlaceholder: "相談内容を選択してください",
           consultationOptions: [
-            "TapForgeについてのご相談",
-            "BoltSiteについてのご相談",
-            "IoTRealmについてのご相談",
+            "Grift / AI見積もりについて",
+            "AI受託開発・システム開発について",
+            "AI顧問・AI研修について",
+            "ローカルLLM・機密データAI活用について",
+            "共創パートナー・採用について",
             "その他"
           ],
           message: "メッセージ"
@@ -695,9 +697,11 @@ const translations = {
           consultationType: "Consultation Type",
           consultationTypePlaceholder: "Please select consultation type",
           consultationOptions: [
-            "Consultation about TapForge",
-            "Consultation about BoltSite",
-            "Consultation about IoTRealm",
+            "Grift / AI estimate",
+            "AI contract & system development",
+            "AI advisory & training",
+            "Local LLM & confidential-data AI",
+            "Co-creation partner & hiring",
             "Other"
           ],
           message: "Message"
@@ -1182,9 +1186,11 @@ const translations = {
           consultationType: "咨询内容",
           consultationTypePlaceholder: "请选择咨询内容",
           consultationOptions: [
-            "关于TapForge的咨询",
-            "关于BoltSite的咨询",
-            "关于IoTRealm的咨询",
+            "Grift / AI报价咨询",
+            "AI受托开发・系统开发",
+            "AI顾问・AI培训",
+            "本地LLM・机密数据AI应用",
+            "共创伙伴・招聘",
             "其他"
           ],
           message: "消息"
@@ -1669,9 +1675,11 @@ const translations = {
           consultationType: "상담 내용",
           consultationTypePlaceholder: "상담 내용을 선택해 주세요",
           consultationOptions: [
-            "TapForge에 대한 상담",
-            "BoltSite에 대한 상담",
-            "IoTRealm에 대한 상담",
+            "Grift / AI 견적 문의",
+            "AI 수탁 개발・시스템 개발",
+            "AI 고문・AI 연수",
+            "로컬 LLM・기밀 데이터 AI 활용",
+            "공동창조 파트너・채용",
             "기타"
           ],
           message: "메시지"
@@ -2156,9 +2164,11 @@ const translations = {
           consultationType: "Tipo de consulta",
           consultationTypePlaceholder: "Seleccione el tipo de consulta",
           consultationOptions: [
-            "Consulta sobre TapForge",
-            "Consulta sobre BoltSite",
-            "Consulta sobre IoTRealm",
+            "Grift / Estimación con IA",
+            "Desarrollo de sistemas y por contrato con IA",
+            "Asesoría y formación en IA",
+            "LLM local y IA con datos confidenciales",
+            "Socio de co-creación y contratación",
             "Otros"
           ],
           message: "Mensaje"


### PR DESCRIPTION
## 概要
公開中の Contact フォーム相談種別に残っていた**旧事業名(TapForge/BoltSite/IoTRealm)を撤去**し、正本00§3.5の新6区分へ差し替え（全5言語）。Wave1 C-4 ガードレールの積み残し解消。正本 #42 / #49。

## 変更（1ファイル）
`src/utils/i18n.ts` の `consultationOptions`（ja/en/zh/ko/es）:
1. Grift / AI見積もりについて
2. AI受託開発・システム開発について
3. AI顧問・AI研修について
4. ローカルLLM・機密データAI活用について
5. 共創パートナー・採用について
6. その他

ContactForm.astro の select は `consultationOptions` を map 表示するためコード変更不要。
※ ja は正本確定、**en/zh/ko/es はネイティブ確認前提のドラフト**。

## 検証
- `npm run build`: **373ページ・0 errors**
- consultationOptions の旧事業: **全5言語 grep 0**／実機 select に6区分描画確認
- レビュー: code-reviewer（Approve・C/H/M 0）+ codex（0）

## 状態
これで公開中の旧事業名は **会社説明文・FAQ・Contact から消滅**。残る旧事業は製品ストーリーセクションのみ（新事業ライン名称/コピー/アイコンの提供待ち＝Phase2）。

Refs #49, #42

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only i18n change; low risk aside from inbound inquiries now using new category strings instead of legacy product names.
> 
> **Overview**
> **Contact form consultation types** are updated in `src/utils/i18n.ts` for **ja, en, zh, ko, and es**: the three legacy product labels (TapForge, BoltSite, IoTRealm) are removed and replaced with **six canonical categories** (Grift / AI estimate, AI contract & system development, AI advisory & training, local LLM & confidential-data AI, co-creation partner & hiring, plus Other).
> 
> `ContactForm.astro` already renders `consultationOptions` from translations, so **no component changes** are required. Submitted `consultationType` values will be the new option strings; anything downstream that matched old labels may need alignment separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257cc64a66247e2e45de1a771d4861128a61ac15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->