### PR TITLE
feat(yomimono): ログイン後ハブ + 手動作成ページ（Markdown＋画像）

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -21,6 +21,15 @@
     ],
     "headers": [
       {
+        "source": "/images/blog/uploads/**",
+        "headers": [
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          }
+        ]
+      },
+      {
         "source": "**/*.@(js|css)",
         "headers": [
           {

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { assertSlug, normalizeArticle, normalizeCategory, sanitizeText, SLUG_RE } from '../validate';
+import {
+  assertSlug,
+  normalizeArticle,
+  normalizeCategory,
+  safeImageName,
+  sanitizeText,
+  SLUG_RE,
+} from '../validate';
 
 describe('assertSlug — パストラバーサル防止（CRITICAL修正の要）', () => {
   // バグ（slug未検証）が存在すれば、これらは throw せず素通りしてしまう。
@@ -102,6 +109,27 @@ describe('normalizeArticle — publish/validate 共通の検証・正規化', ()
     const r = normalizeArticle({ ...base, title: '```' });
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.status).toBe(400);
+  });
+});
+
+describe('safeImageName — 画像名のパストラバーサル/拡張子偽装防止', () => {
+  it('パストラバーサルを安全名に潰す（スラッシュ・ドット除去）', () => {
+    const n = safeImageName('../../../etc/passwd.png');
+    expect(n).not.toMatch(/[/\\]/);
+    expect(n).not.toContain('..');
+    expect(n.endsWith('.png')).toBe(true);
+  });
+  it('スペース・大文字を正規化する', () => {
+    expect(safeImageName('My Photo.PNG')).toBe('my-photo.png');
+  });
+  it.each(['photo.svg', 'evil.html', 'noext', 'script.js', ''])(
+    '非対応拡張子(%s)は拒否',
+    (name) => {
+      expect(() => safeImageName(name)).toThrow();
+    },
+  );
+  it.each(['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif'])('対応拡張子(%s)を通す', (ext) => {
+    expect(safeImageName('pic.' + ext)).toBe('pic.' + ext);
   });
 });
 

--- a/workers/yomimono/src/github.ts
+++ b/workers/yomimono/src/github.ts
@@ -1,6 +1,6 @@
 import { Octokit } from '@octokit/core';
 import { createAppAuth } from '@octokit/auth-app';
-import { assertSlug } from './validate';
+import { assertSlug, safeImageName } from './validate';
 import type { Env } from './types';
 
 export function makeOctokit(env: Env): Octokit {
@@ -101,4 +101,34 @@ export async function commitArticle(
   });
   const data = res.data as { commit?: { html_url?: string } };
   return { committed: true, path, commitUrl: data.commit?.html_url ?? '' };
+}
+
+// 手動エディタからの画像を public/images/blog/uploads/ へコミットし、公開URLを返す。
+// content-bot はここ（画像）と記事 .md にしか書かない。
+export async function commitImage(
+  env: Env,
+  octokit: Octokit,
+  filename: string,
+  base64: string,
+  uploaderEmail: string,
+): Promise<{ url: string; path: string; commitUrl: string }> {
+  const name = safeImageName(filename); // 拡張子検証＋パストラバーサル防止
+  const content = base64.replace(/\s/g, '');
+  if (!content || !/^[A-Za-z0-9+/]+={0,2}$/.test(content)) {
+    throw new Error('画像データ（base64）が不正です');
+  }
+  const full = `${Date.now()}-${name}`;
+  const path = `public/images/blog/uploads/${full}`;
+  const author = uploaderEmail.split('@')[0];
+  console.log('yomimono image upload:', { path, uploaderEmail });
+  const res = await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+    owner: env.GH_OWNER,
+    repo: env.GH_REPO,
+    path,
+    branch: env.PUBLISH_BRANCH,
+    message: `img(yomimono): ${full}（${author}）`,
+    content, // GitHub Contents API は base64 を期待。画像はクライアントが base64 化済み。
+  });
+  const data = res.data as { commit?: { html_url?: string } };
+  return { url: `/images/blog/uploads/${full}`, path, commitUrl: data.commit?.html_url ?? '' };
 }

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -3,17 +3,20 @@ import { verifyAccessEmail } from './auth';
 import { collectTopics } from './collect';
 import { generateArticle, buildMarkdown } from './generate';
 import { scanForViolations } from './guardrails';
-import { makeOctokit, getFileContent, commitArticle, listArticleSlugs } from './github';
+import { makeOctokit, getFileContent, commitArticle, commitImage, listArticleSlugs } from './github';
 import { sanitizeText, normalizeArticle, type ArticleInput } from './validate';
-import { ADMIN_HTML } from './ui';
+import { HUB_HTML } from './ui-hub';
+import { AI_HTML } from './ui-ai';
+import { MANUAL_HTML } from './ui-manual';
 
 // 管理画面は自己完結（外部リソース無し・同一オリジンfetchのみ）。
 // インライン style/script のみ許可し、外部読込・iframe埋め込み・データ送信先を遮断する。
 const CSP =
   "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; " +
   "img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
-const html = (body: string, status = 200): Response =>
-  new Response(body, {
+// __BASE__ プレースホルダを実際のマウントパス(env.BASE_PATH)へ置換して配信。
+const html = (body: string, env: Env, status = 200): Response =>
+  new Response(body.split('__BASE__').join(env.BASE_PATH || ''), {
     status,
     headers: {
       'content-type': 'text/html; charset=utf-8',
@@ -67,7 +70,13 @@ export default {
     try {
       // 管理画面（凪沙さん用UI）。Access 認証済みのブラウザにHTMLを返す。
       if (req.method === 'GET' && (path === '/' || path === '/index.html')) {
-        return html(ADMIN_HTML);
+        return html(HUB_HTML, env); // ハブ（AI生成 / 手動作成）
+      }
+      if (req.method === 'GET' && path === '/ai') {
+        return html(AI_HTML, env);
+      }
+      if (req.method === 'GET' && path === '/manual') {
+        return html(MANUAL_HTML, env);
       }
 
       // 既存記事スラッグ一覧（重複テーマ回避用）
@@ -75,6 +84,23 @@ export default {
         const octokit = makeOctokit(env);
         const slugs = await listArticleSlugs(env, octokit);
         return json({ slugs });
+      }
+
+      // 画像アップロード（手動エディタ用）。public/images/blog/uploads/ にコミットしURLを返す。
+      if (req.method === 'POST' && path === '/api/upload-image') {
+        const body = await readJsonBody(req);
+        if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
+        const filename = typeof body.filename === 'string' ? body.filename : '';
+        const dataBase64 = typeof body.dataBase64 === 'string' ? body.dataBase64 : '';
+        if (!filename || !dataBase64) {
+          return json({ error: 'filename と dataBase64 は必須です' }, 400);
+        }
+        if (dataBase64.length > 7_000_000) {
+          return json({ error: '画像が大きすぎます（5MBまで）' }, 413);
+        }
+        const octokit = makeOctokit(env);
+        const result = await commitImage(env, octokit, filename, dataBase64, email);
+        return json(result);
       }
 
       // ① 情報収集

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -15,8 +15,11 @@ const CSP =
   "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; " +
   "img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
 // __BASE__ プレースホルダを実際のマウントパス(env.BASE_PATH)へ置換して配信。
-const html = (body: string, env: Env, status = 200): Response =>
-  new Response(body.split('__BASE__').join(env.BASE_PATH || ''), {
+// BASE_PATH は JS文字列(var BASE="__BASE__") と HTML属性(href="__BASE__/ai") の両方に入るため、
+// パスに使う文字種のみへ正規化してから埋め込む（万一の注入を構造的に防ぐ）。
+const html = (body: string, env: Env, status = 200): Response => {
+  const base = (env.BASE_PATH || '').replace(/[^a-zA-Z0-9/_-]/g, '');
+  return new Response(body.split('__BASE__').join(base), {
     status,
     headers: {
       'content-type': 'text/html; charset=utf-8',
@@ -25,6 +28,7 @@ const html = (body: string, env: Env, status = 200): Response =>
       'referrer-policy': 'no-referrer',
     },
   });
+};
 
 const json = (data: unknown, status = 200): Response =>
   new Response(JSON.stringify(data), {

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -96,7 +96,7 @@ export default {
           return json({ error: 'filename と dataBase64 は必須です' }, 400);
         }
         if (dataBase64.length > 7_000_000) {
-          return json({ error: '画像が大きすぎます（5MBまで）' }, 413);
+          return json({ error: '画像が大きすぎます（約5MBまで）' }, 413);
         }
         const octokit = makeOctokit(env);
         const result = await commitImage(env, octokit, filename, dataBase64, email);

--- a/workers/yomimono/src/ui-ai.ts
+++ b/workers/yomimono/src/ui-ai.ts
@@ -1,61 +1,9 @@
-// 管理画面（凪沙さん用）。Worker が GET / でこの HTML を返す。
-// Cloudflare Access と同一オリジンのため、fetch は自動で認証される（CORS なし）。
-// 注: 文字列内に ${ とバックティックを入れないこと（外側のTSテンプレートリテラルが壊れる）。
-//     ページ側のJSは文字列連結で書いている。
-export const ADMIN_HTML = `<!doctype html>
-<html lang="ja">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>読みもの 作成スタジオ — Cor.</title>
-<style>
-  :root { --navy:#1b2c40; --navy2:#243a54; --ink:#1b2330; --muted:#64748b; --line:#e2e8f0; --bg:#f6f8fb; --ok:#16a34a; --warn:#dc2626; --accent:#2563eb; }
-  * { box-sizing:border-box; }
-  body { margin:0; font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN',system-ui,sans-serif; color:var(--ink); background:var(--bg); line-height:1.7; }
-  header { background:var(--navy); color:#fff; padding:18px 24px; }
-  header h1 { margin:0; font-size:18px; letter-spacing:.04em; }
-  header p { margin:4px 0 0; font-size:12px; color:#aebfd4; }
-  main { max-width:860px; margin:0 auto; padding:24px 16px 80px; }
-  .step { background:#fff; border:1px solid var(--line); border-radius:14px; padding:20px; margin-bottom:18px; box-shadow:0 1px 2px rgba(16,24,40,.04); }
-  .step h2 { margin:0 0 4px; font-size:15px; color:var(--navy); }
-  .step .hint { margin:0 0 14px; font-size:12px; color:var(--muted); }
-  .num { display:inline-flex; width:22px; height:22px; border-radius:50%; background:var(--navy); color:#fff; font-size:12px; align-items:center; justify-content:center; margin-right:8px; }
-  button { font:inherit; cursor:pointer; border:none; border-radius:10px; padding:11px 18px; font-weight:600; }
-  .primary { background:var(--navy); color:#fff; }
-  .primary:hover { background:var(--navy2); }
-  .primary:disabled { background:#9aa7b8; cursor:not-allowed; }
-  .ghost { background:#eef2f7; color:var(--ink); }
-  .pub { background:var(--ok); color:#fff; }
-  .pub:disabled { background:#bbb; cursor:not-allowed; }
-  .card { border:1px solid var(--line); border-radius:12px; padding:14px; margin:10px 0; }
-  .card.sel { border-color:var(--accent); background:#f0f6ff; }
-  .card label { display:flex; gap:10px; align-items:flex-start; cursor:pointer; }
-  .card .t { font-weight:700; font-size:14px; }
-  .card .s { font-size:13px; color:#374151; margin:4px 0; }
-  .card .src a { font-size:11px; color:var(--accent); margin-right:10px; word-break:break-all; }
-  .badge { display:inline-block; font-size:11px; background:#eef2f7; color:var(--muted); border-radius:20px; padding:2px 9px; margin-left:6px; }
-  .field { margin:10px 0; }
-  .field label { display:block; font-size:12px; color:var(--muted); margin-bottom:4px; }
-  .field input, .field textarea { width:100%; padding:9px 11px; border:1px solid var(--line); border-radius:8px; font:inherit; }
-  .field textarea { min-height:280px; resize:vertical; font-family:ui-monospace,Menlo,monospace; font-size:13px; line-height:1.6; }
-  .viol { background:#fff1f2; border:1px solid #fecaca; color:#991b1b; border-radius:8px; padding:10px 12px; font-size:12px; margin:8px 0; }
-  .viol b { display:block; margin-bottom:4px; }
-  .done { background:#f0fdf4; border:1px solid #bbf7d0; color:#166534; border-radius:8px; padding:10px 12px; font-size:13px; }
-  .done a { color:#166534; }
-  .err { background:#fff1f2; border:1px solid #fecaca; color:#991b1b; border-radius:8px; padding:10px 12px; font-size:13px; margin:8px 0; }
-  .spin { display:inline-block; width:15px; height:15px; border:2px solid #fff; border-top-color:transparent; border-radius:50%; animation:sp .8s linear infinite; vertical-align:-2px; margin-right:6px; }
-  @keyframes sp { to { transform:rotate(360deg); } }
-  .row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
-  .meta { font-size:12px; color:var(--muted); }
-  [hidden] { display:none; }
-</style>
-</head>
-<body>
-<header>
-  <h1>読みもの 作成スタジオ</h1>
-  <p>情報収集 → テーマ選定 → 生成 → レビュー → 公開（main マージ不要で公開されます）</p>
-</header>
-<main>
+import { head, header, tail } from './ui-shared';
+
+// AI生成ページ（情報収集→テーマ選択→生成→レビュー→公開）。
+// 共通JS(BASE/esc/safeUrl/$/api)は ui-shared の COMMON_JS から供給される。
+const BODY = `<main>
+  <p class="lead">情報収集 → テーマ選定 → 生成 → レビュー → 公開（main マージ不要で公開されます）</p>
   <section class="step" id="s1">
     <h2><span class="num">1</span>情報収集</h2>
     <p class="hint">直近およそ27時間の AI / DX / ローカルLLM などの話題から、中小企業に刺さる候補テーマを集めます。</p>
@@ -65,7 +13,6 @@ export const ADMIN_HTML = `<!doctype html>
     </div>
     <div id="collectErr"></div>
   </section>
-
   <section class="step" id="s2" hidden>
     <h2><span class="num">2</span>テーマを選ぶ（複数可）</h2>
     <p class="hint">書きたいテーマにチェックを入れて、記事生成へ進んでください。</p>
@@ -75,38 +22,23 @@ export const ADMIN_HTML = `<!doctype html>
       <span class="meta" id="selMeta">0 件選択中</span>
     </div>
   </section>
-
   <section class="step" id="s3" hidden>
     <h2><span class="num">3</span>レビュー & 公開</h2>
     <p class="hint">本文を確認・編集してから「公開する」を押してください。ガードレール違反があると公開できません。</p>
     <div id="arts"></div>
   </section>
-</main>
-<script>
-(function(){
-  // このページの配置場所からベースパスを算出（cor-jp.com/brog でも workers.dev/ でも動く）。
-  // 例: /brog → /brog/api/...、/brog/index.html → /brog、/ → /api/...
-  var BASE = location.pathname.replace(/\\/(index\\.html)?$/, '');
-  var recentSlugs = []; // 既存記事のスラッグ（/api/recent → {slugs}）。重複テーマ回避に使う
-  var _uid = 0; // 記事カードの一意ID採番（衝突回避に乱数でなくカウンター）
-  var esc = function(s){ return String(s==null?'':s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];}); };
-  // href に使う前にスキームを http(s) のみ許可（javascript: 等を無効化）
-  var safeUrl = function(u){ u = String(u==null?'':u).trim(); return /^https?:\\/\\//i.test(u) ? u : '#'; };
-  var $ = function(id){ return document.getElementById(id); };
+</main>`;
+
+const JS = `
+  var recentSlugs = [];
+  var _uid = 0;
   var show = function(id){ $(id).hidden = false; };
 
-  function api(path, body){
-    return fetch(BASE + path, { method:'POST', headers:{'content-type':'application/json'}, body: JSON.stringify(body||{}) })
-      .then(function(r){ return r.json().then(function(j){ if(!r.ok){ throw new Error(j && j.error ? j.error : ('HTTP '+r.status)); } return j; }); });
-  }
-
-  // 既存記事スラッグ（重複回避）
   fetch(BASE + '/api/recent').then(function(r){ return r.json(); }).then(function(j){
     recentSlugs = (j && j.slugs) ? j.slugs : [];
     $('recentMeta').textContent = '既存記事 ' + recentSlugs.length + ' 件を重複回避に使用';
   }).catch(function(){});
 
-  // STEP 1: 情報収集
   $('collectBtn').addEventListener('click', function(){
     var b = $('collectBtn'); b.disabled = true; b.innerHTML = '<span class="spin"></span>収集中…（30〜60秒）';
     $('collectErr').innerHTML = '';
@@ -149,7 +81,6 @@ export const ADMIN_HTML = `<!doctype html>
     for (var m=0;m<idx.length;m++){ var el=$('cand'+idx[m]); if(el) el.classList.add('sel'); }
   }
 
-  // STEP 2 -> 3: 生成
   $('genBtn').addEventListener('click', function(){
     var idx = selectedIdx(); if(!idx.length) return;
     var b = $('genBtn'); b.disabled = true;
@@ -218,7 +149,6 @@ export const ADMIN_HTML = `<!doctype html>
     var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
     slot.innerHTML = '<div class="done">✓ 公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
   }
-})();
-</script>
-</body>
-</html>`;
+`;
+
+export const AI_HTML = head('AI生成 — 読みもの 作成スタジオ') + header('ai') + BODY + tail(JS);

--- a/workers/yomimono/src/ui-hub.ts
+++ b/workers/yomimono/src/ui-hub.ts
@@ -1,0 +1,15 @@
+import { head, header, tail } from './ui-shared';
+
+// ログイン後の入口。AI生成 / 手動作成 の2択。
+export const HUB_HTML =
+  head('ハブ — 読みもの 作成スタジオ') +
+  header('hub') +
+  '<main>' +
+  '<p class="lead">記事の作り方を選んでください。どちらで書いても、記事は main マージ不要でそのまま cor-jp.com に公開されます。</p>' +
+  '<div class="hub">' +
+  '<a href="__BASE__/ai"><div class="ic">🤖</div><h3>AI生成</h3>' +
+  '<p>最新トピックを収集し、社長の文体でAIが下書き。確認・編集して公開します。</p></a>' +
+  '<a href="__BASE__/manual"><div class="ic">✍️</div><h3>手動作成</h3>' +
+  '<p>テキストと画像を自分で貼って記事を作成。ライブプレビューで確認して公開します。</p></a>' +
+  '</div></main>' +
+  tail('');

--- a/workers/yomimono/src/ui-manual.ts
+++ b/workers/yomimono/src/ui-manual.ts
@@ -1,0 +1,159 @@
+import { head, header, tail } from './ui-shared';
+
+// 手動作成ページ。Markdown を書き、画像はドラッグ&ドロップ/貼り付け/ボタンでアップロード。
+// 右側にライブプレビュー。公開は /api/validate → /api/publish（AI生成と同じ）。
+const BODY = `<main class="wide">
+  <p class="lead">テキストと画像で記事を作成します。画像は本文へドラッグ&ドロップ・貼り付け・「画像を追加」で挿入できます。書いたら「公開する」で cor-jp.com に公開（main マージ不要）。</p>
+  <div class="step">
+    <div class="row" style="gap:14px">
+      <div class="field" style="flex:1;min-width:220px;margin:0"><label>タイトル</label><input id="m_title" placeholder="記事のタイトル"></div>
+      <div class="field" style="width:160px;margin:0"><label>カテゴリ</label>
+        <select id="m_cat"><option value="ai">AI</option><option value="engineering">エンジニアリング</option><option value="founder">創業</option><option value="lab">ラボ</option></select>
+      </div>
+    </div>
+    <div class="row" style="gap:14px;margin-top:10px">
+      <div class="field" style="flex:1;min-width:220px;margin:0"><label>説明（カード・OGP用の1〜2文）</label><input id="m_desc" placeholder="一覧やSNSで表示される短い説明"></div>
+      <div class="field" style="width:240px;margin:0"><label>タグ（カンマ区切り）</label><input id="m_tags" placeholder="AI, 業務効率"></div>
+    </div>
+    <div class="field" style="margin-top:10px"><label>slug（URL・英小文字/数字/ハイフン）</label><input id="m_slug" placeholder="my-first-post"></div>
+  </div>
+
+  <div class="split">
+    <div class="step editor">
+      <div class="toolbar">
+        <strong style="font-size:13px;color:var(--navy)">本文（Markdown）</strong>
+        <button class="ghost" id="m_imgBtn" type="button">画像を追加</button>
+        <span class="meta" id="m_imgMsg"></span>
+        <input type="file" id="m_file" accept="image/*" multiple hidden>
+      </div>
+      <textarea id="m_body" class="drop" maxlength="100000" placeholder="## 見出し
+
+本文をここに。**太字**、[リンク](https://example.com)、- 箇条書き なども使えます。
+画像はここにドラッグ&ドロップ、または貼り付けできます。"></textarea>
+    </div>
+    <div class="step">
+      <div class="toolbar"><strong style="font-size:13px;color:var(--navy)">プレビュー</strong></div>
+      <div class="preview" id="m_prev"><p class="meta">ここに表示されます。</p></div>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="row">
+      <button class="pub" id="m_pub">公開する</button>
+      <button class="ghost" id="m_check" type="button">ガードレール再チェック</button>
+      <span class="meta" id="m_msg"></span>
+    </div>
+    <div id="m_result"></div>
+  </div>
+</main>`;
+
+const JS = `
+  // slug 既定値（post-YYYYMMDD-HHMM）。ユーザーは編集可。
+  (function(){ var d=new Date(), p=function(n){return (n<10?'0':'')+n;};
+    $('m_slug').value='post-'+d.getFullYear()+p(d.getMonth()+1)+p(d.getDate())+'-'+p(d.getHours())+p(d.getMinutes()); })();
+
+  // アップロード直後の画像はまだ本番にデプロイされていないため、
+  // プレビューでは data URL を使って即表示する（本文の markdown は /images/... のまま）。
+  var imgCache = {};
+
+  // --- 最小 Markdown レンダラ（esc + safeUrl で安全に） ---
+  function inline(t){
+    t = esc(t);
+    t = t.replace(/!\\[([^\\]]*)\\]\\(([^)\\s]+)\\)/g, function(m,alt,url){ var src = imgCache[url] ? imgCache[url] : esc(safeUrl(url)); return '<img src="'+src+'" alt="'+alt+'">'; });
+    t = t.replace(/\\[([^\\]]+)\\]\\(([^)\\s]+)\\)/g, function(m,tx,url){ return '<a href="'+esc(safeUrl(url))+'" target="_blank" rel="noopener">'+tx+'</a>'; });
+    t = t.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
+    t = t.replace(/(^|[^*])\\*([^*]+)\\*/g, '$1<em>$2</em>');
+    t = t.replace(/\`([^\`]+)\`/g, '<code>$1</code>');
+    return t;
+  }
+  function mdToHtml(md){
+    var lines = String(md||'').split(/\\r?\\n/);
+    var out = [], list = null;
+    function closeList(){ if(list){ out.push('</'+list+'>'); list=null; } }
+    for (var i=0;i<lines.length;i++){
+      var ln = lines[i];
+      var mh = ln.match(/^(#{1,3})\\s+(.*)$/);
+      var mu = ln.match(/^\\s*[-*]\\s+(.*)$/);
+      var mo = ln.match(/^\\s*\\d+\\.\\s+(.*)$/);
+      if (mh){ closeList(); var lvl=mh[1].length; out.push('<h'+lvl+'>'+inline(mh[2])+'</h'+lvl+'>'); }
+      else if (mu){ if(list!=='ul'){ closeList(); list='ul'; out.push('<ul>'); } out.push('<li>'+inline(mu[1])+'</li>'); }
+      else if (mo){ if(list!=='ol'){ closeList(); list='ol'; out.push('<ol>'); } out.push('<li>'+inline(mo[1])+'</li>'); }
+      else if (/^\\s*$/.test(ln)){ closeList(); }
+      else { closeList(); out.push('<p>'+inline(ln)+'</p>'); }
+    }
+    closeList();
+    return out.join('');
+  }
+  function updatePreview(){
+    var html = mdToHtml($('m_body').value);
+    $('m_prev').innerHTML = html || '<p class="meta">ここに表示されます。</p>';
+  }
+  $('m_body').addEventListener('input', updatePreview);
+
+  // --- 画像アップロード ---
+  function insertAtCursor(text){
+    var ta=$('m_body'), s=ta.selectionStart, e=ta.selectionEnd;
+    ta.value = ta.value.slice(0,s) + text + ta.value.slice(e);
+    ta.selectionStart = ta.selectionEnd = s + text.length;
+    ta.focus(); updatePreview();
+  }
+  function uploadFile(file){
+    if(!file || !/^image\\//.test(file.type||'')){ $('m_imgMsg').textContent='画像ファイルのみ対応です'; return; }
+    $('m_imgMsg').innerHTML='<span class="spin" style="border-color:#1b2c40;border-top-color:transparent"></span>アップロード中…';
+    var reader=new FileReader();
+    reader.onload=function(){
+      var dataUrl=String(reader.result||'');
+      var base64=dataUrl.split(',')[1]||'';
+      api('/api/upload-image', { filename:file.name||'image.png', dataBase64:base64 }).then(function(j){
+        imgCache[j.url]=dataUrl; // プレビュー即表示用
+        insertAtCursor('\\n![' + (file.name||'画像') + '](' + j.url + ')\\n');
+        $('m_imgMsg').textContent='挿入しました: '+j.url;
+      }).catch(function(e){ $('m_imgMsg').innerHTML='<span style="color:#dc2626">画像アップロード失敗: '+esc(e.message)+'</span>'; });
+    };
+    reader.readAsDataURL(file);
+  }
+  $('m_imgBtn').addEventListener('click', function(){ $('m_file').click(); });
+  $('m_file').addEventListener('change', function(){ for(var i=0;i<this.files.length;i++) uploadFile(this.files[i]); this.value=''; });
+
+  var ta=$('m_body');
+  ta.addEventListener('dragover', function(e){ e.preventDefault(); ta.classList.add('over'); });
+  ta.addEventListener('dragleave', function(){ ta.classList.remove('over'); });
+  ta.addEventListener('drop', function(e){ e.preventDefault(); ta.classList.remove('over'); var f=e.dataTransfer&&e.dataTransfer.files; if(f) for(var i=0;i<f.length;i++) uploadFile(f[i]); });
+  ta.addEventListener('paste', function(e){ var it=e.clipboardData&&e.clipboardData.items; if(!it) return; for(var i=0;i<it.length;i++){ if(it[i].type&&it[i].type.indexOf('image')===0){ var f=it[i].getAsFile(); if(f){ e.preventDefault(); uploadFile(f); } } } });
+
+  // --- 公開 / 再チェック ---
+  function gather(){
+    var tags = $('m_tags').value.split(',').map(function(s){ return s.trim(); }).filter(Boolean);
+    return { slug:$('m_slug').value.trim(), title:$('m_title').value.trim(), description:$('m_desc').value.trim(), category:$('m_cat').value, tags:tags, body:$('m_body').value };
+  }
+  function validateLocal(a){
+    if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'slug は英小文字・数字・ハイフン 3〜80字で入力してください';
+    if(!a.title) return 'タイトルを入力してください';
+    if(!a.description) return '説明を入力してください';
+    if(!a.body.trim()) return '本文を入力してください';
+    return '';
+  }
+  $('m_check').addEventListener('click', function(){
+    var a=gather(); var err=validateLocal(a);
+    if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
+    var btn=this; btn.disabled=true; $('m_msg').textContent='チェック中…';
+    api('/api/validate', { article:a }).then(function(j){
+      var v=j.violations||[];
+      if(v.length){ $('m_msg').innerHTML='<span style="color:#dc2626">違反 '+v.length+'件: '+esc(v.map(function(x){return x.name;}).join(', '))+'</span>'; }
+      else { $('m_msg').innerHTML='<span style="color:#16a34a">✓ 違反なし。公開できます</span>'; }
+      btn.disabled=false;
+    }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; });
+  });
+  $('m_pub').addEventListener('click', function(){
+    var a=gather(); var err=validateLocal(a);
+    if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
+    var btn=this; btn.disabled=true; btn.innerHTML='<span class="spin"></span>公開中…'; $('m_msg').textContent='';
+    api('/api/publish', { article:a }).then(function(j){
+      var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
+      $('m_result').innerHTML='<div class="done">✓ 公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
+      $('m_msg').textContent='';
+    }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.innerHTML='公開する'; });
+  });
+`;
+
+export const MANUAL_HTML = head('手動作成 — 読みもの 作成スタジオ') + header('manual') + BODY + tail(JS);

--- a/workers/yomimono/src/ui-manual.ts
+++ b/workers/yomimono/src/ui-manual.ts
@@ -95,7 +95,8 @@ const JS = `
     var html = mdToHtml($('m_body').value);
     $('m_prev').innerHTML = html || '<p class="meta">ここに表示されます。</p>';
   }
-  $('m_body').addEventListener('input', updatePreview);
+  var _pvTimer = null;
+  $('m_body').addEventListener('input', function(){ if(_pvTimer) clearTimeout(_pvTimer); _pvTimer=setTimeout(updatePreview, 120); });
 
   // --- 画像アップロード ---
   function insertAtCursor(text){

--- a/workers/yomimono/src/ui-manual.ts
+++ b/workers/yomimono/src/ui-manual.ts
@@ -68,10 +68,16 @@ const JS = `
   }
   function mdToHtml(md){
     var lines = String(md||'').split(/\\r?\\n/);
-    var out = [], list = null;
+    var out = [], list = null, inCode = false, codeBuf = [];
     function closeList(){ if(list){ out.push('</'+list+'>'); list=null; } }
     for (var i=0;i<lines.length;i++){
       var ln = lines[i];
+      if (/^\`\`\`/.test(ln)){
+        if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); inCode=false; codeBuf=[]; }
+        else { closeList(); inCode=true; }
+        continue;
+      }
+      if (inCode){ codeBuf.push(esc(ln)); continue; }
       var mh = ln.match(/^(#{1,3})\\s+(.*)$/);
       var mu = ln.match(/^\\s*[-*]\\s+(.*)$/);
       var mo = ln.match(/^\\s*\\d+\\.\\s+(.*)$/);
@@ -81,6 +87,7 @@ const JS = `
       else if (/^\\s*$/.test(ln)){ closeList(); }
       else { closeList(); out.push('<p>'+inline(ln)+'</p>'); }
     }
+    if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); } // 未閉じフェンスも描画
     closeList();
     return out.join('');
   }

--- a/workers/yomimono/src/ui-manual.ts
+++ b/workers/yomimono/src/ui-manual.ts
@@ -108,6 +108,7 @@ const JS = `
     if(!file || !/^image\\//.test(file.type||'')){ $('m_imgMsg').textContent='画像ファイルのみ対応です'; return; }
     $('m_imgMsg').innerHTML='<span class="spin" style="border-color:#1b2c40;border-top-color:transparent"></span>アップロード中…';
     var reader=new FileReader();
+    reader.onerror=function(){ $('m_imgMsg').innerHTML='<span style="color:#dc2626">画像の読み込みに失敗しました</span>'; };
     reader.onload=function(){
       var dataUrl=String(reader.result||'');
       var base64=dataUrl.split(',')[1]||'';
@@ -159,6 +160,7 @@ const JS = `
       var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
       $('m_result').innerHTML='<div class="done">✓ 公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
       $('m_msg').textContent='';
+      btn.disabled=false; btn.innerHTML='公開する'; // 成功後もボタンを復帰（別記事を続けて書けるように）
     }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.innerHTML='公開する'; });
   });
 `;

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -69,6 +69,8 @@ export const CSS = `
   .preview img { max-width:100%; border-radius:8px; margin:8px 0; }
   .preview p { margin:8px 0; }
   .preview code { background:#f1f5f9; padding:1px 5px; border-radius:4px; font-size:13px; }
+  .preview pre { background:#0f172a; color:#e2e8f0; padding:12px 14px; border-radius:8px; overflow:auto; font-size:13px; line-height:1.55; }
+  .preview pre code { background:none; color:inherit; padding:0; }
   .preview ul,.preview ol { padding-left:22px; }
   .preview a { color:var(--accent); }
   .toolbar { display:flex; gap:8px; align-items:center; margin-bottom:8px; flex-wrap:wrap; }
@@ -79,17 +81,21 @@ export const CSS = `
 export const COMMON_JS = `
 var BASE="__BASE__";
 var esc=function(s){return String(s==null?'':s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});};
-var safeUrl=function(u){u=String(u==null?'':u).trim();return (/^https?:\\/\\//i.test(u)||/^\\/[a-z0-9._~-]/i.test(u))?u:'#';};
+var safeUrl=function(u){u=String(u==null?'':u).trim();return (/^https?:\\/\\//i.test(u)||/^\\/[a-z0-9_~-]/i.test(u))?u:'#';};
 var $=function(id){return document.getElementById(id);};
 function api(p,b){return fetch(BASE+p,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(b||{})}).then(function(r){return r.json().then(function(j){if(!r.ok){throw new Error(j&&j.error?j.error:('HTTP '+r.status));}return j;});});}
 `;
+
+function escHtml(s: string): string {
+  return s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c] as string);
+}
 
 export function head(title: string): string {
   return (
     '<!doctype html><html lang="ja"><head><meta charset="utf-8" />' +
     '<meta name="viewport" content="width=device-width, initial-scale=1" />' +
     '<title>' +
-    title +
+    escHtml(title) +
     '</title><style>' +
     CSS +
     '</style></head><body>'

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -1,0 +1,115 @@
+// 管理画面 共通パーツ（CSS / ヘッダ・ナビ / 共通JS）。
+// Worker が __BASE__ を env.BASE_PATH に置換して配信する（ベースパス注入）。
+// 注: テンプレートリテラル内に ${ とバックティックを入れないこと。JSは文字列連結で書く。
+
+export const CSS = `
+  :root { --navy:#1b2c40; --navy2:#243a54; --ink:#1b2330; --muted:#64748b; --line:#e2e8f0; --bg:#f6f8fb; --ok:#16a34a; --warn:#dc2626; --accent:#2563eb; }
+  * { box-sizing:border-box; }
+  body { margin:0; font-family:'Hiragino Sans','Hiragino Kaku Gothic ProN',system-ui,sans-serif; color:var(--ink); background:var(--bg); line-height:1.7; }
+  header { background:var(--navy); color:#fff; padding:16px 24px; }
+  .hd { max-width:980px; margin:0 auto; display:flex; justify-content:space-between; align-items:center; gap:16px; flex-wrap:wrap; }
+  header h1 { margin:0; font-size:17px; letter-spacing:.04em; }
+  header p { margin:3px 0 0; font-size:11px; color:#aebfd4; }
+  .nav a { color:#aebfd4; text-decoration:none; font-size:13px; margin-left:16px; padding-bottom:2px; }
+  .nav a.on { color:#fff; border-bottom:2px solid #fff; }
+  .nav a:hover { color:#fff; }
+  main { max-width:860px; margin:0 auto; padding:24px 16px 80px; }
+  .wide { max-width:1100px; }
+  .lead { color:var(--muted); font-size:13px; margin:0 0 18px; }
+  .step { background:#fff; border:1px solid var(--line); border-radius:14px; padding:20px; margin-bottom:18px; box-shadow:0 1px 2px rgba(16,24,40,.04); }
+  .step h2 { margin:0 0 4px; font-size:15px; color:var(--navy); }
+  .step .hint { margin:0 0 14px; font-size:12px; color:var(--muted); }
+  .num { display:inline-flex; width:22px; height:22px; border-radius:50%; background:var(--navy); color:#fff; font-size:12px; align-items:center; justify-content:center; margin-right:8px; }
+  button { font:inherit; cursor:pointer; border:none; border-radius:10px; padding:11px 18px; font-weight:600; }
+  .primary { background:var(--navy); color:#fff; }
+  .primary:hover { background:var(--navy2); }
+  .primary:disabled { background:#9aa7b8; cursor:not-allowed; }
+  .ghost { background:#eef2f7; color:var(--ink); }
+  .pub { background:var(--ok); color:#fff; }
+  .pub:disabled { background:#bbb; cursor:not-allowed; }
+  .card { border:1px solid var(--line); border-radius:12px; padding:14px; margin:10px 0; }
+  .card.sel { border-color:var(--accent); background:#f0f6ff; }
+  .card label { display:flex; gap:10px; align-items:flex-start; cursor:pointer; }
+  .card .t { font-weight:700; font-size:14px; }
+  .card .s { font-size:13px; color:#374151; margin:4px 0; }
+  .card .src a { font-size:11px; color:var(--accent); margin-right:10px; word-break:break-all; }
+  .badge { display:inline-block; font-size:11px; background:#eef2f7; color:var(--muted); border-radius:20px; padding:2px 9px; margin-left:6px; }
+  .field { margin:10px 0; }
+  .field label { display:block; font-size:12px; color:var(--muted); margin-bottom:4px; }
+  .field input, .field textarea, .field select { width:100%; padding:9px 11px; border:1px solid var(--line); border-radius:8px; font:inherit; background:#fff; }
+  .field textarea { min-height:280px; resize:vertical; font-family:ui-monospace,Menlo,monospace; font-size:13px; line-height:1.6; }
+  .viol { background:#fff1f2; border:1px solid #fecaca; color:#991b1b; border-radius:8px; padding:10px 12px; font-size:12px; margin:8px 0; }
+  .viol b { display:block; margin-bottom:4px; }
+  .done { background:#f0fdf4; border:1px solid #bbf7d0; color:#166534; border-radius:8px; padding:10px 12px; font-size:13px; }
+  .done a { color:#166534; }
+  .err { background:#fff1f2; border:1px solid #fecaca; color:#991b1b; border-radius:8px; padding:10px 12px; font-size:13px; margin:8px 0; }
+  .spin { display:inline-block; width:15px; height:15px; border:2px solid #fff; border-top-color:transparent; border-radius:50%; animation:sp .8s linear infinite; vertical-align:-2px; margin-right:6px; }
+  @keyframes sp { to { transform:rotate(360deg); } }
+  .row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
+  .meta { font-size:12px; color:var(--muted); }
+  [hidden] { display:none; }
+  /* hub */
+  .hub { display:grid; gap:16px; grid-template-columns:1fr 1fr; }
+  .hub a { display:block; text-decoration:none; color:var(--ink); background:#fff; border:1px solid var(--line); border-radius:16px; padding:26px 22px; box-shadow:0 1px 2px rgba(16,24,40,.04); transition:transform .12s, box-shadow .12s, border-color .12s; }
+  .hub a:hover { transform:translateY(-2px); box-shadow:0 8px 24px rgba(16,24,40,.10); border-color:var(--accent); }
+  .hub .ic { font-size:30px; }
+  .hub h3 { margin:10px 0 6px; font-size:17px; color:var(--navy); }
+  .hub p { margin:0; font-size:13px; color:var(--muted); }
+  @media (max-width:680px){ .hub { grid-template-columns:1fr; } }
+  /* manual editor */
+  .split { display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+  @media (max-width:820px){ .split { grid-template-columns:1fr; } }
+  .editor textarea { min-height:440px; }
+  .drop { outline:2px dashed transparent; outline-offset:2px; }
+  .drop.over { outline-color:var(--accent); background:#f0f6ff; }
+  .preview { border:1px solid var(--line); border-radius:10px; padding:16px 18px; background:#fff; min-height:440px; overflow:auto; }
+  .preview h1,.preview h2,.preview h3 { color:var(--navy); line-height:1.35; }
+  .preview h2 { font-size:20px; margin:18px 0 8px; }
+  .preview h3 { font-size:16px; margin:14px 0 6px; }
+  .preview img { max-width:100%; border-radius:8px; margin:8px 0; }
+  .preview p { margin:8px 0; }
+  .preview code { background:#f1f5f9; padding:1px 5px; border-radius:4px; font-size:13px; }
+  .preview ul,.preview ol { padding-left:22px; }
+  .preview a { color:var(--accent); }
+  .toolbar { display:flex; gap:8px; align-items:center; margin-bottom:8px; flex-wrap:wrap; }
+`;
+
+// 共通JS（各ページIIFEの先頭で展開）。BASE はサーバが __BASE__ を注入。
+// safeUrl は http(s) に加え、ルート相対(/images/...)も許可（手動プレビューの画像用）。
+export const COMMON_JS = `
+var BASE="__BASE__";
+var esc=function(s){return String(s==null?'':s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];});};
+var safeUrl=function(u){u=String(u==null?'':u).trim();return (/^https?:\\/\\//i.test(u)||/^\\/[a-z0-9._~-]/i.test(u))?u:'#';};
+var $=function(id){return document.getElementById(id);};
+function api(p,b){return fetch(BASE+p,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(b||{})}).then(function(r){return r.json().then(function(j){if(!r.ok){throw new Error(j&&j.error?j.error:('HTTP '+r.status));}return j;});});}
+`;
+
+export function head(title: string): string {
+  return (
+    '<!doctype html><html lang="ja"><head><meta charset="utf-8" />' +
+    '<meta name="viewport" content="width=device-width, initial-scale=1" />' +
+    '<title>' +
+    title +
+    '</title><style>' +
+    CSS +
+    '</style></head><body>'
+  );
+}
+
+export function header(active: 'hub' | 'ai' | 'manual'): string {
+  const link = (href: string, label: string, key: string) =>
+    '<a href="__BASE__' + href + '"' + (active === key ? ' class="on"' : '') + '>' + label + '</a>';
+  return (
+    '<header><div class="hd"><div><h1>読みもの 作成スタジオ</h1><p>Cor. 記事CMS</p></div>' +
+    '<nav class="nav">' +
+    link('/', 'ハブ', 'hub') +
+    link('/ai', 'AI生成', 'ai') +
+    link('/manual', '手動作成', 'manual') +
+    '</nav></div></header>'
+  );
+}
+
+// ページ末尾。COMMON_JS + ページ個別JS を1つのIIFEで包む。
+export function tail(pageJs: string): string {
+  return '<script>(function(){' + COMMON_JS + pageJs + '})();</script></body></html>';
+}

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -29,6 +29,28 @@ export function sanitizeText(s: unknown, maxLen: number): string {
     .slice(0, maxLen);
 }
 
+export const IMAGE_EXT = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif'] as const;
+
+// アップロード画像のファイル名を安全な basename に正規化（パストラバーサル/拡張子偽装を防ぐ）。
+// 戻り値は `<stem>.<ext>` のみ（スラッシュ・連続ドット無し）。svg等は拒否。
+export function safeImageName(filename: unknown): string {
+  const raw = String(filename ?? '')
+    .toLowerCase()
+    .replace(/[\x00-\x1f\x7f]/g, '');
+  const ext = (raw.split('.').pop() || '').replace(/[^a-z0-9]/g, '');
+  if (!(IMAGE_EXT as readonly string[]).includes(ext)) {
+    throw new Error('対応していない画像形式です（png/jpg/jpeg/gif/webp/avif）');
+  }
+  const stem =
+    raw
+      .replace(/\.[^.]+$/, '')
+      .replace(/[^a-z0-9_-]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'image';
+  return stem + '.' + ext;
+}
+
 export interface ArticleInput {
   slug?: string;
   title?: string;


### PR DESCRIPTION
## 概要（社長要望）
AI生成とは別に**手動でも記事を作りたい**／**テキストと画像を自在に貼りたい**との要望を実装。ログイン（Cloudflare Access）後に**ハブ画面 → AI生成 / 手動作成 の2ページ**構成にしました。

## 画面構成
- `GET /brog` → **ハブ**（🤖AI生成 / ✍️手動作成 の2カード＋ナビ）
- `GET /brog/ai` → **AI生成**（既存ウィザード。情報収集→生成→公開）
- `GET /brog/manual` → **手動作成**（新規）

## 手動作成ページ（Notion的な自在さ）
- タイトル / カテゴリ / 説明 / タグ / slug（`post-YYYYMMDD-HHMM` を自動入力、編集可）
- **本文Markdown ＋ 右側ライブプレビュー**（見出し・太字・斜体・リンク・画像・箇条書き・コード）
- **画像**: 本文へ**ドラッグ&ドロップ / 貼り付け / 「画像を追加」**でアップロード → `![](url)` を挿入。公開前は **data URL で即プレビュー**（本文の markdown は `/images/...` のまま）
- 公開前に **ガードレール再チェック**、`公開する` で記事botが main へコミット

## 実装
- **UI分割**: `ui-shared`(CSS/ヘッダ・ナビ/共通JS, `__BASE__` をサーバ注入) + `ui-hub` + `ui-ai`(既存移設) + `ui-manual`(新規)。旧 `ui.ts` 削除。
- **画像API**: `POST /api/upload-image` → `commitImage()` が `public/images/blog/uploads/<ts>-<name>` へコミット。`safeImageName()` で拡張子allowlist（png/jpg/jpeg/gif/webp/avif、**svg等は拒否**）＋パストラバーサル防止。
- **ハードニング**: `firebase.json` の `/images/blog/uploads/**` に `nosniff`。`safeUrl` を制御文字拒否に厳格化。

## セキュリティ（code-reviewer + security-reviewer 両者 APPROVE：CRITICAL/HIGH/MEDIUM 0）
- 手動プレビューXSS: `esc()` を正規表現の**前**に適用、href/img は `safeUrl`（`javascript:`/`data:`/`//evil` を `#` に）。20+ の攻撃ペイロードで実証済み（両レビュアー）。
- 画像 stored XSS: svg拒否＋`image/*` 配信＋nosniff。`/api/upload-image` は Access 認証後。
- `{article}` 契約は手動も同一。slug ローカル検証はサーバ `SLUG_RE` と一致。

## 検証
- ✅ `tsc` clean / `vitest` **57 pass**（safeImageName のパストラバーサル境界テスト含む）/ `wrangler` バンドル成功
- ✅ **ブラウザ実機（`/brog/`）**で hub→ai→manual 遷移、手動エディタ（markdown描画／画像アップロード→data-urlプレビュー／公開）、AI生成の回帰、CSP互換、コンソール違反ゼロを確認

## フォローアップ（非ブロッカー・将来）
- 公開せず放置した画像が `uploads/` に残る → 量が増えたらGC
- 画像アップの commit レート制限（社内ユーザー限定のため低リスク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New repo writes for user-uploaded binaries and a client-side Markdown preview increase attack surface, though mitigated by Access auth, filename validation, CSP, and esc/safeUrl handling.
> 
> **Overview**
> Adds a **post-login hub** (`/`, `/ai`, `/manual`) so editors choose **AI wizard** vs **manual authoring**, replacing the single admin page. Shared chrome lives in `ui-shared` with server-injected `__BASE__` from `env.BASE_PATH` (sanitized before embed).
> 
> **Manual flow** provides metadata fields, split **Markdown editor + live preview** (drag/drop, paste, file picker), guardrail recheck, and publish via the same `/api/validate` and `/api/publish` paths as AI.
> 
> **Image uploads**: new `POST /api/upload-image` calls `commitImage()` to write `public/images/blog/uploads/<timestamp>-<safeName>` on the publish branch; `safeImageName()` allowlists raster extensions and blocks path tricks (tests added). Preview uses data URLs for not-yet-deployed assets; `safeUrl` also allows root-relative `/images/...`.
> 
> **Hosting**: `firebase.json` sets `X-Content-Type-Options: nosniff` on `/images/blog/uploads/**`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d87e7fd26a3465f44e72a6b9927a99d397e991b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->