### PR TITLE
fix(ci): exclude workers/ from root astro check

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
         "name": "@astrojs/ts-plugin"
       }
     ]
-  }
+  },
+  "exclude": ["node_modules", "dist", ".astro", "workers"]
 }


### PR DESCRIPTION
## 問題
PR #141 マージ後の develop デプロイビルドが失敗:
```
workers/yomimono/src/github.ts:2 - error ts(2307): Cannot find module '@octokit/auth-app'
workers/yomimono/src/github.ts:1 - error ts(2307): Cannot find module '@octokit/core'
- 2 errors / exit code 1
```

## 原因（一次情報: CI ログ）
ルートの `npm run build`（=`astro check && astro build`）の `astro check` が `workers/yomimono/*.ts` まで型チェックしていた。CI はルートで `npm ci` するのみで **worker の依存（@octokit/*）をインストールしない**ため、モジュール解決に失敗。ローカルでは worker の node_modules があったため通っていた。

## 修正
`workers/` は独自の `tsconfig.json` / `npm run typecheck` を持つ別パッケージ。ルート `tsconfig.json` の `exclude` に `workers` を追加し、Astro の型チェック対象から外す（正しいパッケージ分離）。

## 検証
```
astro check → Result (137 files): 0 errors
```
worker 11ファイルが対象外に。`src/` の全ページは引き続きカバー（148→137 はworker分のみ減少）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/typecheck scope change only; no runtime or app logic changes, and worker code remains checked via its own package.
> 
> **Overview**
> **Fixes develop deploy failures** where root `astro check` (part of `npm run build`) was type-checking `workers/yomimono/*.ts` and failing on missing `@octokit/*` modules because CI only runs `npm ci` at the repo root, not in the worker package.
> 
> Adds **`workers`** to the root `tsconfig.json` **`exclude`** list (alongside `node_modules`, `dist`, `.astro`) so Astro’s check stays on the main site; the worker keeps its own `tsconfig` and `npm run typecheck`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac55da728e4636849315bacc18dc74c2d802185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->