### PR TITLE
feat(i18n): HomeBlog を5言語対応

### DIFF
--- a/src/components/home/HomeBlog.astro
+++ b/src/components/home/HomeBlog.astro
@@ -1,13 +1,14 @@
 ---
 import { getCollection } from 'astro:content';
 import PostCard from '../blog/PostCard.astro';
-import { getCurrentLocale, getLocalizedUrl } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations, getLocalizedUrl } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
+const t = getTranslations(currentLocale);
 
-// 注目記事（featured）を新着順で最大4本。トップに「読みもの」として出し、滞在→記事→Grift の動線を作る。
+// 注目記事（featured）を新着順で最大4本。現在のロケールの記事に限定し、滞在→記事→Grift の動線を作る。
 const featured = (
-  await getCollection('blog', ({ data }) => data.lang === 'ja' && !data.isDraft && data.featured)
+  await getCollection('blog', ({ data }) => data.lang === currentLocale && !data.isDraft && data.featured)
 )
   .sort((a, b) => new Date(b.data.pubDate).getTime() - new Date(a.data.pubDate).getTime())
   .slice(0, 4);
@@ -20,13 +21,13 @@ const featured = (
         <div class="flex flex-col gap-10 sm:gap-12">
           <div class="flex max-w-3xl flex-col gap-4" data-reveal>
             <p class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400">
-              読みもの
+              {t.homeBlog.eyebrow}
             </p>
             <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
-              AIの「進め方」を、記事で。
+              {t.homeBlog.title}
             </h2>
             <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
-              AI導入・機密データの安全な活用・見積もりの考え方など、現場で使える視点をまとめています。
+              {t.homeBlog.description}
             </p>
           </div>
           <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
@@ -41,7 +42,7 @@ const featured = (
               href={getLocalizedUrl('/blog', currentLocale)}
               class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
             >
-              ブログをすべて見る
+              {t.homeBlog.cta}
             </a>
           </div>
         </div>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -7,6 +7,7 @@ import ProofHighlights from '../../components/home/ProofHighlights.astro';
 import ServicesReframed from '../../components/home/ServicesReframed.astro';
 import SecurityTrust from '../../components/home/SecurityTrust.astro';
 import KyousouPhilosophy from '../../components/home/KyousouPhilosophy.astro';
+import HomeBlog from '../../components/home/HomeBlog.astro';
 import FinalCta from '../../components/home/FinalCta.astro';
 import Layout from '../../layouts/Layout.astro';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
@@ -27,5 +28,6 @@ const t = getTranslations(currentLocale);
   <ServicesReframed />
   <SecurityTrust />
   <KyousouPhilosophy />
+  <HomeBlog />
   <FinalCta />
 </Layout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -7,6 +7,7 @@ import ProofHighlights from '../../components/home/ProofHighlights.astro';
 import ServicesReframed from '../../components/home/ServicesReframed.astro';
 import SecurityTrust from '../../components/home/SecurityTrust.astro';
 import KyousouPhilosophy from '../../components/home/KyousouPhilosophy.astro';
+import HomeBlog from '../../components/home/HomeBlog.astro';
 import FinalCta from '../../components/home/FinalCta.astro';
 import Layout from '../../layouts/Layout.astro';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
@@ -27,5 +28,6 @@ const t = getTranslations(currentLocale);
   <ServicesReframed />
   <SecurityTrust />
   <KyousouPhilosophy />
+  <HomeBlog />
   <FinalCta />
 </Layout>

--- a/src/pages/ko/index.astro
+++ b/src/pages/ko/index.astro
@@ -7,6 +7,7 @@ import ProofHighlights from '../../components/home/ProofHighlights.astro';
 import ServicesReframed from '../../components/home/ServicesReframed.astro';
 import SecurityTrust from '../../components/home/SecurityTrust.astro';
 import KyousouPhilosophy from '../../components/home/KyousouPhilosophy.astro';
+import HomeBlog from '../../components/home/HomeBlog.astro';
 import FinalCta from '../../components/home/FinalCta.astro';
 import Layout from '../../layouts/Layout.astro';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
@@ -27,5 +28,6 @@ const t = getTranslations(currentLocale);
   <ServicesReframed />
   <SecurityTrust />
   <KyousouPhilosophy />
+  <HomeBlog />
   <FinalCta />
 </Layout>

--- a/src/pages/zh/index.astro
+++ b/src/pages/zh/index.astro
@@ -7,6 +7,7 @@ import ProofHighlights from '../../components/home/ProofHighlights.astro';
 import ServicesReframed from '../../components/home/ServicesReframed.astro';
 import SecurityTrust from '../../components/home/SecurityTrust.astro';
 import KyousouPhilosophy from '../../components/home/KyousouPhilosophy.astro';
+import HomeBlog from '../../components/home/HomeBlog.astro';
 import FinalCta from '../../components/home/FinalCta.astro';
 import Layout from '../../layouts/Layout.astro';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
@@ -27,5 +28,6 @@ const t = getTranslations(currentLocale);
   <ServicesReframed />
   <SecurityTrust />
   <KyousouPhilosophy />
+  <HomeBlog />
   <FinalCta />
 </Layout>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -2,6 +2,7 @@ export type Locale = 'ja' | 'en' | 'zh' | 'ko' | 'es';
 
 const translations = {
   ja: {
+    homeBlog: {"eyebrow":"読みもの","title":"AIの「進め方」を、記事で。","description":"AI導入・機密データの安全な活用・見積もりの考え方など、現場で使える視点をまとめています。","cta":"ブログをすべて見る"},
     nav: { home: "ホーム", about: "Cor.について", products: "Products&Insights", blog: "ブログ", contact: "お問い合わせ", security: "セキュリティ", works: "実績・事例", grift: "Grift" },
     hero: {
       title: "言葉を超えて、想いを届ける。",
@@ -987,6 +988,7 @@ const translations = {
     }
   },
   en: {
+    homeBlog: {"eyebrow":"Insights","title":"The \"how\" of AI, in articles.","description":"AI adoption, the safe use of confidential data, how to think about estimates — practical perspectives you can use on the ground.","cta":"See all articles"},
     homeHero: {
       kicker: "COR. INC. — AI × CO-CREATION",
       title: "Let's give your challenge<br />a real shape, together.",
@@ -1944,6 +1946,7 @@ const translations = {
     }
   },
   zh: {
+    homeBlog: {"eyebrow":"读物","title":"AI 的「推进方式」，用文章讲清楚。","description":"AI 导入、机密数据的安全运用、报价的思路等，汇总了现场可用的视角。","cta":"查看全部文章"},
     homeHero: {
       kicker: "COR. INC. — AI × CO-CREATION",
       title: "把你的课题，<br />一起变成现实。",
@@ -2901,6 +2904,7 @@ const translations = {
     }
   },
   ko: {
+    homeBlog: {"eyebrow":"읽을거리","title":"AI의 ‘진행 방법’을, 글로.","description":"AI 도입, 기밀 데이터의 안전한 활용, 견적에 대한 사고방식 등 현장에서 바로 쓸 수 있는 관점을 정리했습니다.","cta":"블로그 전체 보기"},
     homeHero: {
       kicker: "COR. INC. — AI × CO-CREATION",
       title: "당신의 과제를<br />함께 형상화합니다.",
@@ -3858,6 +3862,7 @@ const translations = {
     }
   },
   es: {
+    homeBlog: {"eyebrow":"Lecturas","title":"El «cómo» de la IA, en artículos.","description":"Adopción de IA, uso seguro de datos confidenciales, cómo plantear los presupuestos y más: perspectivas prácticas para el día a día.","cta":"Ver todos los artículos"},
     homeHero: {
       kicker: "COR. INC. — AI × CO-CREATION",
       title: "Damos forma a tu desafío,<br />juntos.",


### PR DESCRIPTION
## 目的
ホームの「読みもの」(ブログ注目記事)セクションを5言語化。Phase3で日本語島回避のため非jaから一旦外していたものを、翻訳UI＋locale別記事で復活。

## 変更
- i18n.ts: `homeBlog`(eyebrow/title/description/cta) を5言語追加。
- HomeBlog.astro: getTranslations(currentLocale) で UI を i18n 化、featured フィルタを `data.lang === currentLocale` に。
- en/zh/ko/es の index.astro に HomeBlog を再追加。

## 検証
- astro check 0/0、build 416p。
- /en=Insights＋英語記事(Codex MCP)、/zh=读物＋中国語記事、ja=読みもの維持。各言語 featured 8本→4枚表示、リンクも /{lang}/blog/...。日本語島漏れ無し。
- レビュー: code-reviewer ＋ 独立2人目とも APPROVE（※codex usage limit のため独立 general-purpose 代替）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/i18n UI and content filtering only; no auth, APIs, or data-handling changes.
> 
> **Overview**
> Restores the home **featured blog** section on **en/zh/ko/es** homepages and makes it fully locale-aware instead of Japanese-only.
> 
> **`HomeBlog.astro`** now pulls section copy from **`t.homeBlog`** and loads featured posts where **`data.lang === currentLocale`** (replacing a hardcoded **`ja`** filter and inline Japanese strings). **`i18n.ts`** adds **`homeBlog`** (eyebrow, title, description, CTA) for all five locales. Non-Japanese **`index.astro`** pages wire **`HomeBlog`** back in before **`FinalCta`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b509555485920b05d6261ccc014c3a21f3959c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->