### PR TITLE
fix(ci): blog-autodraft の参照を future2 から develop へ

### DIFF
--- a/.github/workflows/blog-autodraft.yml
+++ b/.github/workflows/blog-autodraft.yml
@@ -18,10 +18,10 @@ jobs:
   draft:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout (future2 = 新デザインブランチ)
+      - name: Checkout (develop = 統合ブランチ)
         uses: actions/checkout@v4
         with:
-          ref: future2
+          ref: develop
           # PR作成に使うため履歴を取得
           fetch-depth: 0
           # npm ci(依存のpostinstall)時に write 可能なtokenをgit configへ残さない
@@ -66,6 +66,6 @@ jobs:
           git commit -m "draft(blog): 自動下書き ${SLUG}"
           # persist-credentials:false のため push はトークン付きURLで明示的に行う
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:refs/heads/${BRANCH}"
-          gh pr create --base future2 --head "$BRANCH" \
+          gh pr create --base develop --head "$BRANCH" \
             --title "[自動下書き] ${SLUG}" \
             --body $'Claude が自動生成したブログ下書きです（`isDraft: true` なので公開はされません）。\n\n## 公開する場合\nfrontmatter の `isDraft: true` を `false` に変更してこのPRをマージしてください。\n\n## 公開しない場合\nこのPRをクローズしてください。\n\n## ⚠️ 必ず人の目で確認\n- 数値・統計の**出典URLが実在**し、内容が正しいか\n- トーンが「お手伝い目線」か（断定・効果保証になっていないか）\n- 旧事業名・未取得認証の取得済み主張・プレビューURL/下書きキーが無いか\n（自動ガードレール検査は通過済みですが、最終判断は人が行ってください）'

--- a/docs/blog-autodraft-setup.md
+++ b/docs/blog-autodraft-setup.md
@@ -19,7 +19,7 @@
 
 ## 試運転（cronを待たずに今すぐ）
 - GitHub → **Actions** タブ → 「Blog auto-draft (Claude)」→ **Run workflow**（手動実行）
-- 成功すると `auto-draft/...` ブランチで **下書きPR** が `future2` 宛に作られます
+- 成功すると `auto-draft/...` ブランチで **下書きPR** が `develop` 宛に作られます
 - ローカルで試す場合: `ANTHROPIC_API_KEY=xxxx npm run blog:draft`（最終行に生成ファイルパスが出る）
 
 ## 公開フロー（人の承認）
@@ -37,5 +37,5 @@
 - **モデル**: `claude-opus-4-8`（adaptive thinking、`web_search`内蔵で最新調査＋出典取得）。記事1本あたり概ね数十円程度。
 - **頻度**: 毎日 06:00 JST（`.github/workflows/blog-autodraft.yml` の cron）。試運転が済むまでは cron 行をコメントアウトし手動運用でもOK。
 - **重複回避**: 既存記事の直近タイトルを避けるようプロンプトに渡しています。
-- **ベースブランチ**: 現状 `future2`（新デザイン）。`future2` を `develop` に統合した後は、ワークフロー内の `ref: future2` と `--base future2` を `develop` に変更してください。
+- **ベースブランチ**: `develop`（`ref: develop` / `--base develop`）。実験用の `future2` は develop へ統合のうえ削除済み。開発フローは feature → develop → main（main マージは保護で `kisayama0725` のみ）。
 - **文体を変えたい**: `docs/blog-style-guide.md` を編集するだけで生成トーンが変わります。


### PR DESCRIPTION
## 背景
実験用ブランチ `future2` を develop へ統合のうえ削除しました。`blog-autodraft.yml` が `future2` を参照したままだと、毎日の cron が checkout 段階で失敗します。

## 変更
- `.github/workflows/blog-autodraft.yml`: `ref: future2` → `develop`、`gh pr create --base future2` → `develop`
- `docs/blog-autodraft-setup.md`: 下書きPR宛先・ベースブランチ記述を develop に更新

## レビュー
- code-reviewer / codex: CRITICAL/HIGH/MEDIUM なし。LOW（docs の future2 残存）は本PRで解消済み。
- repo 全体の `future2` 実参照ゼロを確認（残るのは「削除済み」という履歴記述のみ）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI のブランチ名とドキュメントのみの変更で、認証・データ処理やアプリ本体には触れていません。
> 
> **Overview**
> **ブログ自動下書き**の GitHub Actions が、削除済みの `future2` ではなく **`develop`** を checkout し、下書き PR のマージ先も **`develop`** になるよう更新されています。これにより毎日の cron が checkout で落ちる問題を解消します。
> 
> `docs/blog-autodraft-setup.md` も同様に、試運転時の PR 宛先と「ベースブランチ」運用メモを `develop` 前提に書き換え、`future2` 統合・削除後の開発フロー（feature → develop → main）を追記しています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8326f66164d1fdc3fac319c7a8e6a79e1023ed3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->