### PR TITLE
fix(seo): hreflang 5言語出し分け・og:locale 5値・og:image 絶対URL

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,17 +3,17 @@ import { ViewTransitions } from 'astro:transitions';
 import Footer from '../components/layout/Footer.astro';
 import Header from '../components/layout/Header.astro';
 import WebVitals from '../components/performance/WebVitals.astro';
-import { getCurrentLocale } from '../utils/i18n';
+import { getCurrentLocale, type Locale } from '../utils/i18n';
 
 interface Props {
   description: string;
   title: string;
   // この URL に実在する言語版だけを hreflang に出す（既定は全5言語）。
   // ja のみのページ（/works, /industries/*）は ['ja'] を渡す。
-  availableLocales?: readonly string[];
+  availableLocales?: readonly Locale[];
 }
 
-const OG_LOCALES: Record<string, string> = {
+const OG_LOCALES: Record<Locale, string> = {
   ja: 'ja_JP',
   en: 'en_US',
   zh: 'zh_CN',
@@ -28,7 +28,7 @@ const currentLocale = getCurrentLocale(Astro.url);
 const basePath =
   currentLocale === 'ja'
     ? Astro.url.pathname
-    : Astro.url.pathname.replace(/^\/(en|zh|ko|es)/, '') || '/';
+    : Astro.url.pathname.replace(/^\/(en|zh|ko|es)(?=\/|$)/, '') || '/';
 const ogImage = new URL('/logo.png', Astro.site);
 ---
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,10 +8,28 @@ import { getCurrentLocale } from '../utils/i18n';
 interface Props {
   description: string;
   title: string;
+  // この URL に実在する言語版だけを hreflang に出す（既定は全5言語）。
+  // ja のみのページ（/works, /industries/*）は ['ja'] を渡す。
+  availableLocales?: readonly string[];
 }
 
-const { description, title } = Astro.props;
+const OG_LOCALES: Record<string, string> = {
+  ja: 'ja_JP',
+  en: 'en_US',
+  zh: 'zh_CN',
+  ko: 'ko_KR',
+  es: 'es_ES',
+};
+const ALL_LOCALES = ['ja', 'en', 'zh', 'ko', 'es'] as const;
+
+const { description, title, availableLocales = ALL_LOCALES } = Astro.props;
 const currentLocale = getCurrentLocale(Astro.url);
+// 現在のパスからロケール接頭辞を外した ja 基準パス（hreflang の各ロケールURL生成に使う）
+const basePath =
+  currentLocale === 'ja'
+    ? Astro.url.pathname
+    : Astro.url.pathname.replace(/^\/(en|zh|ko|es)/, '') || '/';
+const ogImage = new URL('/logo.png', Astro.site);
 ---
 
 <!doctype html>
@@ -33,28 +51,23 @@ const currentLocale = getCurrentLocale(Astro.url);
     <link rel="sitemap" href="/sitemap-index.xml" />
     <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site)} />
     
-    <!-- Hreflang tags for bilingual SEO -->
-    {currentLocale === 'ja' ? (
-      <>
-        <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="ja" />
-        <link rel="alternate" href={new URL(`/en${Astro.url.pathname}`, Astro.site)} hreflang="en" />
-        <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="x-default" />
-      </>
-    ) : (
-      <>
-        <link rel="alternate" href={new URL(Astro.url.pathname.replace('/en', '') || '/', Astro.site)} hreflang="ja" />
-        <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="en" />
-        <link rel="alternate" href={new URL(Astro.url.pathname.replace('/en', '') || '/', Astro.site)} hreflang="x-default" />
-      </>
-    )}
+    <!-- Hreflang: この URL に実在する言語版のみ出力（ja基準パスから各ロケールURLを生成） -->
+    {availableLocales.map((loc) => (
+      <link
+        rel="alternate"
+        href={new URL(loc === 'ja' ? basePath : `/${loc}${basePath}`, Astro.site)}
+        hreflang={loc}
+      />
+    ))}
+    <link rel="alternate" href={new URL(basePath, Astro.site)} hreflang="x-default" />
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content={Astro.url} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:image" content="/logo.png" />
-    <meta property="og:locale" content={currentLocale === 'ja' ? 'ja_JP' : 'en_US'} />
+    <meta property="og:image" content={ogImage} />
+    <meta property="og:locale" content={OG_LOCALES[currentLocale]} />
     <meta property="og:site_name" content="Cor.inc" />
     <meta property="article:author" content="寺田康佑" />
     
@@ -65,7 +78,7 @@ const currentLocale = getCurrentLocale(Astro.url);
     <meta name="twitter:url" content={Astro.url} />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content="/logo.png" />
+    <meta name="twitter:image" content={ogImage} />
     
     <!-- Structured Data - Organization -->
     <script type="application/ld+json">

--- a/src/pages/industries/construction.astro
+++ b/src/pages/industries/construction.astro
@@ -11,6 +11,7 @@ const griftUrl = 'https://griftai.org';
 <Layout
   description={t.meta.industryConstruction.description}
   title={t.meta.industryConstruction.title}
+  availableLocales={['ja']}
 >
   <!-- 1. Hero -->
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">

--- a/src/pages/industries/education.astro
+++ b/src/pages/industries/education.astro
@@ -11,6 +11,7 @@ const griftUrl = 'https://griftai.org';
 <Layout
   description={t.meta.industryEducation.description}
   title={t.meta.industryEducation.title}
+  availableLocales={['ja']}
 >
   <!-- 1. Hero -->
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">

--- a/src/pages/industries/manufacturing.astro
+++ b/src/pages/industries/manufacturing.astro
@@ -11,6 +11,7 @@ const griftUrl = 'https://griftai.org';
 <Layout
   description={t.meta.industryManufacturing.description}
   title={t.meta.industryManufacturing.title}
+  availableLocales={['ja']}
 >
   <!-- 1. Hero -->
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">

--- a/src/pages/industries/medical.astro
+++ b/src/pages/industries/medical.astro
@@ -11,6 +11,7 @@ const griftUrl = 'https://griftai.org';
 <Layout
   description={t.meta.industryMedical.description}
   title={t.meta.industryMedical.title}
+  availableLocales={['ja']}
 >
   <!-- 1. Hero -->
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">

--- a/src/pages/industries/shigyo.astro
+++ b/src/pages/industries/shigyo.astro
@@ -11,6 +11,7 @@ const griftUrl = 'https://griftai.org';
 <Layout
   description={t.meta.industryShigyo.description}
   title={t.meta.industryShigyo.title}
+  availableLocales={['ja']}
 >
   <!-- 1. Hero -->
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -53,7 +53,7 @@ const colors = [
 ];
 ---
 
-<Layout description="Style guide for Stone premium Astro theme" title="Styleguide · Stone">
+<Layout description="Style guide for Stone premium Astro theme" title="Styleguide · Stone" availableLocales={['ja']}>
   <header class="py-16 lg:py-20">
     <div class="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:max-w-7xl lg:px-8">
       <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">Styleguide</h1>

--- a/src/pages/test-blog.astro
+++ b/src/pages/test-blog.astro
@@ -15,7 +15,7 @@ try {
 }
 ---
 
-<Layout title="Blog Test" description="Testing blog collection functionality">
+<Layout title="Blog Test" description="Testing blog collection functionality" availableLocales={['ja']}>
   <div class="container mx-auto p-8">
     <h1>Blog Test Page</h1>
     

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -9,6 +9,7 @@ const t = getJaTranslations();
 <Layout
   description={t.meta.works.description}
   title={t.meta.works.title}
+  availableLocales={['ja']}
 >
   <div class="mx-auto max-w-2xl px-4 py-16 sm:px-6 sm:py-20 lg:max-w-7xl lg:px-8">
     <div class="mx-auto flex max-w-3xl flex-col gap-4 pb-10 text-center sm:pb-12">


### PR DESCRIPTION
## 背景（多言語#60の一部・SEO実害の即修正）
develop の SEO meta に多言語起因の実害があった: hreflang が ja/en の2言語のみ＋zh等で誤った en alternate / 存在しない `/en/industries/*` への壊れた alternate / og:locale が ja_JP・en_US の二値 / og:image が相対パス（SNSクローラで解決不可）。翻訳には非依存で修正可能なため先行。

## 変更
- `Layout.astro`: `availableLocales` プロップ（既定=全5言語）。多言語ページは ja/en/zh/ko/es + x-default を正出力。ja のみのページ（works / industries 5 / styleguide / test-blog の計8）は `['ja']` で壊れた alternate を解消。basePath の regex に境界 `(?=\/|$)` を追加。
- og:locale を 5値マップ（ja_JP/en_US/zh_CN/ko_KR/es_ES）。og:image・twitter:image を `Astro.site` 基準の絶対URL化。
- 型: `OG_LOCALES: Record<Locale,string>` / `availableLocales: readonly Locale[]`。

## 検証
- `astro check` 0エラー/0警告、`npm run build` 416ページ成功。
- dist 実HTMLで確認: ja home=5言語+x-default、industries/styleguide/test-blog=ja+x-defaultのみ、/en/about の ja link=/about/、og:locale 各言語正値、og:image=https://cor-jp.com/logo.png。
- レビュー: code-reviewer（再レビュー）＋独立した敵対的レビュー の2本とも APPROVE（diff内 0 blocking）。※codex は usage limit のため独立 general-purpose で代替。

## 既知の follow-up（本PR対象外・別レイアウト）
`BlogLayout.astro`（ブログ記事用）に同じ旧 hreflang/og バグが残存。記事ごとの翻訳存在判定が要るため別途対応。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 変更は head メタと8ページの Layout プロップのみで、ランタイムや認証・データ処理には触れない。誤った hreflang は SEO 上の影響があり得るが、本 PR は既知の実害を是正する方向。
> 
> **Overview**
> **`Layout.astro`** の SEO メタを、5言語サイト向けに直し、存在しない言語への **hreflang** を出さないようにする。
> 
> **hreflang** は ja/en 固定の分岐をやめ、オプション **`availableLocales`**（既定は ja/en/zh/ko/es）で実在する言語だけを出力する。ロケール接頭辞を外した **ja 基準の `basePath`**（境界付き regex）から各言語 URL を組み立て、**`x-default`** は ja パスを指す。日本語のみの **`/works`**、**`/industries/*`**（5ページ）、**`styleguide`**、**`test-blog`** では **`availableLocales={['ja']}`** を渡し、壊れた alternate（例: 存在しない `/en/industries/*`）を防ぐ。
> 
> **`og:locale`** は 5 ロケールのマップ（`ja_JP` … `es_ES`）に拡張。**`og:image`** / **`twitter:image`** は `Astro.site` 基準の絶対 URL に変更する。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069279d5be8944a982a2063c2f22b87181a803d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->