### PR TITLE
feat(home): ファーストビュー刷新（凪沙さんレビュー反映#62-65）+ 日本語可読性

### DIFF
--- a/src/components/home/ProblemHero.astro
+++ b/src/components/home/ProblemHero.astro
@@ -22,33 +22,24 @@ const griftUrl = 'https://griftai.org';
         {t.homeHero.kicker}
       </p>
       <div class="flex max-w-3xl flex-col items-center gap-4 sm:gap-6">
-        <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
-          {t.homeHero.title}
-        </h1>
-        <p class="text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
-          {t.homeHero.subtitle}
-        </p>
+        <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl" set:html={t.homeHero.title} />
+        <p class="text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl" set:html={t.homeHero.subtitle}></p>
       </div>
-      <div class="flex flex-col items-center gap-4 sm:flex-row sm:flex-wrap sm:justify-center">
+      <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        {/* パターンA(凪沙さん #64): 主役=Grift体験を大きく塗りつぶしで、脇役=相談はテキストリンクで。最初の一歩を1つに絞る。 */}
         <a
           href={griftUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+          class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
         >
           {t.homeHero.primaryCta}
         </a>
         <a
           href={getLocalizedUrl('/contact', currentLocale)}
-          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
-        >
-          {t.homeHero.secondaryCta}
-        </a>
-        <a
-          href={`${getLocalizedUrl('/about', currentLocale)}#kyousou`}
           class="inline-flex items-center justify-center rounded-full px-5 py-3 text-base font-medium text-primary-950 underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200"
         >
-          {t.homeHero.philosophyCta}
+          {t.homeHero.secondaryCta}
         </a>
       </div>
       {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -167,7 +167,19 @@ const currentLocale = getCurrentLocale(Astro.url);
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
       }
-      
+
+      /* 日本語の改行を読みやすく: 見出しは文節単位で折り(auto-phrase, 非対応ブラウザは従来動作)、
+         行を均等割り(balance)。本文は孤立行(widow)を回避(pretty)。 */
+      h1, h2, h3, p, li, dd, figcaption {
+        word-break: auto-phrase;
+      }
+      h1, h2, h3 {
+        text-wrap: balance;
+      }
+      p {
+        text-wrap: pretty;
+      }
+
       /* Inter font with optional display - won't block render */
       @font-face {
         font-family: 'Inter';

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -482,18 +482,18 @@ const translations = {
     },
     homeHero: {
       kicker: "COR. INC. — AI × CO-CREATION",
-      title: "現場の課題を、AIで解く。",
-      subtitle: "違いをぶつけ、価値を磨き、AIで形にする。Cor.は受託開発・AI顧問・自社プロダクトGriftを通じて、事業と作り手が本来の力を発揮できる共創を実装します。",
-      primaryCta: "AI見積もりを試す",
-      secondaryCta: "課題から相談する",
+      title: "あなたの課題を<br />一緒に形にする。",
+      subtitle: "業務の無駄・使いにくいシステム・<br class='sm:hidden' />やりたいけど進まないこと——<br class='sm:hidden' />Cor.が伴走します。",
+      primaryCta: "30秒で見積もりを試す",
+      secondaryCta: "まず相談する",
       philosophyCta: "きょうそうの思想を読む",
-      trustBadges: ["福岡100選 2026-2027", "AI駆動開発 4〜5倍生産性", "ローカルLLM × ISMS取得準備中", "OSS 18万行 / 8名貢献"]
+      trustBadges: ["AI駆動開発 4〜5倍（内部実測）", "ローカルLLM・情報を外に出さない", "ISMS取得に向け整備中", "福岡発・全国対応"]
     },
     homeChallenges: {
       eyebrow: "01 / あなたの課題",
       title: "こんな課題、一緒に解きましょう。",
       items: [
-        { title: "老朽化した基幹システムをクラウド化したい", description: "既存DB調査、スキーマ整理、Cloud SQL移行、運用設計まで支援。" },
+        { title: "老朽化した基幹システムをクラウド化したい", description: "既存DB調査、スキーマ整理、Cloud SQL移行、運用設計まで支援。" },
         { title: "多言語対応のAI受付・チャットを導入したい", description: "音声、RAG、エージェント、施設/自治体向けの案内体験を設計。" },
         { title: "生成AIサービスをゼロから本番化したい", description: "要件定義、UX、API、課金、CI/CD、監視まで一気通貫。" },
         { title: "機密データを外に出さずAI活用したい", description: "ローカルLLM、承認AIツール、機密度ティアに応じた設計。" },


### PR DESCRIPTION
## 概要
凪沙さんの体験軸1デザインレビュー（#62-65）を実装 + 日本語の改行可読性を全体改善。最優先軸「**開いた瞬間に離脱させない**」に直結。正本 #43 / 体験軸 #62。

## 変更（3ファイル・ja優先）
1. **Hero H1（B案 #63）**: 「あなたの課題を」/「一緒に形にする。」（読点排除・2行・`set:html`+`<br>`）
2. **Hero サブ文**: モバイルで論理改行（中間改行・孤立文字を解消）
3. **CTA パターンA（#64）**: 主役「**30秒で見積もりを試す**」（Grift・大・塗り）＋脇役「まず相談する」（テキスト）。思想CTAは hero から除去（最初の一歩を1つに）
4. **Trust バッジ（#65）**: 4〜5倍（内部実測）/ ローカルLLM・情報を外に出さない / ISMS取得に向け整備中 / 福岡発・全国対応（福岡100選は非表示）
5. **日本語可読性（Layout global `<style>`）**: 見出し・本文を文節折り `word-break: auto-phrase` ＋均等割り `text-wrap: balance` ＋孤立行回避 `text-wrap: pretty`。「Cloud SQL」を non-breaking space で連結

## 検証
- `npm run build`: **373ページ・0 errors**
- 実機モバイル（スクショ）: H1/サブ/CTA/バッジ、カード見出し・説明文の改行が文節単位で自然に（監視・Cloud SQL の語中割れ解消）
- レビュー: code-reviewer（Approve・C/H/M 0）+ codex（0）

## 補足
- ja の C案 Home への反映。en/zh/ko/es は後の5言語展開で同様に反映。
- `word-break: auto-phrase` は Chrome/Android で文節折り、**iOS Safari は従来動作にフォールバック**（Hero手動改行・balance・Cloud SQL連結は全ブラウザ有効）。

Refs #62, #63, #64, #65

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy, layout CSS, and controlled i18n HTML only; no auth, APIs, or data paths. Minor note: `set:html` requires keeping translation strings trusted.
> 
> **Overview**
> Refreshes the Japanese home **first view** per design review (#62–65): new H1/subcopy with intentional line breaks via `set:html`, updated CTAs and trust badges in `homeHero` (ja only).
> 
> **Hero (`ProblemHero`)** — Title and subtitle render from i18n HTML (`<br>` / responsive breaks). **CTA pattern A**: one dominant Grift button (“30秒で見積もりを試す”, larger filled style); secondary “まず相談する” as underline text link to contact. The third “きょうそうの思想” hero link is removed so the primary action stays singular.
> 
> **Copy (`i18n` ja)** — Messaging shifts to “あなたの課題を一緒に形にする” and a shorter, pain-point-led subtitle. Trust badges are rewritten (e.g. internal productivity claim, local LLM, ISMS prep, nationwide); “福岡100選” drops from the list (component still filters it if present). “Cloud SQL” uses a non-breaking space in challenge card copy.
> 
> **Global typography (`Layout`)** — Site-wide critical CSS adds `word-break: auto-phrase`, `text-wrap: balance` on headings, and `text-wrap: pretty` on paragraphs for more natural Japanese wrapping (with noted Safari fallback for `auto-phrase`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26b40fcfb832731dc371858032fc74f9716485b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->