### PR TITLE
feat(home): 体験軸4/5仕上げ — タップ48px/可読性/カード高さ/実績注記 + Contact誤表示修正 (#77/#78/#79/#80)

### DIFF
--- a/src/components/about/KyousouDefinition.astro
+++ b/src/components/about/KyousouDefinition.astro
@@ -12,10 +12,10 @@ const t = getJaTranslations();
           {t.aboutPage.kyousouTitle}
         </h2>
       </div>
-      <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
+      <ul class="grid grid-cols-1 items-stretch gap-6 sm:grid-cols-2 lg:grid-cols-5">
         {
           t.aboutPage.kyousou.map((item) => (
-            <li class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+            <li class="flex h-full flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
               <h3 class="text-2xl font-medium tracking-tight">{item.word}</h3>
               <p class="text-base text-primary-950/70 dark:text-primary-200/70">{item.usage}</p>
             </li>

--- a/src/components/common/NextStep.astro
+++ b/src/components/common/NextStep.astro
@@ -34,7 +34,7 @@ const { heading, lead, ctas } = Astro.props;
                 href={cta.href}
                 target={cta.isExternal ? '_blank' : undefined}
                 rel={cta.isExternal ? 'noopener noreferrer' : undefined}
-                class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+                class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
               >
                 {cta.label}
               </a>
@@ -43,7 +43,7 @@ const { heading, lead, ctas } = Astro.props;
                 href={cta.href}
                 target={cta.isExternal ? '_blank' : undefined}
                 rel={cta.isExternal ? 'noopener noreferrer' : undefined}
-                class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+                class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
               >
                 {cta.label}
               </a>

--- a/src/components/contact/ContactForm.astro
+++ b/src/components/contact/ContactForm.astro
@@ -31,7 +31,7 @@ const t = getTranslations(currentLocale);
             name="name"
             id="your-name"
             autocomplete="name"
-            class="block w-full appearance-none rounded-md border-0 bg-primary-50 px-4 py-4 text-base ring-1 ring-primary-900/40 transition placeholder:text-primary-950/60 hover:ring-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 dark:bg-primary-950 dark:ring-primary-200/40 dark:placeholder:text-primary-200/60 dark:hover:ring-primary-400 dark:focus:ring-primary-400"
+            class="block min-h-[48px] w-full appearance-none rounded-md border-0 bg-primary-50 px-4 py-4 text-base ring-1 ring-primary-900/40 transition placeholder:text-primary-950/60 hover:ring-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 dark:bg-primary-950 dark:ring-primary-200/40 dark:placeholder:text-primary-200/60 dark:hover:ring-primary-400 dark:focus:ring-primary-400"
             placeholder={t.contact.form.fields.name}
             required
           />
@@ -45,7 +45,8 @@ const t = getTranslations(currentLocale);
             name="email"
             id="email"
             autocomplete="email"
-            class="block w-full appearance-none rounded-md border-0 bg-primary-50 px-4 py-4 text-base ring-1 ring-primary-900/40 transition placeholder:text-primary-950/60 hover:ring-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 dark:bg-primary-950 dark:ring-primary-200/40 dark:placeholder:text-primary-200/60 dark:hover:ring-primary-400 dark:focus:ring-primary-400"
+            inputmode="email"
+            class="block min-h-[48px] w-full appearance-none rounded-md border-0 bg-primary-50 px-4 py-4 text-base ring-1 ring-primary-900/40 transition placeholder:text-primary-950/60 hover:ring-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 dark:bg-primary-950 dark:ring-primary-200/40 dark:placeholder:text-primary-200/60 dark:hover:ring-primary-400 dark:focus:ring-primary-400"
             placeholder={t.contact.form.fields.email}
             pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}"
             required
@@ -58,7 +59,7 @@ const t = getTranslations(currentLocale);
           <select
             name="consultationType"
             id="consultation-type"
-            class="block w-full appearance-none rounded-md border-0 bg-primary-50 px-4 py-4 text-base ring-1 ring-primary-900/40 transition hover:ring-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 dark:bg-primary-950 dark:ring-primary-200/40 dark:hover:ring-primary-400 dark:focus:ring-primary-400"
+            class="block min-h-[48px] w-full appearance-none rounded-md border-0 bg-primary-50 px-4 py-4 text-base ring-1 ring-primary-900/40 transition hover:ring-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 dark:bg-primary-950 dark:ring-primary-200/40 dark:hover:ring-primary-400 dark:focus:ring-primary-400"
             required
           >
             <option value="">{t.contact.form.fields.consultationTypePlaceholder}</option>
@@ -77,19 +78,19 @@ const t = getTranslations(currentLocale);
             name="message"
             id="message"
             rows="3"
-            class="block w-full appearance-none rounded-md border-0 bg-primary-50 px-4 py-4 text-base ring-1 ring-primary-900/40 transition placeholder:text-primary-950/60 hover:ring-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 dark:bg-primary-950 dark:ring-primary-200/40 dark:placeholder:text-primary-200/60 dark:hover:ring-primary-400 dark:focus:ring-primary-400"
+            class="block min-h-[120px] w-full appearance-none rounded-md border-0 bg-primary-50 px-4 py-4 text-base ring-1 ring-primary-900/40 transition placeholder:text-primary-950/60 hover:ring-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-600 dark:bg-primary-950 dark:ring-primary-200/40 dark:placeholder:text-primary-200/60 dark:hover:ring-primary-400 dark:focus:ring-primary-400"
             placeholder={t.contact.form.fields.message}
             required></textarea>
         </div>
         <!-- Submit and Reset buttons -->
-        <div>
+        <div class="flex flex-wrap items-center gap-4">
           <button
             type="submit"
             data-sitekey="6LebReopAAAAABVSeGDrJZ7aFIT41z3x7OHR02Q0"
             data-callback="onSubmit"
             data-action="submit"
-            class="g-recaptcha inline-flex items-center justify-center rounded-full border
-            border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition
+            class="g-recaptcha inline-flex min-h-[48px] items-center justify-center rounded-full border
+            border-transparent bg-primary-600 px-6 py-3 text-base font-medium text-white transition
             hover:bg-primary-700 focus-visible:outline focus-visible:outline-2
             focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400
             dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
@@ -98,7 +99,7 @@ const t = getTranslations(currentLocale);
           </button>
           <button
             type="reset"
-            class="inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
+            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-primary-950/20 bg-transparent px-4 py-3 text-sm font-medium text-primary-950/70 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200/70 dark:hover:bg-primary-400/10"
           >
             {t.contact.form.reset}
           </button>

--- a/src/components/home/ChallengeGrid.astro
+++ b/src/components/home/ChallengeGrid.astro
@@ -25,7 +25,7 @@ const griftUrl = 'https://griftai.org';
           t.homeChallenges.items.map((item) => (
             <li class="flex flex-col gap-3 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
               <h3 class="text-lg font-medium tracking-tight">{item.title}</h3>
-              <p class="text-base text-primary-950/70 dark:text-primary-200/70">
+              <p class="text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
                 {item.description}
               </p>
             </li>
@@ -38,13 +38,13 @@ const griftUrl = 'https://griftai.org';
           href={griftUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+          class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
         >
           {t.homeChallenges.ctaPrimary}
         </a>
         <a
           href={getLocalizedUrl('/contact', currentLocale)}
-          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+          class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
         >
           {t.homeChallenges.ctaSecondary}
         </a>

--- a/src/components/home/FinalCta.astro
+++ b/src/components/home/FinalCta.astro
@@ -23,13 +23,13 @@ const griftUrl = 'https://griftai.org';
           href={griftUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+          class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
         >
           {t.finalCta.primary}
         </a>
         <a
           href={getLocalizedUrl('/contact', currentLocale)}
-          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+          class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
         >
           {t.finalCta.secondary}
         </a>

--- a/src/components/home/GriftBridge.astro
+++ b/src/components/home/GriftBridge.astro
@@ -19,7 +19,7 @@ const mock = t.griftBridge.mock;
         <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
           {t.griftBridge.title}
         </h2>
-        <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+        <p class="text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70">
           {t.griftBridge.description}
         </p>
         <div>
@@ -27,7 +27,7 @@ const mock = t.griftBridge.mock;
             href={griftUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
           >
             {t.griftBridge.cta}
           </a>
@@ -55,6 +55,9 @@ const mock = t.griftBridge.mock;
             <div class="flex flex-col gap-1 rounded-2xl bg-primary-50 p-4 dark:bg-primary-950">
               <dt class="text-sm text-primary-950/70 dark:text-primary-200/70">{mock.similarLabel}</dt>
               <dd class="text-xl font-medium tracking-tight">{mock.similar}</dd>
+              {mock.similarNote && (
+                <dd class="text-xs text-primary-950/60 dark:text-primary-200/60">{mock.similarNote}</dd>
+              )}
             </div>
           </dl>
         </div>

--- a/src/components/home/ProblemHero.astro
+++ b/src/components/home/ProblemHero.astro
@@ -23,7 +23,7 @@ const griftUrl = 'https://griftai.org';
       </p>
       <div class="flex max-w-3xl flex-col items-center gap-4 sm:gap-6">
         <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl" set:html={t.homeHero.title} />
-        <p class="text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl" set:html={t.homeHero.subtitle}></p>
+        <p class="text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl" set:html={t.homeHero.subtitle}></p>
       </div>
       <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
         {/* パターンA(凪沙さん #64): 主役=Grift体験を大きく塗りつぶしで、脇役=相談はテキストリンクで。最初の一歩を1つに絞る。 */}
@@ -31,13 +31,13 @@ const griftUrl = 'https://griftai.org';
           href={griftUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+          class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
         >
           {t.homeHero.primaryCta}
         </a>
         <a
           href={getLocalizedUrl('/contact', currentLocale)}
-          class="inline-flex items-center justify-center rounded-full px-5 py-3 text-base font-medium text-primary-950 underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200"
+          class="inline-flex min-h-[48px] items-center justify-center rounded-full px-5 py-3 text-base font-medium text-primary-950 underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200"
         >
           {t.homeHero.secondaryCta}
         </a>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -89,7 +89,7 @@ const bottomLinks = [
           alt="Cor.inc"
           loading="lazy"
         />
-        <p class="text-base text-primary-950/70 dark:text-primary-200/70">
+        <p class="px-5 text-base leading-[1.8] text-primary-950/70 dark:text-primary-200/70 sm:px-0">
           {t.footer.description}
         </p>
         {/* 年は SSG(output:static) のためビルド時評価で焼き込まれる。年初の定期再ビルド、または #44(SSR化) 後のリクエスト時評価で自動更新される。 */}

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -24,7 +24,8 @@ const t = getTranslations(currentLocale);
 
   {currentLocale === 'ja' && (
     <NextStep
-      heading="送信ありがとうございます。返信までの間に、実績をご覧ください。"
+      heading="お問い合わせの前に"
+      lead="Cor.の実績も、ぜひご覧ください。"
       ctas={[{ label: '実績・事例を見る', href: '/works', primary: true }]}
     />
   )}

--- a/src/pages/security.astro
+++ b/src/pages/security.astro
@@ -17,7 +17,7 @@ const t = getTranslations(currentLocale);
       <p class="text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
     </div>
     <div>
-      <p class="mb-4">
+      <p class="mb-4 text-base leading-[1.8]">
         {t.security.lead}
       </p>
 
@@ -27,20 +27,20 @@ const t = getTranslations(currentLocale);
           Array.isArray(t.security?.pillars) && t.security.pillars.map((pillar) => (
             <div>
               <h3 class="mb-2 text-lg font-medium">{pillar.title}</h3>
-              <p>{pillar.description}</p>
+              <p class="text-base leading-[1.8]">{pillar.description}</p>
             </div>
           ))
         }
       </div>
 
       <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
-      <ul class="list-inside list-disc space-y-4">
+      <ul class="list-inside list-disc space-y-4 text-base leading-[1.8]">
         <li>{t.security.status.legal}</li>
         <li>{t.security.status.isms}</li>
       </ul>
 
       <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
-      <p class="mb-4">{t.security.aiDescription}</p>
+      <p class="mb-4 text-base leading-[1.8]">{t.security.aiDescription}</p>
 
       <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
       <div class="overflow-x-auto">
@@ -67,7 +67,7 @@ const t = getTranslations(currentLocale);
       </div>
 
       <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
-      <p class="mb-4">
+      <p class="mb-4 text-base leading-[1.8]">
         {t.security.privacyDescription}<span class="font-medium"><a href={getLocalizedUrl('/privacy', currentLocale)}>{t.security.privacyLinkText}</a></span>{t.security.privacySuffix}
       </p>
     </div>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -517,7 +517,8 @@ const translations = {
         durationLabel: "参考納期",
         duration: "4週間〜",
         similarLabel: "類似実績",
-        similar: "5件"
+        similar: "5件",
+        similarNote: "社内実績ベース"
       }
     },
     proof: {


### PR DESCRIPTION
## 概要
凪沙さん体験軸4/5の仕上げ＋claude-review #100 の実害修正（ja）。

## 変更（11ファイル）
- **#79 タップ/フォーム**: CTA全般＋ContactForm入力に `min-h-[48px]`、email に `inputmode="email"`、送信=主役/リセット=控えめ・`gap-4`
- **#77 スマホ可読性**: 本文 `leading`(1.7-1.8)・footer会社説明 `px-5`・security本文 `leading-[1.8]`
- **#78 レイアウト**: About「きょうそう」5カードの高さ揃え(`items-stretch`/`h-full`)
- **#80 実績注記**: GriftBridge「類似実績 5件」に「**社内実績ベース**」注記(参考トーン)
- **実害修正(#100)**: Contact の「送信ありがとうございます…」が**送信前から常時表示**され誤解を招いていた → 中立文言「お問い合わせの前に / Cor.の実績も、ぜひご覧ください。」に変更

## 検証
- `npm run build`: 373ページ・0 errors
- 「送信ありがとう」完全削除(grep 0)・48px・inputmode・社内実績ベース注記・カード高さ揃え 確認
- en/zh/ko/es 非破壊・旧事業/架空 0
- レビュー: code-reviewer（Approve・C/H/M 0）+ codex（0）

Refs #77, #78, #79, #80

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tailwind class and copy/i18n tweaks only; no auth, APIs, or form submission logic changes beyond UX attributes.
> 
> **Overview**
> Polishes **mobile/touch UX and readability** across marketing pages, plus a **ja contact-page copy fix** and a **Grift mock disclaimer**.
> 
> **Touch & forms:** Site-wide CTAs and `ContactForm` controls get **`min-h-[48px]`**; email adds **`inputmode="email"`**; textarea **`min-h-[120px]`**; submit/reset row uses **`gap-4`** with reset restyled as a secondary outline button.
> 
> **Readability & layout:** Body copy gains **`leading-relaxed`** / **`leading-[1.8]`** (home sections, footer description with mobile **`px-5`**, security page). About **きょうそう** grid uses **`items-stretch`** and **`h-full`** on cards for equal heights.
> 
> **Content:** Grift bridge shows optional **`similarNote`** (“社内実績ベース”) from i18n. **ja** `contact.astro` `NextStep` no longer implies post-submit thanks before sending—replaced with **「お問い合わせの前に」** / lead about viewing works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5648f9085dffcd3357d4d70b84629bd3d83912b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->