### PR TITLE
feat(i18n): ホームを5言語の新デザインに（Phase 1B+3-home）

### DIFF
--- a/src/components/home/ChallengeGrid.astro
+++ b/src/components/home/ChallengeGrid.astro
@@ -1,8 +1,8 @@
 ---
-import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations, getLocalizedUrl } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
-const t = getJaTranslations();
+const t = getTranslations(currentLocale);
 
 const griftUrl = 'https://griftai.org';
 ---

--- a/src/components/home/FinalCta.astro
+++ b/src/components/home/FinalCta.astro
@@ -1,8 +1,8 @@
 ---
-import { getCurrentLocale, getJaTranslations, getLocalizedUrl, emphasizeKyousou } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations, getLocalizedUrl, emphasizeKyousou } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
-const t = getJaTranslations();
+const t = getTranslations(currentLocale);
 
 const griftUrl = 'https://griftai.org';
 ---

--- a/src/components/home/GriftBridge.astro
+++ b/src/components/home/GriftBridge.astro
@@ -1,7 +1,7 @@
 ---
-import { getJaTranslations } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
-const t = getJaTranslations();
+const t = getTranslations(getCurrentLocale(Astro.url));
 
 const griftUrl = 'https://griftai.org';
 const mock = t.griftBridge.mock;

--- a/src/components/home/IndustryTable.astro
+++ b/src/components/home/IndustryTable.astro
@@ -1,7 +1,7 @@
 ---
-import { getJaTranslations } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
-const t = getJaTranslations();
+const t = getTranslations(getCurrentLocale(Astro.url));
 ---
 
 <section class="py-24 sm:py-32">

--- a/src/components/home/KyousouPhilosophy.astro
+++ b/src/components/home/KyousouPhilosophy.astro
@@ -1,8 +1,8 @@
 ---
-import { getCurrentLocale, getJaTranslations, getLocalizedUrl, emphasizeKyousou } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations, getLocalizedUrl, emphasizeKyousou } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
-const t = getJaTranslations();
+const t = getTranslations(currentLocale);
 ---
 
 <section class="py-24 sm:py-32">

--- a/src/components/home/ProblemHero.astro
+++ b/src/components/home/ProblemHero.astro
@@ -1,8 +1,8 @@
 ---
-import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations, getLocalizedUrl } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
-const t = getJaTranslations();
+const t = getTranslations(currentLocale);
 
 // 福岡100選 2026-2027 の badge は公開可能日まで非表示（正本ガードレール）。
 const HIDDEN_TRUST_BADGES = ['福岡100選 2026-2027'];

--- a/src/components/home/ProofHighlights.astro
+++ b/src/components/home/ProofHighlights.astro
@@ -1,8 +1,8 @@
 ---
-import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations, getLocalizedUrl } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
-const t = getJaTranslations();
+const t = getTranslations(currentLocale);
 
 // 見出し → カード(1枚ずつ) → CTA の順に浮き上がる stagger。固定(pin)はせず通常スクロールで通過しながら自動表示。
 const cardBaseDelay = 0.15;

--- a/src/components/home/SecurityTrust.astro
+++ b/src/components/home/SecurityTrust.astro
@@ -1,8 +1,8 @@
 ---
-import { getCurrentLocale, getJaTranslations, getLocalizedUrl } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations, getLocalizedUrl } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
-const t = getJaTranslations();
+const t = getTranslations(currentLocale);
 ---
 
 <section class="py-24 sm:py-32">

--- a/src/components/home/ServicesReframed.astro
+++ b/src/components/home/ServicesReframed.astro
@@ -1,7 +1,7 @@
 ---
-import { getJaTranslations } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
-const t = getJaTranslations();
+const t = getTranslations(getCurrentLocale(Astro.url));
 ---
 
 <section class="py-24 sm:py-32">

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,11 +1,14 @@
 ---
-import About from '../../components/home/About.astro';
-import Cta from '../../components/home/Cta.astro';
-import Hero from '../../components/home/Hero.astro';
-import Services from '../../components/home/Services.astro';
-import Testimonials from '../../components/home/Testimonials.astro';
+import ProblemHero from '../../components/home/ProblemHero.astro';
+import ChallengeGrid from '../../components/home/ChallengeGrid.astro';
+import IndustryTable from '../../components/home/IndustryTable.astro';
+import GriftBridge from '../../components/home/GriftBridge.astro';
+import ProofHighlights from '../../components/home/ProofHighlights.astro';
+import ServicesReframed from '../../components/home/ServicesReframed.astro';
+import SecurityTrust from '../../components/home/SecurityTrust.astro';
+import KyousouPhilosophy from '../../components/home/KyousouPhilosophy.astro';
+import FinalCta from '../../components/home/FinalCta.astro';
 import Layout from '../../layouts/Layout.astro';
-import Expertise from '../../components/home/Expertise.astro';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -16,10 +19,13 @@ const t = getTranslations(currentLocale);
   description={t.meta.home.description}
   title={t.meta.home.title}
 >
-  <Hero />
-  <Services />
-  <Expertise />
-  <About />
-  <Testimonials />
-  <Cta />
+  <ProblemHero />
+  <ChallengeGrid />
+  <IndustryTable />
+  <GriftBridge />
+  <ProofHighlights />
+  <ServicesReframed />
+  <SecurityTrust />
+  <KyousouPhilosophy />
+  <FinalCta />
 </Layout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,11 +1,14 @@
 ---
-import About from '../../components/home/About.astro';
-import Cta from '../../components/home/Cta.astro';
-import Hero from '../../components/home/Hero.astro';
-import Services from '../../components/home/Services.astro';
-import Testimonials from '../../components/home/Testimonials.astro';
+import ProblemHero from '../../components/home/ProblemHero.astro';
+import ChallengeGrid from '../../components/home/ChallengeGrid.astro';
+import IndustryTable from '../../components/home/IndustryTable.astro';
+import GriftBridge from '../../components/home/GriftBridge.astro';
+import ProofHighlights from '../../components/home/ProofHighlights.astro';
+import ServicesReframed from '../../components/home/ServicesReframed.astro';
+import SecurityTrust from '../../components/home/SecurityTrust.astro';
+import KyousouPhilosophy from '../../components/home/KyousouPhilosophy.astro';
+import FinalCta from '../../components/home/FinalCta.astro';
 import Layout from '../../layouts/Layout.astro';
-import Expertise from '../../components/home/Expertise.astro';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -16,10 +19,13 @@ const t = getTranslations(currentLocale);
   description={t.meta.home.description}
   title={t.meta.home.title}
 >
-  <Hero />
-  <Services />
-  <Expertise />
-  <About />
-  <Testimonials />
-  <Cta />
+  <ProblemHero />
+  <ChallengeGrid />
+  <IndustryTable />
+  <GriftBridge />
+  <ProofHighlights />
+  <ServicesReframed />
+  <SecurityTrust />
+  <KyousouPhilosophy />
+  <FinalCta />
 </Layout>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -1,11 +1,14 @@
 ---
-import About from '../../components/home/About.astro';
-import Cta from '../../components/home/Cta.astro';
-import Hero from '../../components/home/Hero.astro';
-import Services from '../../components/home/Services.astro';
-import Testimonials from '../../components/home/Testimonials.astro';
+import ProblemHero from '../../components/home/ProblemHero.astro';
+import ChallengeGrid from '../../components/home/ChallengeGrid.astro';
+import IndustryTable from '../../components/home/IndustryTable.astro';
+import GriftBridge from '../../components/home/GriftBridge.astro';
+import ProofHighlights from '../../components/home/ProofHighlights.astro';
+import ServicesReframed from '../../components/home/ServicesReframed.astro';
+import SecurityTrust from '../../components/home/SecurityTrust.astro';
+import KyousouPhilosophy from '../../components/home/KyousouPhilosophy.astro';
+import FinalCta from '../../components/home/FinalCta.astro';
 import Layout from '../../layouts/Layout.astro';
-import Expertise from '../../components/home/Expertise.astro';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -16,10 +19,13 @@ const t = getTranslations(currentLocale);
   description={t.meta.home.description}
   title={t.meta.home.title}
 >
-  <Hero />
-  <Services />
-  <Expertise />
-  <About />
-  <Testimonials />
-  <Cta />
+  <ProblemHero />
+  <ChallengeGrid />
+  <IndustryTable />
+  <GriftBridge />
+  <ProofHighlights />
+  <ServicesReframed />
+  <SecurityTrust />
+  <KyousouPhilosophy />
+  <FinalCta />
 </Layout>

--- a/src/pages/zh/index.astro
+++ b/src/pages/zh/index.astro
@@ -1,11 +1,14 @@
 ---
-import About from '../../components/home/About.astro';
-import Cta from '../../components/home/Cta.astro';
-import Hero from '../../components/home/Hero.astro';
-import Services from '../../components/home/Services.astro';
-import Testimonials from '../../components/home/Testimonials.astro';
+import ProblemHero from '../../components/home/ProblemHero.astro';
+import ChallengeGrid from '../../components/home/ChallengeGrid.astro';
+import IndustryTable from '../../components/home/IndustryTable.astro';
+import GriftBridge from '../../components/home/GriftBridge.astro';
+import ProofHighlights from '../../components/home/ProofHighlights.astro';
+import ServicesReframed from '../../components/home/ServicesReframed.astro';
+import SecurityTrust from '../../components/home/SecurityTrust.astro';
+import KyousouPhilosophy from '../../components/home/KyousouPhilosophy.astro';
+import FinalCta from '../../components/home/FinalCta.astro';
 import Layout from '../../layouts/Layout.astro';
-import Expertise from '../../components/home/Expertise.astro';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -16,10 +19,13 @@ const t = getTranslations(currentLocale);
   description={t.meta.home.description}
   title={t.meta.home.title}
 >
-  <Hero />
-  <Services />
-  <Expertise />
-  <About />
-  <Testimonials />
-  <Cta />
+  <ProblemHero />
+  <ChallengeGrid />
+  <IndustryTable />
+  <GriftBridge />
+  <ProofHighlights />
+  <ServicesReframed />
+  <SecurityTrust />
+  <KyousouPhilosophy />
+  <FinalCta />
 </Layout>


### PR DESCRIPTION
## 目的（多言語#60 Phase 1B + Phase 3-home）
`/en /zh /ko /es` のトップを**新デザイン＋各言語コピー**で表示する。

## 変更
- home 9コンポーネントを `getJaTranslations()` → `getTranslations(getCurrentLocale(Astro.url))`（locale対応）。ja は getCurrentLocale が 'ja' を返すため**表示不変**。
- en/zh/ko/es の `index.astro` を旧コンポーネント構成 → ja と同じ新コンポーネント構成へ配線。
- HomeBlog（UI文言ハードコードJA＋ja記事固定）は非jaの index から除外（日本語の島を防止）。ja は維持。

## 検証
- `astro check` 0エラー/0警告、`npm run build` 416p。
- preview 実機: /en=英語・/zh=中国語の新デザイン描画、ja 完全不変、ISMS全言語「整備中」、非jaに「読みもの」JA漏れ無しを確認。
- レビュー: code-reviewer ＋ 独立2人目（敵対的）の2本とも **APPROVE**（※codex usage limit のため独立 general-purpose で代替）。

## 既知の follow-up（本PR対象外・develop上で順次）
1. **業種LPの言語ルート化** ＋ IndustryTable の `row.link` を locale 化（現状 /en 等の業種リンクは ja 業種ページへ。CTAは getLocalizedUrl で正しい）
2. **About ページ多言語化**（aboutPage サブキー翻訳＋about 4コンポーネント locale 化。現状 ja 固定）
3. **HomeBlog 多言語化**（UI文言の i18n 化＋locale 別記事フィルタ）
4. BlogLayout の hreflang/og・OGP CJKフォント
5. 旧 home コンポーネント(Hero/Services/Expertise/About/Testimonials)の dead code 削除

## 注
main 昇格は作り込み後（諫山さん判断）。本PRは develop まで。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing-page composition and i18n wiring only; no auth, data, or security paths. Main residual risk is wrong/missing locale strings or industry links still pointing at JA URLs until follow-up.
> 
> **Overview**
> Rolls out the **new Japanese home page layout** to `/en`, `/zh`, `/ko`, and `/es`, and makes the shared home sections load copy from the **active locale** instead of hard-coded Japanese.
> 
> Nine home components (`ProblemHero`, `ChallengeGrid`, `IndustryTable`, `GriftBridge`, `ProofHighlights`, `ServicesReframed`, `SecurityTrust`, `KyousouPhilosophy`, `FinalCta`) now use `getTranslations(getCurrentLocale(Astro.url))` (or `currentLocale` where already resolved) instead of `getJaTranslations()`. CTAs that already used `getLocalizedUrl` keep locale-correct routes; **industry row links in `IndustryTable` still use whatever `row.link` is in translations** (follow-up to locale-route those).
> 
> Each non-Japanese `index.astro` **replaces** the legacy stack (`Hero`, `Services`, `Expertise`, `About`, `Testimonials`, `Cta`) with the same section order as the Japanese home. **`HomeBlog` is not wired on these locales** (only the root `ja` index still includes it), avoiding Japanese-only blog UI on foreign homepages.
> 
> Japanese `/` behavior is intended to stay the same because `getCurrentLocale` returns `ja` and the section set was already the new design.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8de9cd78c987437cfb0a5362ee9f34b4ce1905d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->