### PR TITLE
feat(nav): 体験軸3 — ナビ日本語化/現在地ハイライト + 各ページ次CTA (#72/#73)

### DIFF
--- a/src/components/common/NextStep.astro
+++ b/src/components/common/NextStep.astro
@@ -1,0 +1,56 @@
+---
+interface Cta {
+  label: string;
+  href: string;
+  isExternal?: boolean;
+  primary?: boolean;
+}
+
+interface Props {
+  heading: string;
+  lead?: string;
+  ctas: Cta[];
+}
+
+const { heading, lead, ctas } = Astro.props;
+---
+
+<section class="py-16 sm:py-20">
+  <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
+    <div
+      class="flex flex-col items-center gap-8 rounded-3xl bg-primary-500/10 px-6 py-12 text-center dark:bg-primary-400/10 sm:px-12 sm:py-16"
+    >
+      <div class="flex max-w-2xl flex-col gap-4">
+        <h2 class="text-2xl font-medium tracking-tight sm:text-3xl">{heading}</h2>
+        {lead && (
+          <p class="text-lg text-primary-950/70 dark:text-primary-200/70">{lead}</p>
+        )}
+      </div>
+      <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        {
+          ctas.map((cta) =>
+            cta.primary ? (
+              <a
+                href={cta.href}
+                target={cta.isExternal ? '_blank' : undefined}
+                rel={cta.isExternal ? 'noopener noreferrer' : undefined}
+                class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+              >
+                {cta.label}
+              </a>
+            ) : (
+              <a
+                href={cta.href}
+                target={cta.isExternal ? '_blank' : undefined}
+                rel={cta.isExternal ? 'noopener noreferrer' : undefined}
+                class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+              >
+                {cta.label}
+              </a>
+            )
+          )
+        }
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -17,9 +17,20 @@ const baseLinks = [
   { name: t.nav.blog, href: getLocalizedUrl('/blog', currentLocale), isExternal: false },
   { name: t.nav.contact, href: getLocalizedUrl('/contact', currentLocale), isExternal: false },
 ];
+// 現在地ハイライト判定: Astro.url.pathname と各リンクの href を比較。
+// 末尾スラッシュの揺れを吸収するため正規化してから比較する。トップ(/)も対象。
+// ロジックは全言語共通。外部リンク(Grift 等)は判定対象外。
+const normalizePath = (path: string) => {
+  if (!path) return '/';
+  const trimmed = path.replace(/\/+$/, '');
+  return trimmed === '' ? '/' : trimmed;
+};
+const currentPath = normalizePath(Astro.url.pathname);
+
 const links = baseLinks.map((link, index) => ({
   ...link,
   ref: String(index + 1).padStart(2, '0'),
+  isActive: !link.isExternal && normalizePath(link.href) === currentPath,
 }));
 ---
 
@@ -183,7 +194,12 @@ const links = baseLinks.map((link, index) => ({
               <div class="flex flex-1 items-center justify-between rounded-3xl group-focus-visible:outline group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-primary-950 dark:group-focus-visible:outline-primary-200">
                 <div class="flex items-center gap-6">
                   <span class="text-xs">{link.ref}</span>
-                  <span class="group-hover:underline">{link.name}</span>
+                  <span
+                    class:list={['group-hover:underline', { 'font-semibold text-[#2d4a6b]': link.isActive }]}
+                    aria-current={link.isActive ? 'page' : undefined}
+                  >
+                    {link.name}
+                  </span>
                 </div>
                 <svg
                   class="h-6 w-6 text-primary-600 dark:text-primary-400 sm:h-8 sm:w-8"

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,6 +3,7 @@ import AboutHero from '../components/about/AboutHero.astro';
 import KyousouDefinition from '../components/about/KyousouDefinition.astro';
 import MvvSection from '../components/about/MvvSection.astro';
 import FounderNote from '../components/about/FounderNote.astro';
+import NextStep from '../components/common/NextStep.astro';
 import Layout from '../layouts/Layout.astro';
 import { getJaTranslations } from '../utils/i18n';
 
@@ -17,4 +18,9 @@ const t = getJaTranslations();
   <KyousouDefinition />
   <MvvSection />
   <FounderNote />
+
+  <NextStep
+    heading="Cor.のことが少し分かったら、実際の仕事を見てみませんか？"
+    ctas={[{ label: '実績・事例を見る', href: '/works', primary: true }]}
+  />
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,6 +3,7 @@ import Calendar from '../components/contact/Calendar.astro';
 import ContactForm from '../components/contact/ContactForm.astro';
 import ContactInfo from '../components/contact/ContactInfo.astro';
 import Heading from '../components/contact/Heading.astro';
+import NextStep from '../components/common/NextStep.astro';
 import Layout from '../layouts/Layout.astro';
 import { getCurrentLocale, getTranslations } from '../utils/i18n';
 
@@ -20,4 +21,11 @@ const t = getTranslations(currentLocale);
   <ContactInfo />
   <Calendar />
   <ContactForm />
+
+  {currentLocale === 'ja' && (
+    <NextStep
+      heading="送信ありがとうございます。返信までの間に、実績をご覧ください。"
+      ctas={[{ label: '実績・事例を見る', href: '/works', primary: true }]}
+    />
+  )}
 </Layout>

--- a/src/pages/security.astro
+++ b/src/pages/security.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import NextStep from '../components/common/NextStep.astro';
 import { getCurrentLocale, getLocalizedUrl, getTranslations } from '../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -71,4 +72,11 @@ const t = getTranslations(currentLocale);
       </p>
     </div>
   </div>
+
+  {currentLocale === 'ja' && (
+    <NextStep
+      heading="安心して任せられそうと感じたら、まずは話してみませんか？"
+      ctas={[{ label: '無料で相談する', href: '/contact', primary: true }]}
+    />
+  )}
 </Layout>

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import NextStep from '../components/common/NextStep.astro';
 import { getJaTranslations } from '../utils/i18n';
 
 const t = getJaTranslations();
@@ -50,13 +51,11 @@ const t = getJaTranslations();
       }
     </ul>
 
-    <div class="mt-16 flex justify-center sm:mt-20">
-      <a
-        class="text-base font-medium text-primary-950/70 underline-offset-4 hover:underline dark:text-primary-200/70"
-        href="/contact"
-      >
-        課題を相談する →
-      </a>
-    </div>
   </div>
+
+  <NextStep
+    heading="気になる実績がありましたか？"
+    lead="あなたの課題も、一緒に考えさせてください。"
+    ctas={[{ label: '課題から相談する', href: '/contact', primary: true }]}
+  />
 </Layout>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -2,7 +2,7 @@ export type Locale = 'ja' | 'en' | 'zh' | 'ko' | 'es';
 
 const translations = {
   ja: {
-    nav: { home: "Home", about: "About", products: "Products&Insights", blog: "Blog", contact: "Contact", security: "Security", works: "Works", grift: "Grift" },
+    nav: { home: "ホーム", about: "Cor.について", products: "Products&Insights", blog: "ブログ", contact: "お問い合わせ", security: "セキュリティ", works: "実績・事例", grift: "Grift" },
     hero: {
       title: "言葉を超えて、想いを届ける。",
       subtitle: "かつてトランペットで伝えた感動を、今はコードで。元音楽家が追求する「誤解のないコミュニケーション」の実現。",
@@ -112,12 +112,12 @@ const translations = {
       company: "Company",
       legal: "Legal",
       links: {
-        home: "Home",
-        about: "About",
-        products: "Products&Insights",
-        contact: "Contact",
-        privacy: "Privacy",
-        security: "Security",
+        home: "ホーム",
+        about: "Cor.について",
+        products: "サービス・読みもの",
+        contact: "お問い合わせ",
+        privacy: "プライバシー",
+        security: "セキュリティ",
         legal: "特商法表記"
       },
       description: "Cor.inc は「競争ではなく共創を通じて未来を切り拓き、幸福な社会を実現する。」をミッションに掲げ、AIソリューションの企画・要件定義・開発・運用、及び付随する経理・財務業務を行っています。「競争」よりも「共創」を重視し、スタートアップの強みである「スピード感」を活かし、創造性と革新性に満ちたサービスを提供しています。",


### PR DESCRIPTION
## 概要
凪沙さん体験軸3（#72 ナビ・#73 次に見る場所）を実装（ja）。体験軸3「導線・離脱防止＝迷わせない／行き止まりを作らない」。

## 変更（6編集＋1新規）
- **#72 ナビ**: ja の `nav.*`/`footer.links.*` を日本語化（ホーム/実績・事例/セキュリティ/Cor.について/プライバシー等。**en/zh/ko/es 不変**）。Header に**現在地ハイライト**（`Astro.url.pathname` 比較で active に `text-[#2d4a6b]`+`aria-current=page`・外部Grift除外）。並び順・Works ja限定ガード・Grift外部rel 維持。
- **#73 次に見る場所**: `src/components/common/NextStep.astro` 新設。**works/about/security/contact** 末尾に誘導CTAブロック配置（行き止まり防止）。主役ボタンはネイビー #2d4a6b。Home は既存 FinalCta 活用。

## 検証
- `npm run build`: 373ページ・0 errors
- 現在地ハイライト: 各ページ active ちょうど1件（ja/en/zh/ko/es 実測）
- NextStep CTA href: works→/contact・about→/works・security→/contact・contact→/works
- en/zh/ko/es 非破壊（ラベル維持・ja テキスト漏れ0）
- レビュー: code-reviewer（Approve・C/H/M 0）+ codex（footer privacy/security 日本語化の指摘→対応済）

Refs #72, #73

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer navigation and marketing CTAs only; no auth, APIs, or data handling changes.
> 
> **Overview**
> Improves **Japanese wayfinding** and **end-of-page guidance** without changing other locales’ nav copy.
> 
> **Navigation (#72):** Japanese `nav.*` and `footer.links.*` strings replace English labels (e.g. ホーム, 実績・事例, Cor.について). The header mobile menu compares normalized `Astro.url.pathname` to each internal link and marks the match with navy styling and `aria-current="page"`; external links like Grift are excluded.
> 
> **Next steps (#73):** New reusable `NextStep.astro` adds a rounded CTA band (heading, optional lead, primary/secondary buttons). It is wired at the bottom of **works**, **about**, and on **security** / **contact** for `ja` only, with page-specific copy and targets (`/works`, `/contact`). **works** drops its old inline “課題を相談する” link in favor of this block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8da75b35d15ceb84824da8078ef4c91c75fc18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->