### PR TITLE
fix(home): 業種テーブルをラインナップB(5業種)に統一

### DIFF
--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -583,7 +583,7 @@ const translations = {
       tableHead: { industry: "業種", theme: "よくあるテーマ", detail: "" },
       rows: [
         {
-          industry: "医療・ヘルスケア",
+          industry: "医療",
           theme: "院内データの整理、患者対応、情報セキュリティ、AI活用方針",
           link: "/industries/medical",
           linkLabel: "医療関連の方はこちら →"
@@ -611,18 +611,6 @@ const translations = {
           theme: "テスト作業、保護者連絡、調査報告、ICT名簿管理",
           link: "/industries/education",
           linkLabel: "教育関連の方はこちら →"
-        },
-        {
-          industry: "建築・不動産",
-          theme: "図面・間取りのAI処理、業務データの自動化",
-          link: null,
-          linkLabel: null
-        },
-        {
-          industry: "自治体・公共",
-          theme: "多言語案内、問い合わせ対応、情報公開の整理",
-          link: null,
-          linkLabel: null
         }
       ]
     },


### PR DESCRIPTION
## 背景
#115 マージで home 業種テーブルが7行版（リンク無しの「建築・不動産」「自治体・公共」を含む）になっていた。以前の方針決定（ラインナップB＝医療/士業/建設/製造/教育の5つのみ）に揃える。

## 変更
- `src/utils/i18n.ts` の `homeIndustries.rows`: リンク無し2行を削除、「医療・ヘルスケア」→「医療」。5行に統一。
- #112(士業) が持っていた lineup統一の独自コミットを本コミットで取り込み（→ #112 はクローズ予定）。

## 検証
- `npm run build` 成功（416ページ、astro check 0エラー）。
- dist/index.html の業種テーブルは5業種ちょうど・建築・不動産/自治体・公共なしを確認。
- code-reviewer / codex: 0 blocking（APPROVE）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only i18n change for the home industry table; no routing, auth, or business logic.
> 
> **Overview**
> Realigns the Japanese home page **industry table** with **Lineup B** after a prior merge had expanded it to seven rows.
> 
> In `src/utils/i18n.ts`, **`homeIndustries.rows`** drops the two placeholder rows (**建築・不動産**, **自治体・公共**) that had no detail links, and shortens the medical label from **医療・ヘルスケア** to **医療**. The table now lists exactly five linked industries (医療, 士業, 建設, 製造, 教育), which `IndustryTable.astro` renders from the same `rows` data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197bcb15c028c3e8a0703d435180443206afe96c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->