### PR TITLE
feat(home): 体験軸2/3反映 — やさしい言い換え+注釈+CTA配置/ネイビー (#68/#69/#71)

### DIFF
--- a/src/components/home/ChallengeGrid.astro
+++ b/src/components/home/ChallengeGrid.astro
@@ -3,6 +3,8 @@ import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../util
 
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getJaTranslations();
+
+const griftUrl = 'https://griftai.org';
 ---
 
 <section class="py-16 sm:py-20">
@@ -30,12 +32,21 @@ const t = getJaTranslations();
           ))
         }
       </ul>
-      <div>
+      <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-start">
+        {/* 主役=Grift体験(外部)を大きく塗りつぶしネイビーで、脇役=相談は控えめに（凪沙さん #71）。 */}
+        <a
+          href={griftUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+        >
+          {t.homeChallenges.ctaPrimary}
+        </a>
         <a
           href={getLocalizedUrl('/contact', currentLocale)}
-          class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
         >
-          {t.homeChallenges.cta}
+          {t.homeChallenges.ctaSecondary}
         </a>
       </div>
     </div>

--- a/src/components/home/FinalCta.astro
+++ b/src/components/home/FinalCta.astro
@@ -23,7 +23,7 @@ const griftUrl = 'https://griftai.org';
           href={griftUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+          class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
         >
           {t.finalCta.primary}
         </a>

--- a/src/components/home/GriftBridge.astro
+++ b/src/components/home/GriftBridge.astro
@@ -27,7 +27,7 @@ const mock = t.griftBridge.mock;
             href={griftUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+            class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
           >
             {t.griftBridge.cta}
           </a>

--- a/src/components/home/ProblemHero.astro
+++ b/src/components/home/ProblemHero.astro
@@ -31,7 +31,7 @@ const griftUrl = 'https://griftai.org';
           href={griftUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+          class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
         >
           {t.homeHero.primaryCta}
         </a>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -484,8 +484,8 @@ const translations = {
       kicker: "COR. INC. — AI × CO-CREATION",
       title: "あなたの課題を<br />一緒に形にする。",
       subtitle: "業務の無駄・使いにくいシステム・<br class='sm:hidden' />やりたいけど進まないこと——<br class='sm:hidden' />Cor.が伴走します。",
-      primaryCta: "30秒で見積もりを試す",
-      secondaryCta: "まず相談する",
+      primaryCta: "AIで見積もりを試す（30秒・登録不要）",
+      secondaryCta: "無料で相談する",
       philosophyCta: "きょうそうの思想を読む",
       trustBadges: ["AI駆動開発 4〜5倍（内部実測）", "ローカルLLM・情報を外に出さない", "ISMS取得に向け整備中", "福岡発・全国対応"]
     },
@@ -493,19 +493,21 @@ const translations = {
       eyebrow: "01 / あなたの課題",
       title: "こんな課題、一緒に解きましょう。",
       items: [
-        { title: "老朽化した基幹システムをクラウド化したい", description: "既存DB調査、スキーマ整理、Cloud SQL移行、運用設計まで支援。" },
-        { title: "多言語対応のAI受付・チャットを導入したい", description: "音声、RAG、エージェント、施設/自治体向けの案内体験を設計。" },
-        { title: "生成AIサービスをゼロから本番化したい", description: "要件定義、UX、API、課金、CI/CD、監視まで一気通貫。" },
-        { title: "機密データを外に出さずAI活用したい", description: "ローカルLLM、承認AIツール、機密度ティアに応じた設計。" },
+        { title: "老朽化した基幹システムをクラウド化したい", description: "今使っているデータの整理から、クラウド上への移行・運用設計まで一緒に進めます。" },
+        { title: "多言語対応のAI受付・チャットを導入したい", description: "音声対応や社内資料で学習したAI、自動で動くAIの仕組みを使って、施設・自治体向けの案内体験を設計します。" },
+        { title: "生成AIサービスをゼロから本番化したい", description: "何を作るかの整理から、使い心地の設計、システム同士をつなぐ仕組み、課金、自動テスト・公開、監視まで一気に対応します。" },
+        { title: "機密データを外に出さずAI活用したい", description: "情報を外に出さないAIや、承認済みのAIツールを使って、情報の重要度ランクに合わせた設計をします。" },
         { title: "業界特化のAIツールを作りたい", description: "建築図面、間取り生成、業務固有データのAI処理など。" },
-        { title: "AI駆動開発を社内に内製化したい", description: "AI顧問、AI研修、開発プロセス設計、チーム伴走。" }
+        { title: "AI駆動開発を社内に内製化したい", description: "AIの活用方針づくり、社内向け研修、開発の進め方の整備まで、チームに寄り添って進めます。" }
       ],
-      cta: "無料相談する"
+      cta: "無料相談する",
+      ctaPrimary: "AIで見積もりを試す",
+      ctaSecondary: "まず相談する"
     },
     griftBridge: {
       eyebrow: "Try Our AI / Grift",
       title: "言葉で説明する前に、AIで試してみませんか？",
-      description: "自社AIツール Grift に、あなたの作りたいものを入力するだけ。GitHub実績と市場相場から、根拠ある参考見積もり・納期・類似実績を30秒で生成します。",
+      description: "過去の開発実績と市場の相場をもとに、参考となる費用・納期・似た事例を30秒で出します。",
       cta: "GriftでAI見積もりを試す",
       note: "Griftの結果は相談前の参考見積もりです。正式な金額・納期は要件確認後に確定します。",
       mock: {
@@ -531,7 +533,7 @@ const translations = {
       cta: "実績を見る"
     },
     services2026: {
-      title: "事業の現場に、AIを実装する。",
+      title: "事業の現場に、AI（人の代わりに考え、動く技術）を実装する。",
       items: [
         { name: "AI受託開発", description: "生成AI、RAG、エージェント、画像/音声処理を使った本番システムを、要件定義から運用まで実装。" },
         { name: "AI顧問・AI研修", description: "経営/開発/現場チームに合わせ、AI活用方針、ツール選定、業務導入、内製化を伴走。" },
@@ -552,7 +554,7 @@ const translations = {
     },
     kyousou: {
       title: "Cor.は、きょうそうを追い続ける。",
-      description: "迎合ではなく、衝突でもなく、互いの価値観を持ち寄り、違いを磨き合い、AIで現場の課題を形にする。それがCor.の考える「きょうそう」です。",
+      description: "迎合ではなく、衝突でもなく、互いの価値観を持ち寄り、違いを磨き合い、AIで現場の課題を形にする。それがCor.の考える「きょうそう（共創・協奏・競争・狂想・狂騒。一緒に作り、磨き合い、響き合うCor.の造語）」です。",
       items: [
         { word: "共創", meaning: "一緒に価値を作る", cor: "顧客・パートナー・AIと共に作る" },
         { word: "協奏", meaning: "異なる強みが響き合う", cor: "人、AI、専門性、地域が役割を持つ" },
@@ -565,7 +567,7 @@ const translations = {
     finalCta: {
       title: "課題から、きょうそうを始めましょう。",
       description: "Griftで参考見積もりを試すか、まだ言語化できていない課題からご相談ください。",
-      primary: "AI見積もりを試す",
+      primary: "AIで見積もりを試す",
       secondary: "相談する"
     },
     works: {


### PR DESCRIPTION
## 概要
凪沙さんの体験軸2/3デザイン決定（#68/#69/#71）を実装（ja）。正本 #43 / 体験軸 #66,#70。

## 変更（5ファイル・ja優先）
- **#68 やさしい言い換え**: `homeChallenges` 5件＋`griftBridge.description` を平易な日本語へ（言い換え辞書準拠）。※業界特化カードは凪沙さん未指定のため現状維持
- **#69 専門語注釈**: 「AI（人の代わりに考え、動く技術）」「きょうそう（共創・協奏・競争・狂想・狂騒…Cor.の造語）」を各**1回・初出のみ**（過剰注釈なし）
- **#71 CTA配置＋ネイビーテーマ**:
  - 主役CTA文言「**AIで見積もりを試す（30秒・登録不要）**」、脇役「無料で相談する」
  - 主役ボタンを**ネイビー #2d4a6b / hover #1e3350 / 白文字**に統一（4箇所: ProblemHero/GriftBridge/FinalCta/ChallengeGrid）
  - ChallengeGrid を**主役（Grift・外部）＋脇役（相談・/contact）の2CTA**化

## 検証
- `npm run build`: **373ページ・0 errors**
- **コントラスト #2d4a6b×白 = 9.12:1（WCAG AAA 合格）**
- 全主役CTAで griftai.org 別タブ・`rel="noopener noreferrer"` 維持
- 実機モバイル（スクショ）: 主役CTAネイビー、ChallengeGrid 2CTA、やさしい言い換え、注釈各1回
- レビュー: code-reviewer（Approve・C/H/M 0）+ codex（0）

## 補足
- ja の C案 Home への反映。en/zh/ko/es は後の5言語展開で同様に。
- 旧 `homeChallenges.cta` キーは未参照のデッドキーとして残置（en等との構造一貫性のため・実害なし）。

Refs #68, #69, #71

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> マーケ文言とホームCTAの見た目のみで、認証・API・データ処理は触れていません。
> 
> **Overview**
> 日本語ホーム向けに、体験軸デザイン（#68/#69/#71）のコピーとCTAを反映します。
> 
> **やさしい言い換え** — `homeChallenges` の課題説明と `griftBridge.description` を平易な表現に差し替え。ヒーロー／最終CTAの文言も「AIで見積もりを試す」「無料で相談する」などに更新。
> 
> **専門語の初出注釈** — `services2026` の見出しと `kyousou` の説明に、AI・きょうそうの短い注釈を各1回だけ追加。
> 
> **CTAの主従と見た目** — Grift（`griftai.org`）を主役、相談を脇役に。`ChallengeGrid` は単一の相談ボタンから **Grift＋相談の2CTA** に変更。`ProblemHero` / `GriftBridge` / `FinalCta` / `ChallengeGrid` の主役ボタンは **ネイビー `#2d4a6b`**（hover `#1e3350`）に統一し、脇役はアウトライン／控えめスタイルに揃えています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 351deafe7a6e7cb7f4ca7499b1e01f8021ce2b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->