### PR TITLE
feat(yomimono): 管理画面を cor-jp.com/brog に載せる

### DIFF
--- a/workers/yomimono/README.md
+++ b/workers/yomimono/README.md
@@ -1,23 +1,30 @@
 # 読みものCMS バックエンド（Cloudflare Worker / `cor-yomimono`）
 
-凪沙さんが **main マージ権限なしで毎日記事を投稿**できるようにする、サーバーレス・バックエンド。
+凪沙さんが **main マージ権限なしで毎日記事を投稿**できるようにする、サーバーレス・バックエンド＋管理画面。
 記事は DB を使わず **.md として git にコミット**され、既存の静的デプロイでそのまま公開される（A案：記事bot方式）。
 
+管理画面は **HP と同じドメインの隠しページ `https://cor-jp.com/brog`** で開ける（cor-jp.com は Cloudflare の裏にいるため、`/brog*` だけを Cloudflare Worker のルートに流す）。HP本体（静的・Firebase）はそのまま。
+
 ```
-情報収集(/api/collect) → テーマ選定(人) → 生成(/api/generate) → レビュー(人) → 公開(/api/publish)
-                                    Claude                Claude＋ガードレール        記事botがmainへcommit
+情報収集(/brog/api/collect) → テーマ選定(人) → 生成(/brog/api/generate) → レビュー(人) → 公開(/brog/api/publish)
+                                       Claude                  Claude＋ガードレール          記事botがmainへcommit
 ```
 
-## エンドポイント
+## エンドポイント（`BASE_PATH=/brog` のため実URLは `cor-jp.com/brog...`）
 
-| Method | Path | 説明 |
+| Method | 論理Path | 説明 |
 |--------|------|------|
-| GET  | `/health` | 死活確認（認証不要） |
+| GET  | `/` | 管理画面HTML（凪沙さん用） → `cor-jp.com/brog` |
+| GET  | `/health` | 死活確認 → `cor-jp.com/brog/health` |
+| GET  | `/api/recent` | 既存記事スラッグ一覧（重複テーマ回避） |
 | POST | `/api/collect` | 直近約27hのAI/DX/ローカルLLM記事から候補テーマを10〜15件返す |
 | POST | `/api/generate` | 選んだテーマで記事を1本生成（社長の文体）＋ガードレール検査結果を同梱 |
+| POST | `/api/validate` | コミットせずガードレール再チェック（編集後の確認用） |
 | POST | `/api/publish` | 記事botが `src/content/blog/ja/<slug>.md` を `main` にコミット |
 
-`/health` 以外は **Cloudflare Access**（cor-jp.com 限定）で認証。Worker は `Cf-Access-Jwt-Assertion`（JWT）をチームの公開鍵で**暗号検証**し、`aud`/`iss`/`exp`/メールドメインを全て確認する（ヘッダ盲信はしない＝workers.dev 直叩きでも突破不可）。`CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` 未設定時は全リクエストを拒否（fail closed）。
+Worker は受信パスから `BASE_PATH`(=`/brog`) を剥がして上記の論理パスにルーティングする。`BASE_PATH` 空ならルート直下（`*.workers.dev/` でのテスト）でもそのまま動く。
+
+`/health` 以外は **Cloudflare Access**（cor-jp.com 限定）で認証。Worker は `Cf-Access-Jwt-Assertion`（JWT）をチームの公開鍵で**暗号検証**し、`aud`/`iss`/`exp`/メールドメインを全て確認する（ヘッダ盲信はしない＝直叩きでも突破不可）。`CF_ACCESS_TEAM_DOMAIN` / `CF_ACCESS_AUD` 未設定時は全リクエストを拒否（fail closed）。
 
 ## デプロイ手順（初回）
 
@@ -35,15 +42,19 @@ npm run deploy            # 公開（*.workers.dev のURLが発行される）
 
 `wrangler.toml` の `[vars]` に App ID / Installation ID 等の非シークレット設定が入っている（編集不要）。
 
+## ルート（`cor-jp.com/brog`）について
+
+`wrangler.toml` の `routes = [{ pattern = "cor-jp.com/brog*", zone_name = "cor-jp.com" }]` により、`npm run deploy` で **cor-jp.com の `/brog*` だけがこの Worker に流れる**。cor-jp.com は Cloudflare の裏にいる（NS が `*.ns.cloudflare.com`）ため、HP本体（Firebase 配信）はそのまま、`/brog` だけ Worker が応答する。`zone_name` の cor-jp.com が同じ Cloudflare アカウントにある必要がある。
+
 ## 認証（Cloudflare Access）— デプロイ後に設定
 
 1. Cloudflare ダッシュボード → **Zero Trust** → **Access → Applications → Add an application → Self-hosted**
-2. アプリのドメインに Worker の URL（`cor-yomimono.<account>.workers.dev`）を指定
+2. アプリのドメイン/パスに **`cor-jp.com`** + パス **`/brog`**（サブパス含む）を指定
 3. ポリシー: **Action=Allow**, **Include → Emails ending in → `@cor-jp.com`**
 4. ログイン方法に Google（または One-time PIN）を追加 → 保存
 5. アプリ設定の **Application Audience (AUD) タグ** をコピーし、`wrangler.toml` の `CF_ACCESS_AUD` に貼る。`CF_ACCESS_TEAM_DOMAIN` にはチームドメイン（例 `cor.cloudflareaccess.com`）を入れて `npm run deploy` で再デプロイ。
 
-これで cor-jp.com のメンバーだけがログインでき、Worker は JWT を暗号検証してメールを得る。
+これで cor-jp.com のメンバーだけが `cor-jp.com/brog` にログインでき、Worker は JWT を暗号検証してメールを得る。HP の一般訪問者には `/brog` は見えない（リンクを置かない限り）。
 
 ### コスト保護（推奨）
 

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -48,8 +48,15 @@ function sanitizeTitles(input: unknown): string[] {
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
+    // マウントプレフィックス(/brog)を剥がして論理パスに正規化。
+    // cor-jp.com/brog* ルートでは /brog/api/x → /api/x、/brog → / に変換する。
+    // BASE_PATH 未設定（ルート直下=workers.dev）でもそのまま動く。
+    const base = env.BASE_PATH || '';
+    let path = url.pathname;
+    if (base && path === base) path = '/';
+    else if (base && path.startsWith(base + '/')) path = path.slice(base.length);
 
-    if (url.pathname === '/health') return json({ ok: true });
+    if (path === '/health') return json({ ok: true });
 
     // 認証: Cloudflare Access の JWT を暗号検証（ヘッダ盲信はしない）
     const email = await verifyAccessEmail(req, env);
@@ -59,19 +66,19 @@ export default {
 
     try {
       // 管理画面（凪沙さん用UI）。Access 認証済みのブラウザにHTMLを返す。
-      if (req.method === 'GET' && (url.pathname === '/' || url.pathname === '/index.html')) {
+      if (req.method === 'GET' && (path === '/' || path === '/index.html')) {
         return html(ADMIN_HTML);
       }
 
       // 既存記事スラッグ一覧（重複テーマ回避用）
-      if (req.method === 'GET' && url.pathname === '/api/recent') {
+      if (req.method === 'GET' && path === '/api/recent') {
         const octokit = makeOctokit(env);
         const slugs = await listArticleSlugs(env, octokit);
         return json({ slugs });
       }
 
       // ① 情報収集
-      if (req.method === 'POST' && url.pathname === '/api/collect') {
+      if (req.method === 'POST' && path === '/api/collect') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const candidates = await collectTopics(env, sanitizeTitles(body.recentTitles));
@@ -79,7 +86,7 @@ export default {
       }
 
       // ④ 記事生成（＋ガードレール検査結果を同梱して⑤レビューへ）
-      if (req.method === 'POST' && url.pathname === '/api/generate') {
+      if (req.method === 'POST' && path === '/api/generate') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const theme = (body.theme ?? {}) as {
@@ -112,7 +119,7 @@ export default {
       }
 
       // ⑤ レビュー: コミットせずガードレール検査のみ（編集後の再チェック用）
-      if (req.method === 'POST' && url.pathname === '/api/validate') {
+      if (req.method === 'POST' && path === '/api/validate') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const norm = normalizeArticle(body.article as ArticleInput | undefined);
@@ -122,7 +129,7 @@ export default {
       }
 
       // ⑥ 公開（記事botが main へコミット → 既存の静的デプロイで公開）
-      if (req.method === 'POST' && url.pathname === '/api/publish') {
+      if (req.method === 'POST' && path === '/api/publish') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const norm = normalizeArticle(body.article as ArticleInput | undefined);

--- a/workers/yomimono/src/types.ts
+++ b/workers/yomimono/src/types.ts
@@ -11,6 +11,7 @@ export interface Env {
   PUBLISH_BRANCH: string;
   ALLOWED_EMAIL_DOMAIN: string;
   STYLE_GUIDE_PATH: string;
+  BASE_PATH: string; // マウントプレフィックス（例 /brog）。cor-jp.com/brog* ルートで使用。空ならルート直下。
   // Cloudflare Access（JWT検証用）。Accessアプリ作成後に設定。未設定なら全リクエスト拒否（fail closed）。
   CF_ACCESS_TEAM_DOMAIN: string; // 例: cor.cloudflareaccess.com
   CF_ACCESS_AUD: string; // Access アプリの Application Audience (AUD) タグ

--- a/workers/yomimono/src/ui.ts
+++ b/workers/yomimono/src/ui.ts
@@ -84,6 +84,9 @@ export const ADMIN_HTML = `<!doctype html>
 </main>
 <script>
 (function(){
+  // このページの配置場所からベースパスを算出（cor-jp.com/brog でも workers.dev/ でも動く）。
+  // 例: /brog → /brog/api/...、/brog/index.html → /brog、/ → /api/...
+  var BASE = location.pathname.replace(/\\/(index\\.html)?$/, '');
   var recentSlugs = []; // 既存記事のスラッグ（/api/recent → {slugs}）。重複テーマ回避に使う
   var _uid = 0; // 記事カードの一意ID採番（衝突回避に乱数でなくカウンター）
   var esc = function(s){ return String(s==null?'':s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];}); };
@@ -93,12 +96,12 @@ export const ADMIN_HTML = `<!doctype html>
   var show = function(id){ $(id).hidden = false; };
 
   function api(path, body){
-    return fetch(path, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(body||{}) })
+    return fetch(BASE + path, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(body||{}) })
       .then(function(r){ return r.json().then(function(j){ if(!r.ok){ throw new Error(j && j.error ? j.error : ('HTTP '+r.status)); } return j; }); });
   }
 
   // 既存記事スラッグ（重複回避）
-  fetch('/api/recent').then(function(r){ return r.json(); }).then(function(j){
+  fetch(BASE + '/api/recent').then(function(r){ return r.json(); }).then(function(j){
     recentSlugs = (j && j.slugs) ? j.slugs : [];
     $('recentMeta').textContent = '既存記事 ' + recentSlugs.length + ' 件を重複回避に使用';
   }).catch(function(){});

--- a/workers/yomimono/wrangler.toml
+++ b/workers/yomimono/wrangler.toml
@@ -3,6 +3,10 @@ main = "src/index.ts"
 compatibility_date = "2025-01-09"
 compatibility_flags = ["nodejs_compat"]
 
+# cor-jp.com の /brog* だけをこの Worker に流す（HP本体は Firebase のまま）。
+# cor-jp.com は Cloudflare の裏にいるため、このルートで「HPと同じドメインの隠しページ」になる。
+routes = [{ pattern = "cor-jp.com/brog*", zone_name = "cor-jp.com" }]
+
 # 公開可能な設定値（非シークレット）。記事botのIDは公開情報なのでここでOK。
 [vars]
 GH_OWNER = "Cor-Incorporated"
@@ -13,6 +17,8 @@ BLOG_DIR = "src/content/blog"
 PUBLISH_BRANCH = "main"
 ALLOWED_EMAIL_DOMAIN = "cor-jp.com"
 STYLE_GUIDE_PATH = "docs/blog-style-guide.md"
+# ↓ BASE_PATH は上の routes の pattern と必ず一致させること（/brog ⇔ cor-jp.com/brog*）
+BASE_PATH = "/brog"          # cor-jp.com/brog* に載せるためのプレフィックス
 # ↓ Cloudflare Access アプリ作成後に値を入れる（空のままだと全リクエストを拒否＝安全側）
 CF_ACCESS_TEAM_DOMAIN = ""   # 例: cor.cloudflareaccess.com
 CF_ACCESS_AUD = ""            # Access アプリ設定画面の Application Audience (AUD) タグ


### PR DESCRIPTION
## 概要
読みものCMS の管理画面を **HPと同じドメインの隠しページ `cor-jp.com/brog`** で開けるようにする。

`dig` で確認したとおり **cor-jp.com の DNS は Cloudflare 管理**（NS=`*.ns.cloudflare.com`, A=Cloudflare IP）。よって `/brog*` だけを Cloudflare Worker のルートに流せば、HP本体（静的・Firebase配信）はそのまま、`/brog` だけ Worker が応答する＝「HPの裏側」が実現できる。

## 変更
- **wrangler.toml**: `routes=[{pattern:"cor-jp.com/brog*", zone_name:"cor-jp.com"}]` + `BASE_PATH="/brog"`
- **index.ts**: 受信パスから `BASE_PATH` を剥がして論理パスに正規化（`/brog/api/x`→`/api/x`、`/brog`→`/`）。`BASE_PATH` 空ならルート直下（`*.workers.dev`）でも動く。**認証(`verifyAccessEmail`)は strip 後・全ルート前で不変**。
- **ui.ts**: `location.pathname` からベースパスを算出し全 fetch に前置（`/brog/api/...`）。`/index.html` 入口にも頑健。
- **types.ts**: `Env.BASE_PATH` 追加。**README**: `/brog` ルート + Access(`cor-jp.com/brog`) 手順に更新。

## セキュリティ（code-reviewer APPROVE: CRITICAL/HIGH/MEDIUM 0）
- パスstripに **auth-bypass なし**（strip は認証の前だが、`/health` 以外は全て `verifyAccessEmail` を通る。JWT検証はパス非依存）
- strip の edge case 網羅: `/brog`→`/`、`/brog/`→`/`、`/brog/api/x`→`/api/x`、`/brogXYZ`→不一致で404、`/`→不変。`/brog/../api` は `new URL()` が正規化＋edgeルート不一致で到達不可

## 検証
- ✅ `tsc` clean / `vitest` 44 pass / `wrangler` バンドル成功
- ✅ **ブラウザプレビューを `/brog/` で配信**し、fetch が `/brog/api/collect|generate|publish` に前置され**全フロー（収集→生成→公開）動作**を確認
- ✅ BASE 算出を全4ケースで検証（`/brog`・`/brog/`・`/brog/index.html`→`/brog`、`/`→`''`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production routing and URL layout for an internal CMS; JWT auth is unchanged but Access must be reconfigured for the new path, and a BASE_PATH/routes mismatch would break the UI.
> 
> **Overview**
> Mounts the 読みもの CMS admin on **`cor-jp.com/brog`** while the main site stays on static/Firebase: only `/brog*` is routed to the Worker.
> 
> **`wrangler.toml`** adds `cor-jp.com/brog*` route and `BASE_PATH="/brog"`. **`index.ts`** strips that prefix before routing (`/brog` → `/`, `/brog/api/...` → `/api/...`); empty `BASE_PATH` keeps root/`workers.dev` behavior. **`ui.ts`** derives a base from `location.pathname` and prefixes all `fetch` calls. **`types.ts`** adds `Env.BASE_PATH`; **README** documents URLs, routing, and Cloudflare Access on `cor-jp.com/brog`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2faf88f65793ccbccb951ea60559f9496c80e77d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->