### PR TITLE
feat(yomimono): 管理画面UI（Workerが配信）

### DIFF
--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { assertSlug, normalizeCategory, sanitizeText, SLUG_RE } from '../validate';
+import { assertSlug, normalizeArticle, normalizeCategory, sanitizeText, SLUG_RE } from '../validate';
 
 describe('assertSlug — パストラバーサル防止（CRITICAL修正の要）', () => {
   // バグ（slug未検証）が存在すれば、これらは throw せず素通りしてしまう。
@@ -36,6 +36,72 @@ describe('normalizeCategory', () => {
   it('未知カテゴリは ai にフォールバック', () => {
     expect(normalizeCategory('malicious')).toBe('ai');
     expect(normalizeCategory(undefined)).toBe('ai');
+  });
+});
+
+describe('normalizeArticle — publish/validate 共通の検証・正規化', () => {
+  const base = {
+    slug: 'valid-slug-123',
+    title: 'タイトル',
+    description: '説明',
+    category: 'engineering',
+    tags: ['a', 'b'],
+    body: '## 本文\n\n内容',
+  };
+
+  it('正当な記事を ok:true で正規化する', () => {
+    const r = normalizeArticle(base);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.article.slug).toBe('valid-slug-123');
+      expect(r.article.category).toBe('engineering');
+    }
+  });
+
+  it.each([
+    ['slug欠落', { ...base, slug: undefined }],
+    ['title欠落', { ...base, title: undefined }],
+    ['description欠落', { ...base, description: undefined }],
+    ['body欠落', { ...base, body: undefined }],
+    ['undefined', undefined],
+  ])('必須欠落(%s)は ok:false / 400', (_n, input) => {
+    const r = normalizeArticle(input as never);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
+
+  it.each(['../../../etc/passwd', 'foo/bar', 'UP', 'a'.repeat(81)])(
+    'パストラバーサル/不正slug(%s)は 400 で拒否',
+    (slug) => {
+      const r = normalizeArticle({ ...base, slug });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.status).toBe(400);
+    },
+  );
+
+  it('未知カテゴリは ai にフォールバック、tagsは10件・各50字に制限', () => {
+    const r = normalizeArticle({
+      ...base,
+      category: 'evil',
+      tags: Array.from({ length: 20 }, (_, i) => 'tag' + i),
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.article.category).toBe('ai');
+      expect(r.article.tags.length).toBe(10);
+    }
+  });
+
+  it('body は100k字で打ち切る（markdown構造は保持＝制御文字以外そのまま）', () => {
+    const r = normalizeArticle({ ...base, body: 'x'.repeat(200_000) });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.body.length).toBe(100_000);
+  });
+
+  it('サニタイズ後に title が空なら 400', () => {
+    const r = normalizeArticle({ ...base, title: '```' });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
   });
 });
 

--- a/workers/yomimono/src/github.ts
+++ b/workers/yomimono/src/github.ts
@@ -41,6 +41,26 @@ export async function getFileContent(env: Env, octokit: Octokit, path: string): 
   return base64ToUtf8(data.content);
 }
 
+// 既存記事のスラッグ一覧（重複テーマ回避用）。BLOG_DIR/ja のファイル名から .md を除いたもの。
+export async function listArticleSlugs(env: Env, octokit: Octokit): Promise<string[]> {
+  try {
+    const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+      owner: env.GH_OWNER,
+      repo: env.GH_REPO,
+      path: `${env.BLOG_DIR}/ja`,
+      ref: env.PUBLISH_BRANCH,
+    });
+    const items = res.data as Array<{ name: string; type: string }>;
+    return Array.isArray(items)
+      ? items
+          .filter((it) => it.type === 'file' && it.name.endsWith('.md'))
+          .map((it) => it.name.replace(/\.md$/, ''))
+      : [];
+  } catch {
+    return []; // 一覧取得失敗は致命的でない（重複回避が弱まるだけ）
+  }
+}
+
 // 記事 .md を PUBLISH_BRANCH（既定 main）へコミット。
 // content-bot はこのパス（記事のみ）にしか書かない＝コードには触れない。
 export async function commitArticle(

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -7,8 +7,21 @@ import { makeOctokit, getFileContent, commitArticle, listArticleSlugs } from './
 import { sanitizeText, normalizeArticle, type ArticleInput } from './validate';
 import { ADMIN_HTML } from './ui';
 
+// 管理画面は自己完結（外部リソース無し・同一オリジンfetchのみ）。
+// インライン style/script のみ許可し、外部読込・iframe埋め込み・データ送信先を遮断する。
+const CSP =
+  "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; " +
+  "img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
 const html = (body: string, status = 200): Response =>
-  new Response(body, { status, headers: { 'content-type': 'text/html; charset=utf-8' } });
+  new Response(body, {
+    status,
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+      'content-security-policy': CSP,
+      'x-content-type-options': 'nosniff',
+      'referrer-policy': 'no-referrer',
+    },
+  });
 
 const json = (data: unknown, status = 200): Response =>
   new Response(JSON.stringify(data), {

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -3,8 +3,12 @@ import { verifyAccessEmail } from './auth';
 import { collectTopics } from './collect';
 import { generateArticle, buildMarkdown } from './generate';
 import { scanForViolations } from './guardrails';
-import { makeOctokit, getFileContent, commitArticle } from './github';
+import { makeOctokit, getFileContent, commitArticle, listArticleSlugs } from './github';
 import { assertSlug, normalizeCategory, sanitizeText } from './validate';
+import { ADMIN_HTML } from './ui';
+
+const html = (body: string, status = 200): Response =>
+  new Response(body, { status, headers: { 'content-type': 'text/html; charset=utf-8' } });
 
 const json = (data: unknown, status = 200): Response =>
   new Response(JSON.stringify(data), {
@@ -28,6 +32,51 @@ function sanitizeTitles(input: unknown): string[] {
   return input.slice(0, 50).map((t) => sanitizeText(t, 200)).filter(Boolean);
 }
 
+interface ArticleInput {
+  slug?: string;
+  title?: string;
+  description?: string;
+  category?: string;
+  tags?: unknown;
+  body?: string;
+}
+type NormalizedArticle = {
+  slug: string;
+  title: string;
+  description: string;
+  category: ReturnType<typeof normalizeCategory>;
+  tags: string[];
+  body: string;
+};
+
+// publish / validate 共通: 受け取った article を検証・正規化（パストラバーサル防止含む）。
+function normalizeArticle(
+  a: ArticleInput | undefined,
+): { ok: true; article: NormalizedArticle } | { ok: false; error: string; status: number } {
+  if (!a?.slug || !a?.body || !a?.title || !a?.description) {
+    return { ok: false, error: 'article.slug / title / description / body は必須です', status: 400 };
+  }
+  try {
+    assertSlug(a.slug);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'slug が不正です', status: 400 };
+  }
+  const article: NormalizedArticle = {
+    slug: a.slug,
+    title: sanitizeText(a.title, 200),
+    description: sanitizeText(a.description, 500),
+    category: normalizeCategory(a.category),
+    tags: Array.isArray(a.tags)
+      ? a.tags.slice(0, 10).map((t) => sanitizeText(t, 50)).filter(Boolean)
+      : [],
+    body: String(a.body).slice(0, 100_000), // markdown構造を保つため制御文字は除去せず長さのみ制限
+  };
+  if (!article.title || !article.description) {
+    return { ok: false, error: 'title / description が空です', status: 400 };
+  }
+  return { ok: true, article };
+}
+
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
@@ -41,6 +90,18 @@ export default {
     }
 
     try {
+      // 管理画面（凪沙さん用UI）。Access 認証済みのブラウザにHTMLを返す。
+      if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
+        return html(ADMIN_HTML);
+      }
+
+      // 既存記事スラッグ一覧（重複テーマ回避用）
+      if (req.method === 'GET' && url.pathname === '/api/recent') {
+        const octokit = makeOctokit(env);
+        const slugs = await listArticleSlugs(env, octokit);
+        return json({ slugs });
+      }
+
       // ① 情報収集
       if (req.method === 'POST' && url.pathname === '/api/collect') {
         const body = await readJsonBody(req);
@@ -69,7 +130,10 @@ export default {
             title,
             summary: sanitizeText(theme.summary, 500),
             sources: Array.isArray(theme.sources)
-              ? theme.sources.slice(0, 5).map((s) => sanitizeText(s, 300)).filter(Boolean)
+              ? theme.sources
+                  .slice(0, 5)
+                  .map((s) => sanitizeText(s, 300))
+                  .filter((s) => /^https?:\/\//i.test(s)) // http(s) のみ（javascript: 等を排除）
               : [],
             freshnessHours: Number(theme.freshnessHours) || 0,
           },
@@ -79,42 +143,23 @@ export default {
         return json({ article, markdown, violations });
       }
 
+      // ⑤ レビュー: コミットせずガードレール検査のみ（編集後の再チェック用）
+      if (req.method === 'POST' && url.pathname === '/api/validate') {
+        const body = await readJsonBody(req);
+        if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
+        const norm = normalizeArticle(body.article as ArticleInput | undefined);
+        if (!norm.ok) return json({ error: norm.error }, norm.status);
+        const violations = scanForViolations(buildMarkdown(norm.article));
+        return json({ violations });
+      }
+
       // ⑥ 公開（記事botが main へコミット → 既存の静的デプロイで公開）
       if (req.method === 'POST' && url.pathname === '/api/publish') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
-        const a = body.article as
-          | {
-              slug?: string;
-              title?: string;
-              description?: string;
-              category?: string;
-              tags?: unknown;
-              body?: string;
-            }
-          | undefined;
-        if (!a?.slug || !a?.body || !a?.title || !a?.description) {
-          return json({ error: 'article.slug / title / description / body は必須です' }, 400);
-        }
-        // パストラバーサル防止: slug を厳格に再検証（generate と同一ルール）
-        try {
-          assertSlug(a.slug);
-        } catch (e) {
-          return json({ error: e instanceof Error ? e.message : 'slug が不正です' }, 400);
-        }
-        const normalized = {
-          slug: a.slug,
-          title: sanitizeText(a.title, 200),
-          description: sanitizeText(a.description, 500),
-          category: normalizeCategory(a.category),
-          tags: Array.isArray(a.tags)
-            ? a.tags.slice(0, 10).map((t) => sanitizeText(t, 50)).filter(Boolean)
-            : [],
-          body: String(a.body).slice(0, 100_000), // markdown構造を保つため制御文字は除去せず長さのみ制限
-        };
-        if (!normalized.title || !normalized.description) {
-          return json({ error: 'title / description が空です' }, 400);
-        }
+        const norm = normalizeArticle(body.article as ArticleInput | undefined);
+        if (!norm.ok) return json({ error: norm.error }, norm.status);
+        const normalized = norm.article;
         // 公開直前にもう一度ガードレールを通す（最終防衛線）
         const markdown = buildMarkdown(normalized);
         const violations = scanForViolations(markdown);

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -4,7 +4,7 @@ import { collectTopics } from './collect';
 import { generateArticle, buildMarkdown } from './generate';
 import { scanForViolations } from './guardrails';
 import { makeOctokit, getFileContent, commitArticle, listArticleSlugs } from './github';
-import { assertSlug, normalizeCategory, sanitizeText } from './validate';
+import { sanitizeText, normalizeArticle, type ArticleInput } from './validate';
 import { ADMIN_HTML } from './ui';
 
 const html = (body: string, status = 200): Response =>
@@ -30,51 +30,6 @@ async function readJsonBody(req: Request): Promise<Record<string, unknown> | nul
 function sanitizeTitles(input: unknown): string[] {
   if (!Array.isArray(input)) return [];
   return input.slice(0, 50).map((t) => sanitizeText(t, 200)).filter(Boolean);
-}
-
-interface ArticleInput {
-  slug?: string;
-  title?: string;
-  description?: string;
-  category?: string;
-  tags?: unknown;
-  body?: string;
-}
-type NormalizedArticle = {
-  slug: string;
-  title: string;
-  description: string;
-  category: ReturnType<typeof normalizeCategory>;
-  tags: string[];
-  body: string;
-};
-
-// publish / validate 共通: 受け取った article を検証・正規化（パストラバーサル防止含む）。
-function normalizeArticle(
-  a: ArticleInput | undefined,
-): { ok: true; article: NormalizedArticle } | { ok: false; error: string; status: number } {
-  if (!a?.slug || !a?.body || !a?.title || !a?.description) {
-    return { ok: false, error: 'article.slug / title / description / body は必須です', status: 400 };
-  }
-  try {
-    assertSlug(a.slug);
-  } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : 'slug が不正です', status: 400 };
-  }
-  const article: NormalizedArticle = {
-    slug: a.slug,
-    title: sanitizeText(a.title, 200),
-    description: sanitizeText(a.description, 500),
-    category: normalizeCategory(a.category),
-    tags: Array.isArray(a.tags)
-      ? a.tags.slice(0, 10).map((t) => sanitizeText(t, 50)).filter(Boolean)
-      : [],
-    body: String(a.body).slice(0, 100_000), // markdown構造を保つため制御文字は除去せず長さのみ制限
-  };
-  if (!article.title || !article.description) {
-    return { ok: false, error: 'title / description が空です', status: 400 };
-  }
-  return { ok: true, article };
 }
 
 export default {

--- a/workers/yomimono/src/ui.ts
+++ b/workers/yomimono/src/ui.ts
@@ -1,0 +1,220 @@
+// 管理画面（凪沙さん用）。Worker が GET / でこの HTML を返す。
+// Cloudflare Access と同一オリジンのため、fetch は自動で認証される（CORS なし）。
+// 注: 文字列内に ${ とバックティックを入れないこと（外側のTSテンプレートリテラルが壊れる）。
+//     ページ側のJSは文字列連結で書いている。
+export const ADMIN_HTML = `<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>読みもの 作成スタジオ — Cor.</title>
+<style>
+  :root { --navy:#1b2c40; --navy2:#243a54; --ink:#1b2330; --muted:#64748b; --line:#e2e8f0; --bg:#f6f8fb; --ok:#16a34a; --warn:#dc2626; --accent:#2563eb; }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN',system-ui,sans-serif; color:var(--ink); background:var(--bg); line-height:1.7; }
+  header { background:var(--navy); color:#fff; padding:18px 24px; }
+  header h1 { margin:0; font-size:18px; letter-spacing:.04em; }
+  header p { margin:4px 0 0; font-size:12px; color:#aebfd4; }
+  main { max-width:860px; margin:0 auto; padding:24px 16px 80px; }
+  .step { background:#fff; border:1px solid var(--line); border-radius:14px; padding:20px; margin-bottom:18px; box-shadow:0 1px 2px rgba(16,24,40,.04); }
+  .step h2 { margin:0 0 4px; font-size:15px; color:var(--navy); }
+  .step .hint { margin:0 0 14px; font-size:12px; color:var(--muted); }
+  .num { display:inline-flex; width:22px; height:22px; border-radius:50%; background:var(--navy); color:#fff; font-size:12px; align-items:center; justify-content:center; margin-right:8px; }
+  button { font:inherit; cursor:pointer; border:none; border-radius:10px; padding:11px 18px; font-weight:600; }
+  .primary { background:var(--navy); color:#fff; }
+  .primary:hover { background:var(--navy2); }
+  .primary:disabled { background:#9aa7b8; cursor:not-allowed; }
+  .ghost { background:#eef2f7; color:var(--ink); }
+  .pub { background:var(--ok); color:#fff; }
+  .pub:disabled { background:#bbb; cursor:not-allowed; }
+  .card { border:1px solid var(--line); border-radius:12px; padding:14px; margin:10px 0; }
+  .card.sel { border-color:var(--accent); background:#f0f6ff; }
+  .card label { display:flex; gap:10px; align-items:flex-start; cursor:pointer; }
+  .card .t { font-weight:700; font-size:14px; }
+  .card .s { font-size:13px; color:#374151; margin:4px 0; }
+  .card .src a { font-size:11px; color:var(--accent); margin-right:10px; word-break:break-all; }
+  .badge { display:inline-block; font-size:11px; background:#eef2f7; color:var(--muted); border-radius:20px; padding:2px 9px; margin-left:6px; }
+  .field { margin:10px 0; }
+  .field label { display:block; font-size:12px; color:var(--muted); margin-bottom:4px; }
+  .field input, .field textarea { width:100%; padding:9px 11px; border:1px solid var(--line); border-radius:8px; font:inherit; }
+  .field textarea { min-height:280px; resize:vertical; font-family:ui-monospace,Menlo,monospace; font-size:13px; line-height:1.6; }
+  .viol { background:#fff1f2; border:1px solid #fecaca; color:#991b1b; border-radius:8px; padding:10px 12px; font-size:12px; margin:8px 0; }
+  .viol b { display:block; margin-bottom:4px; }
+  .done { background:#f0fdf4; border:1px solid #bbf7d0; color:#166534; border-radius:8px; padding:10px 12px; font-size:13px; }
+  .done a { color:#166534; }
+  .err { background:#fff1f2; border:1px solid #fecaca; color:#991b1b; border-radius:8px; padding:10px 12px; font-size:13px; margin:8px 0; }
+  .spin { display:inline-block; width:15px; height:15px; border:2px solid #fff; border-top-color:transparent; border-radius:50%; animation:sp .8s linear infinite; vertical-align:-2px; margin-right:6px; }
+  @keyframes sp { to { transform:rotate(360deg); } }
+  .row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
+  .meta { font-size:12px; color:var(--muted); }
+  [hidden] { display:none; }
+</style>
+</head>
+<body>
+<header>
+  <h1>読みもの 作成スタジオ</h1>
+  <p>情報収集 → テーマ選定 → 生成 → レビュー → 公開（main マージ不要で公開されます）</p>
+</header>
+<main>
+  <section class="step" id="s1">
+    <h2><span class="num">1</span>情報収集</h2>
+    <p class="hint">直近およそ27時間の AI / DX / ローカルLLM などの話題から、中小企業に刺さる候補テーマを集めます。</p>
+    <div class="row">
+      <button class="primary" id="collectBtn">情報収集を開始</button>
+      <span class="meta" id="recentMeta"></span>
+    </div>
+    <div id="collectErr"></div>
+  </section>
+
+  <section class="step" id="s2" hidden>
+    <h2><span class="num">2</span>テーマを選ぶ（複数可）</h2>
+    <p class="hint">書きたいテーマにチェックを入れて、記事生成へ進んでください。</p>
+    <div id="cands"></div>
+    <div class="row" style="margin-top:12px">
+      <button class="primary" id="genBtn" disabled>選択したテーマで記事を生成</button>
+      <span class="meta" id="selMeta">0 件選択中</span>
+    </div>
+  </section>
+
+  <section class="step" id="s3" hidden>
+    <h2><span class="num">3</span>レビュー & 公開</h2>
+    <p class="hint">本文を確認・編集してから「公開する」を押してください。ガードレール違反があると公開できません。</p>
+    <div id="arts"></div>
+  </section>
+</main>
+<script>
+(function(){
+  var recentTitles = [];
+  var esc = function(s){ return String(s==null?'':s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];}); };
+  // href に使う前にスキームを http(s) のみ許可（javascript: 等を無効化）
+  var safeUrl = function(u){ u = String(u==null?'':u).trim(); return /^https?:\\/\\//i.test(u) ? u : '#'; };
+  var $ = function(id){ return document.getElementById(id); };
+  var show = function(id){ $(id).hidden = false; };
+
+  function api(path, body){
+    return fetch(path, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(body||{}) })
+      .then(function(r){ return r.json().then(function(j){ if(!r.ok){ throw new Error(j && j.error ? j.error : ('HTTP '+r.status)); } return j; }); });
+  }
+
+  // 既存記事スラッグ（重複回避）
+  fetch('/api/recent').then(function(r){ return r.json(); }).then(function(j){
+    recentTitles = (j && j.slugs) ? j.slugs : [];
+    $('recentMeta').textContent = '既存記事 ' + recentTitles.length + ' 件を重複回避に使用';
+  }).catch(function(){});
+
+  // STEP 1: 情報収集
+  $('collectBtn').addEventListener('click', function(){
+    var b = $('collectBtn'); b.disabled = true; b.innerHTML = '<span class="spin"></span>収集中…（30〜60秒）';
+    $('collectErr').innerHTML = '';
+    api('/api/collect', { recentTitles: recentTitles }).then(function(j){
+      renderCands(j.candidates || []);
+      show('s2'); $('s2').scrollIntoView({behavior:'smooth'});
+    }).catch(function(e){
+      $('collectErr').innerHTML = '<div class="err">情報収集に失敗しました: ' + esc(e.message) + '</div>';
+    }).then(function(){ b.disabled = false; b.textContent = 'もう一度 情報収集'; });
+  });
+
+  function renderCands(list){
+    var html = '';
+    for (var i=0;i<list.length;i++){
+      var c = list[i];
+      var src = (c.sources||[]).map(function(u){ return '<a href="'+esc(safeUrl(u))+'" target="_blank" rel="noopener">'+esc(u)+'</a>'; }).join('');
+      var fresh = c.freshnessHours ? ('<span class="badge">約'+esc(c.freshnessHours)+'時間前</span>') : '';
+      html += '<div class="card" id="cand'+i+'"><label><input type="checkbox" data-i="'+i+'">'
+        + '<span><span class="t">'+esc(c.title)+'</span>'+fresh
+        + '<div class="s">'+esc(c.summary)+'</div>'
+        + '<div class="src">'+src+'</div></span></label></div>';
+    }
+    $('cands').innerHTML = html || '<div class="meta">候補が見つかりませんでした。もう一度お試しください。</div>';
+    window.__cands = list;
+    var boxes = $('cands').querySelectorAll('input[type=checkbox]');
+    for (var k=0;k<boxes.length;k++){ boxes[k].addEventListener('change', updateSel); }
+  }
+
+  function selectedIdx(){
+    var out=[]; var boxes=$('cands').querySelectorAll('input[type=checkbox]:checked');
+    for (var k=0;k<boxes.length;k++){ out.push(parseInt(boxes[k].getAttribute('data-i'),10)); }
+    return out;
+  }
+  function updateSel(){
+    var idx = selectedIdx();
+    $('selMeta').textContent = idx.length + ' 件選択中';
+    $('genBtn').disabled = idx.length === 0;
+    var cards = $('cands').querySelectorAll('.card');
+    for (var k=0;k<cards.length;k++){ cards[k].classList.remove('sel'); }
+    for (var m=0;m<idx.length;m++){ var el=$('cand'+idx[m]); if(el) el.classList.add('sel'); }
+  }
+
+  // STEP 2 -> 3: 生成
+  $('genBtn').addEventListener('click', function(){
+    var idx = selectedIdx(); if(!idx.length) return;
+    var b = $('genBtn'); b.disabled = true;
+    $('arts').innerHTML = ''; show('s3'); $('s3').scrollIntoView({behavior:'smooth'});
+    var i = 0;
+    function next(){
+      if (i >= idx.length){ b.disabled=false; b.innerHTML='選択したテーマで記事を生成'; return; }
+      var theme = window.__cands[idx[i]];
+      b.innerHTML = '<span class="spin"></span>生成中 ' + (i+1) + '/' + idx.length + '…';
+      var slot = document.createElement('div'); slot.className='card'; slot.innerHTML='<div class="meta"><span class="spin" style="border-color:#1b2c40;border-top-color:transparent"></span>「'+esc(theme.title)+'」を生成中…</div>';
+      $('arts').appendChild(slot);
+      api('/api/generate', { theme: theme, recentTitles: recentTitles }).then(function(j){
+        renderArticle(slot, j.article, j.violations||[]);
+      }).catch(function(e){
+        slot.innerHTML = '<div class="err">生成に失敗しました（'+esc(theme.title)+'）: '+esc(e.message)+'</div>';
+      }).then(function(){ i++; next(); });
+    }
+    next();
+  });
+
+  function renderArticle(slot, a, viol){
+    var uid = 'a' + Math.floor(Math.random()*1e9);
+    var violHtml = '';
+    if (viol.length){
+      var items = viol.map(function(v){ return '・['+esc(v.name)+'] '+esc(v.reason)+'（'+esc(v.match)+' / '+esc(v.line)+'行目）'; }).join('<br>');
+      violHtml = '<div class="viol"><b>⚠ ガードレール違反 '+viol.length+'件 — このままでは公開できません</b>'+items+'</div>';
+    }
+    slot.className='card';
+    slot.innerHTML =
+      '<div class="row" style="justify-content:space-between"><strong>'+esc(a.title)+'</strong>'
+      + '<span class="meta">カテゴリ: '+esc(a.category)+' / タグ: '+esc((a.tags||[]).join(', '))+'</span></div>'
+      + '<div class="meta" style="margin-top:4px">slug: '+esc(a.slug)+'</div>'
+      + violHtml
+      + '<div class="field"><label>タイトル</label><input id="'+uid+'_title" value="'+esc(a.title)+'"></div>'
+      + '<div class="field"><label>説明（カード・OGP用）</label><input id="'+uid+'_desc" value="'+esc(a.description)+'"></div>'
+      + '<div class="field"><label>本文（Markdown・編集可）</label><textarea id="'+uid+'_body">'+esc(a.body)+'</textarea></div>'
+      + '<div class="row"><button class="pub" id="'+uid+'_pub"'+(viol.length?' disabled':'')+'>公開する</button>'
+      + '<button class="ghost" id="'+uid+'_recheck">再チェック</button>'
+      + '<span id="'+uid+'_msg" class="meta"></span></div>';
+
+    var getArticle = function(){
+      return { slug:a.slug, title:$(uid+'_title').value, description:$(uid+'_desc').value, category:a.category, tags:a.tags||[], body:$(uid+'_body').value };
+    };
+    $(uid+'_recheck').addEventListener('click', function(){
+      var btn=this; btn.disabled=true; $(uid+'_msg').textContent='チェック中…';
+      api('/api/validate', getArticle()).then(function(j){
+        var v = j.violations || [];
+        if (v.length){
+          $(uid+'_msg').innerHTML='<span style="color:#dc2626">違反 '+v.length+'件: '+esc(v.map(function(x){return x.name;}).join(', '))+'</span>';
+          $(uid+'_pub').disabled = true;
+        } else {
+          $(uid+'_msg').innerHTML='<span style="color:#16a34a">✓ 違反なし。公開できます</span>';
+          $(uid+'_pub').disabled = false;
+        }
+        btn.disabled=false;
+      }).catch(function(e){ $(uid+'_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; });
+    });
+    $(uid+'_pub').addEventListener('click', function(){
+      var btn=this; btn.disabled=true; btn.innerHTML='<span class="spin"></span>公開中…'; $(uid+'_msg').textContent='';
+      api('/api/publish', getArticle()).then(function(j){ finishPublish(slot, uid, j); })
+        .catch(function(e){ $(uid+'_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.textContent='公開する'; });
+    });
+  }
+
+  function finishPublish(slot, uid, j){
+    var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
+    slot.innerHTML = '<div class="done">✓ 公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
+  }
+})();
+</script>
+</body>
+</html>`;

--- a/workers/yomimono/src/ui.ts
+++ b/workers/yomimono/src/ui.ts
@@ -84,7 +84,8 @@ export const ADMIN_HTML = `<!doctype html>
 </main>
 <script>
 (function(){
-  var recentTitles = [];
+  var recentSlugs = []; // 既存記事のスラッグ（/api/recent → {slugs}）。重複テーマ回避に使う
+  var _uid = 0; // 記事カードの一意ID採番（衝突回避に乱数でなくカウンター）
   var esc = function(s){ return String(s==null?'':s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];}); };
   // href に使う前にスキームを http(s) のみ許可（javascript: 等を無効化）
   var safeUrl = function(u){ u = String(u==null?'':u).trim(); return /^https?:\\/\\//i.test(u) ? u : '#'; };
@@ -98,15 +99,15 @@ export const ADMIN_HTML = `<!doctype html>
 
   // 既存記事スラッグ（重複回避）
   fetch('/api/recent').then(function(r){ return r.json(); }).then(function(j){
-    recentTitles = (j && j.slugs) ? j.slugs : [];
-    $('recentMeta').textContent = '既存記事 ' + recentTitles.length + ' 件を重複回避に使用';
+    recentSlugs = (j && j.slugs) ? j.slugs : [];
+    $('recentMeta').textContent = '既存記事 ' + recentSlugs.length + ' 件を重複回避に使用';
   }).catch(function(){});
 
   // STEP 1: 情報収集
   $('collectBtn').addEventListener('click', function(){
     var b = $('collectBtn'); b.disabled = true; b.innerHTML = '<span class="spin"></span>収集中…（30〜60秒）';
     $('collectErr').innerHTML = '';
-    api('/api/collect', { recentTitles: recentTitles }).then(function(j){
+    api('/api/collect', { recentTitles: recentSlugs }).then(function(j){
       renderCands(j.candidates || []);
       show('s2'); $('s2').scrollIntoView({behavior:'smooth'});
     }).catch(function(e){
@@ -157,7 +158,7 @@ export const ADMIN_HTML = `<!doctype html>
       b.innerHTML = '<span class="spin"></span>生成中 ' + (i+1) + '/' + idx.length + '…';
       var slot = document.createElement('div'); slot.className='card'; slot.innerHTML='<div class="meta"><span class="spin" style="border-color:#1b2c40;border-top-color:transparent"></span>「'+esc(theme.title)+'」を生成中…</div>';
       $('arts').appendChild(slot);
-      api('/api/generate', { theme: theme, recentTitles: recentTitles }).then(function(j){
+      api('/api/generate', { theme: theme, recentTitles: recentSlugs }).then(function(j){
         renderArticle(slot, j.article, j.violations||[]);
       }).catch(function(e){
         slot.innerHTML = '<div class="err">生成に失敗しました（'+esc(theme.title)+'）: '+esc(e.message)+'</div>';
@@ -167,7 +168,7 @@ export const ADMIN_HTML = `<!doctype html>
   });
 
   function renderArticle(slot, a, viol){
-    var uid = 'a' + Math.floor(Math.random()*1e9);
+    var uid = 'a' + (++_uid);
     var violHtml = '';
     if (viol.length){
       var items = viol.map(function(v){ return '・['+esc(v.name)+'] '+esc(v.reason)+'（'+esc(v.match)+' / '+esc(v.line)+'行目）'; }).join('<br>');
@@ -181,7 +182,7 @@ export const ADMIN_HTML = `<!doctype html>
       + violHtml
       + '<div class="field"><label>タイトル</label><input id="'+uid+'_title" value="'+esc(a.title)+'"></div>'
       + '<div class="field"><label>説明（カード・OGP用）</label><input id="'+uid+'_desc" value="'+esc(a.description)+'"></div>'
-      + '<div class="field"><label>本文（Markdown・編集可）</label><textarea id="'+uid+'_body">'+esc(a.body)+'</textarea></div>'
+      + '<div class="field"><label>本文（Markdown・編集可）</label><textarea id="'+uid+'_body" maxlength="100000">'+esc(a.body)+'</textarea></div>'
       + '<div class="row"><button class="pub" id="'+uid+'_pub"'+(viol.length?' disabled':'')+'>公開する</button>'
       + '<button class="ghost" id="'+uid+'_recheck">再チェック</button>'
       + '<span id="'+uid+'_msg" class="meta"></span></div>';

--- a/workers/yomimono/src/ui.ts
+++ b/workers/yomimono/src/ui.ts
@@ -191,7 +191,7 @@ export const ADMIN_HTML = `<!doctype html>
     };
     $(uid+'_recheck').addEventListener('click', function(){
       var btn=this; btn.disabled=true; $(uid+'_msg').textContent='チェック中…';
-      api('/api/validate', getArticle()).then(function(j){
+      api('/api/validate', { article: getArticle() }).then(function(j){
         var v = j.violations || [];
         if (v.length){
           $(uid+'_msg').innerHTML='<span style="color:#dc2626">違反 '+v.length+'件: '+esc(v.map(function(x){return x.name;}).join(', '))+'</span>';
@@ -205,7 +205,7 @@ export const ADMIN_HTML = `<!doctype html>
     });
     $(uid+'_pub').addEventListener('click', function(){
       var btn=this; btn.disabled=true; btn.innerHTML='<span class="spin"></span>公開中…'; $(uid+'_msg').textContent='';
-      api('/api/publish', getArticle()).then(function(j){ finishPublish(slot, uid, j); })
+      api('/api/publish', { article: getArticle() }).then(function(j){ finishPublish(slot, uid, j); })
         .catch(function(e){ $(uid+'_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.textContent='公開する'; });
     });
   }

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -28,3 +28,48 @@ export function sanitizeText(s: unknown, maxLen: number): string {
     .trim()
     .slice(0, maxLen);
 }
+
+export interface ArticleInput {
+  slug?: string;
+  title?: string;
+  description?: string;
+  category?: string;
+  tags?: unknown;
+  body?: string;
+}
+export type NormalizedArticle = {
+  slug: string;
+  title: string;
+  description: string;
+  category: Article['category'];
+  tags: string[];
+  body: string;
+};
+
+// publish / validate 共通: 受け取った article を検証・正規化（パストラバーサル防止含む）。
+export function normalizeArticle(
+  a: ArticleInput | undefined,
+): { ok: true; article: NormalizedArticle } | { ok: false; error: string; status: number } {
+  if (!a?.slug || !a?.body || !a?.title || !a?.description) {
+    return { ok: false, error: 'article.slug / title / description / body は必須です', status: 400 };
+  }
+  try {
+    assertSlug(a.slug);
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'slug が不正です', status: 400 };
+  }
+  const article: NormalizedArticle = {
+    slug: a.slug,
+    title: sanitizeText(a.title, 200),
+    description: sanitizeText(a.description, 500),
+    category: normalizeCategory(a.category),
+    tags: Array.isArray(a.tags)
+      ? a.tags.slice(0, 10).map((t) => sanitizeText(t, 50)).filter(Boolean)
+      : [],
+    body: String(a.body).slice(0, 100_000), // markdown構造を保つため制御文字は除去せず長さのみ制限
+  };
+  if (!article.title || !article.description) {
+    return { ok: false, error: 'title / description が空です', status: 400 };
+  }
+  return { ok: true, article };
+}


### PR DESCRIPTION
## 概要
読みものCMS の**管理画面**（凪沙さん用）を追加。Worker 自身が `GET /` で配信するため、**Cloudflare Access が UI も API も同一オリジンで保護**（CORS なし・認証統一・「秘密のページ」概念に合致）。凪沙さんは Worker の URL を開くだけで完結します。

[#141](https://github.com/Cor-Incorporated/corsweb2024/pull/141) のバックエンドに続くフェーズ。`workers/yomimono/` のみ変更で**本番サイトに影響なし**。

## フロー（main マージ不要で公開）
```
① 情報収集 → ② テーマ選択(複数可) → ③ 生成 → レビュー&編集 → 公開
```
- **① 情報収集**: ボタン1つ。「既存記事 N 件を重複回避に使用」表示
- **② テーマ選択**: 候補カード＋チェックボックス＋鮮度バッジ＋出典リンク。複数選択可
- **③ レビュー&公開**: タイトル/説明/**本文(Markdown)を編集可能**。ガードレール違反は赤表示＆公開ボタン無効。「公開する」(緑)→記事botがmainへcommit。「再チェック」で検証のみ

## 追加エンドポイント
| Method | Path | 説明 |
|--------|------|------|
| GET | `/` `/index.html` | 管理画面HTML（vanilla, ビルド不要） |
| GET | `/api/recent` | 既存記事スラッグ一覧（重複回避） |
| POST | `/api/validate` | コミットせずガードレール再チェック |

`normalizeArticle()` を publish/validate で共通化。

## セキュリティ（code-reviewer 承認: CRITICAL/HIGH/MEDIUM 0）
- 全動的値を `esc()` エスケープ＋`href` は `safeUrl()` で **http(s) スキームのみ許可**（`javascript:`/`data:` を無効化）。サーバ側も `theme.sources` を http(s) に限定（多層防御）
- 「再チェック」は `/api/validate` のみ＝**誤公開なし**。公開は「公開する」ボタンのみ
- 全ルートは `verifyAccessEmail` の後（未認証は401）

## 検証
- ✅ `tsc --noEmit` clean / `vitest` 31 pass / `wrangler` バンドル成功（gzip 115KiB）
- ✅ **ブラウザプレビューで全3ステップ動作確認**（情報収集→選択→生成→編集→公開ボタン）。スキームフィルタ（javascript:/data: → 無効化、http(s) → 保持）も実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated publish-to-main flows and new HTML/JS surface area, but routes stay behind Access JWT verification and validation/guardrails are layered on publish and validate.
> 
> **Overview**
> Adds a **self-contained admin UI** (“読みもの 作成スタジオ”) that the yomimono Worker serves at `GET /` and `/index.html`, with a strict **CSP** and same-origin API calls behind **Cloudflare Access**.
> 
> The UI walks through **collect → theme selection → generate → edit/review → publish**, including guardrail display, **再チェック** via a new **`POST /api/validate`** (no commit), and **公開する** via existing publish. **`GET /api/recent`** returns existing article slugs from GitHub (`listArticleSlugs`) for duplicate-theme avoidance in collect/generate.
> 
> **`normalizeArticle()`** centralizes publish/validate validation (required fields, slug/path rules, sanitization, tag limits, body length); **`/api/publish`** now uses it instead of inline logic. **`/api/generate`** additionally filters `theme.sources` to **http(s)** URLs only (aligned with client `safeUrl`). Tests cover **`normalizeArticle`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0d0908d1d79128264e8df6057b2ba0175de0de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->