### PR TITLE
feat(works): /works を実績7件で実装（寺田社長アサイン #54）

### DIFF
--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -9,12 +9,54 @@ const t = getJaTranslations();
   description={t.meta.works.description}
   title={t.meta.works.title}
 >
-  <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="flex flex-col gap-4 pb-16 text-center sm:pb-20">
+  <div class="mx-auto max-w-2xl px-4 py-16 sm:px-6 sm:py-20 lg:max-w-7xl lg:px-8">
+    <div class="mx-auto flex max-w-3xl flex-col gap-4 pb-10 text-center sm:pb-12">
       <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{t.works.title}</h1>
+      <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+        {t.works.intro}
+      </p>
     </div>
-    <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
-      {t.works.intro}
+
+    <p class="mx-auto mb-12 max-w-3xl text-center text-sm text-primary-950/50 dark:text-primary-200/50">
+      {t.works.note}
     </p>
+
+    <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {
+        t.works.items.map((item) => (
+          <li class="flex flex-col gap-3 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+            <span class="inline-flex w-fit rounded-full bg-primary-500/15 px-3 py-1 text-xs font-medium text-primary-950/70 dark:bg-primary-400/15 dark:text-primary-200/70">
+              {item.tag}
+            </span>
+            <h2 class="text-lg font-medium tracking-tight">
+              {'link' in item && item.link ? (
+                <a
+                  class="underline-offset-4 hover:underline"
+                  href={item.link}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  {item.name}
+                </a>
+              ) : (
+                item.name
+              )}
+            </h2>
+            <p class="text-base text-primary-950/70 dark:text-primary-200/70">
+              {item.description}
+            </p>
+          </li>
+        ))
+      }
+    </ul>
+
+    <div class="mt-16 flex justify-center sm:mt-20">
+      <a
+        class="text-base font-medium text-primary-950/70 underline-offset-4 hover:underline dark:text-primary-200/70"
+        href="/contact"
+      >
+        課題を相談する →
+      </a>
+    </div>
   </div>
 </Layout>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -571,8 +571,18 @@ const translations = {
       secondary: "相談する"
     },
     works: {
-      title: "実績",
-      intro: "実績は順次公開予定です。"
+      title: "実装で語る、Cor.の実績。",
+      intro: "領域も立ち上げ方も異なる実装実績を掲載しています。自称ではなく、コード・運用・数字で示します。",
+      note: "※ 寄与率は git 実測のコミット比率です。NDA・機密案件はクライアント名・製品名を伏せ、内容を抽象化して掲載しています。",
+      items: [
+        { name: "Engineer Cafe Navigator", tag: "OSS / 実名公開", description: "多言語音声AI受付のオープンソース。182,368行・8名貢献、自社寄与率87.7%（git実測）。" },
+        { name: "Grift", tag: "自社プロダクト", description: "GitHub実績と市場相場から、説明できる参考見積もりを生成する自社AI見積・評価基盤。", link: "https://griftai.org" },
+        { name: "cor-jp.com", tag: "自社制作", description: "このコーポレートサイト。Astro・5言語・AI翻訳・高速表示を自社で実装。" },
+        { name: "マルチモーダル生成AI SaaS", tag: "受託 / 匿名", description: "画像・音声・テキストを扱う生成AI SaaSの本番開発（クライアント名は非公開）。" },
+        { name: "アンケート基盤の刷新", tag: "受託 / 匿名", description: "引き継ぎ後のアンケート基盤を刷新・本番化。エージェント基盤移行、テスト・CI/CD整備まで対応。" },
+        { name: "レガシー基幹システムのクラウド移行", tag: "受託 / NDA", description: "教育系の基幹データベースをクラウドへ移行（詳細はNDAのため抽象化）。" },
+        { name: "建築図面・間取り生成AI", tag: "受託 / NDA", description: "建築図面や間取りを扱うAI群を0→1で高速実装（建築系・NDAのため抽象化）。" }
+      ]
     },
     security: {
       title: "セキュリティ",


### PR DESCRIPTION
## 概要
寺田社長アサイン **#54「/works新設＋worksデータ構造」** を正本00§3.2準拠で実装（ja）。/works スタブを実装に置換。Home「実績を見る」CTA の遷移先。

## 変更（2ファイル・ja優先）
- `src/utils/i18n.ts`: ja `works` を title/intro/note/items[7] に拡張
- `src/pages/works.astro`: 見出し＋注記＋実績カードグリッド＋相談CTA

## 実績7件（正本00§3.2）
- **実名公開**: Engineer Cafe Navigator（OSS・182,368行/8名/自社寄与率87.7% git実測）/ Grift（自社・griftai.org外部）/ cor-jp.com（自社制作）
- **匿名**: マルチモーダル生成AI SaaS / アンケート基盤の刷新
- **NDA**: レガシー基幹移行（教育系・抽象化）/ 建築AI（建築系・抽象化）

## ガードレール
- **NDA/匿名はクライアント名・製品名を伏せ抽象化**（code-reviewerが旧IoTRealmストーリーとの照合まで確認・漏洩なし）
- 寄与率=git実測の注記必須・架空実績ゼロ・旧事業名なし・絶対表現なし
- Grift カードは外部 griftai.org（rel="noopener noreferrer" target="_blank"）

## 検証
- `npm run build`: 373ページ・0 errors
- 実機（スクショ）: 7実績カード・git実測注記・NDA抽象化を確認
- レビュー: code-reviewer（Approve・C/H/M 0）+ codex（0）
- ja限定（en/zh/ko/es の /works 非生成・Worksナビは ja限定ガード済）

Refs #54

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static marketing content and ja i18n only; no auth or backend changes. Main review focus is NDA wording and factual claims in copy, not runtime risk.
> 
> **Overview**
> Replaces the **/works** placeholder with a full Japanese portfolio page driven by expanded `works` copy in `i18n.ts` (title, intro, git-measured contribution note, and **seven** case studies).
> 
> **`works.astro`** now renders a responsive card grid (tag, title, description), optional external links (e.g. Grift → `griftai.org` with `rel="noopener noreferrer"`), and a bottom **課題を相談する** link to `/contact`. Layout widens on large screens for the grid. NDA/anonymous entries stay abstracted per the disclaimer note.
> 
> This is the destination for Home **実績を見る** (`ProofHighlights`); Works nav remains ja-only per existing header guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba3a28019df0f4e532059048da969bba2977206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->