### PR TITLE
chore(ci): main へのマージは develop からのみ許可する base ガードを追加

### DIFF
--- a/.github/workflows/guard-base-branch.yml
+++ b/.github/workflows/guard-base-branch.yml
@@ -1,0 +1,48 @@
+name: Guard base branch
+
+# main へのマージは develop からのみ許可する。
+# それ以外のブランチから main 宛に PR が開かれたら、自動で fail させ、
+# develop 経由にするよう PR にコメントで誘導する（誤 base=main の再発防止）。
+#
+# 注1: pull_request ワークフローは base ブランチ側のファイルで実行されるため、
+#      このガードを効かせるには main にこのファイルが存在している必要がある。
+# 注2: ワークフロー単体ではマージを物理的にブロックできない（チェックが赤くなるだけ）。
+#      確実に止めるには main のブランチ保護で status check "guard" を
+#      required に設定すること（develop からの PR のみが緑になる）。
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: main へは develop からのみ許可
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD: ${{ github.head_ref }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -eo pipefail
+          echo "main 宛 PR #${PR}  head=${HEAD}"
+          if [ "$HEAD" = "develop" ]; then
+            echo "✅ develop → main は許可された唯一の経路です"
+            exit 0
+          fi
+          # 誘導コメントは初回のみ。隠しマーカーで既出を判定し、edited 連発でも重複させない。
+          MARKER="<!-- guard-base-branch -->"
+          EXISTING=$(gh pr view "$PR" --repo "$REPO" --json comments \
+            --jq "[.comments[] | select(.body | contains(\"$MARKER\"))] | length" 2>/dev/null || echo 0)
+          if [ "${EXISTING:-0}" -eq 0 ]; then
+            # 単一引用符の format 文字列なのでバッククォートはリテラル。動的値は %s で渡す。
+            BODY=$(printf '%s\n🚫 **`main` へのマージは `develop` からのみ許可しています。**\n\nこのPRは head=`%s` → base=`main` ですが、変更は **`develop` を経由** してください:\n\n1. base を `develop` に変更（このPR画面の base 切替、または `gh pr edit %s --base develop`）\n2. develop に取り込まれた後、リリース時に develop → main をまとめて PR します。' "$MARKER" "$HEAD" "$PR")
+            gh pr comment "$PR" --repo "$REPO" --body "$BODY" || true
+          fi
+          echo "::error title=base が main です::main へは develop からの PR のみ許可されています。base を develop に変更してください。"
+          exit 1


### PR DESCRIPTION
## 目的
誤って feature ブランチから `main` 宛に PR が開かれた場合（今回の建設/製造/教育LP #113-#115 のような誤 base=main）に、CI を自動 fail させ、`develop` 経由にするよう PR コメントで誘導します。再発防止策。

## 挙動
- `main` 宛 PR で head が `develop` → ✅ pass（exit 0）
- それ以外の head → 🚫 fail（exit 1）＋ 初回のみ誘導コメント（隠しマーカーで重複防止）

## なぜ main に入れる必要があるか
`pull_request` ワークフローは **base ブランチ側のファイル**で実行されるため、`main` 宛PRを捕捉するにはこのファイルが `main` に存在している必要があります。CI専用で、デザイン/コンテンツには一切影響しません（`.github/workflows/` 追加のみ）。

## 完全にブロックするには（このPRマージ後）
ワークフロー単体ではチェックが赤くなるだけです。物理的にマージを止めるには、`main` のブランチ保護で status check `guard` を **required** に設定してください。

## レビュー
- code-reviewer: CRITICAL/HIGH なし。指摘 MEDIUM 2件（必須チェック化の明記 / edited 重複コメント）は本コミットで解消済み。
- codex: 指摘ゼロ。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow with pull-request write; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`.github/workflows/guard-base-branch.yml`**, a `pull_request` workflow that runs on PRs targeting **`main`** (opened/reopened/edited/synchronize).
> 
> The **`guard`** job passes only when **`head` is `develop`**; any other head branch fails the check and posts a **one-time** PR comment (HTML marker) telling authors to retarget **`develop`** and merge to **`main`** via the release flow. Comments in the workflow note that it must live on **`main`** to run (base-branch workflow files) and that making the **`guard`** check required in branch protection is needed to block merges, not just show red CI.
> 
> No app or content changes—CI config only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39cb2d86de21fd7675d3d7e2370e4ef72539ac76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->