### PR TITLE
ci: develop push で Firebase Hosting preview channel に自動デプロイ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     branches:
       - main
@@ -55,6 +56,16 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_COR_JP_WEB }}
           projectId: cor-jp-web
+          expires: 30d
+
+      - name: Deploy to Firebase Hosting (Develop preview)
+        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        uses: FirebaseExtended/action-hosting-deploy@v0.7.1
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_COR_JP_WEB }}
+          projectId: cor-jp-web
+          channelId: develop
           expires: 30d
 
       - name: Deploy to Firebase Hosting (Production)


### PR DESCRIPTION
## 概要
develop の最新を**常設の preview URL** で確認できるよう、`deploy.yml` に develop 用デプロイを追加。凪沙さん/社長が**ローカル起動なし**で develop を確認できる（先日の課題解決）。

## 変更（deploy.yml のみ）
- `on.push.branches` に `develop` 追加
- 新ステップ「Deploy to Firebase Hosting (Develop preview)」: `if: ref==refs/heads/develop && push` → `channelId: develop` / `expires: 30d`
- **本番（channelId: live）は main push 限定のまま維持**

## 安全性（レビュー済）
- code-reviewer + codex が「**develop push で本番(live)は誤発火しない**」を断定（Production step の `if: ref==main && push` を維持、develop push は ref≠main で確実にskip）
- トリガー行列: push main→live / push develop→preview(develop) / PR→main→preview。相互排他。
- secrets は既存3ステップと同一の渡し方・ログ露出なし

## 留意
- preview channel は unguessable な公開URL（レビュー用途・認証なし）。マージ後、develop push で初回デプロイされ URL が発行されます。

base=develop。マージで develop push が走り、初回デプロイ＆URL発行。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with mutually exclusive `if` conditions; develop cannot trigger the production `live` channel.
> 
> **Overview**
> **Adds automatic Firebase Hosting preview deploys on `develop` pushes** so stakeholders can use a stable preview URL without running the app locally.
> 
> `on.push.branches` now includes **`develop`**, and a new step **Deploy to Firebase Hosting (Develop preview)** runs when `ref == refs/heads/develop` and the event is a push, deploying to **`channelId: develop`** with a **30-day** expiry. **Production** deploy to **`channelId: live`** is unchanged and still runs only on **`main`** pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0643f08ad4573e9a6aed2fe909d5a0f4a5a29d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->