### PR TITLE
fix(yomimono): AI生成の524タイムアウトをストリーミングで解消

### DIFF
--- a/workers/yomimono/src/anthropic.ts
+++ b/workers/yomimono/src/anthropic.ts
@@ -14,25 +14,29 @@ interface CallOptions {
 }
 
 // web_search はサーバーサイドツール。stop_reason: "pause_turn" が出たら継続再送する。
-// （scripts/generate-blog-draft.mjs と同じ手順を踏襲）
+// 重要: messages.stream() で逐次受信する。web検索は1回の応答が長くなりがちで、
+// Cloudflare Workers のサブリクエスト上限(~100s)を超えると 524 になるため、
+// ストリーミングで接続を保ち続ける。max_uses で検索回数も抑える。
 export async function callClaude(env: Env, opts: CallOptions): Promise<string> {
   const client = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
   const tools: Anthropic.ToolUnion[] | undefined = opts.useWebSearch
-    ? [{ type: 'web_search_20260209', name: 'web_search' }]
+    ? [{ type: 'web_search_20260209', name: 'web_search', max_uses: 5 }]
     : undefined;
 
   const messages: Anthropic.MessageParam[] = [{ role: 'user', content: opts.userText }];
 
   let response: Anthropic.Message | undefined;
   for (let i = 0; i < MAX_PAUSE_TURNS; i++) {
-    response = await client.messages.create({
-      model: opts.model ?? MODEL_HEAVY,
-      max_tokens: opts.maxTokens ?? 16000,
-      thinking: { type: 'adaptive' },
-      system: opts.system,
-      tools,
-      messages,
-    });
+    response = await client.messages
+      .stream({
+        model: opts.model ?? MODEL_HEAVY,
+        max_tokens: opts.maxTokens ?? 16000,
+        thinking: { type: 'adaptive' },
+        system: opts.system,
+        tools,
+        messages,
+      })
+      .finalMessage();
     if (response.stop_reason === 'pause_turn') {
       messages.push({ role: 'assistant', content: response.content });
       continue;

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -68,6 +68,60 @@ const json = (data: unknown, status = 200): Response =>
     headers: { 'content-type': 'application/json; charset=utf-8' },
   });
 
+// 長時間処理（AI＋web検索）向け。即座にヘッダを返し、処理中は空白を送り続けて
+// Cloudflare の 524（無応答100秒）を回避する。完了時に最終行として JSON を送る。
+// クライアントは本文の最終行を JSON.parse する（apiLong）。エラーも 200 のボディ内で返す。
+function friendlyError(e: unknown): string {
+  const m = e instanceof Error ? e.message : String(e);
+  if (/credit balance/i.test(m)) {
+    return 'Anthropic API のクレジット残高が不足しています（コンソールでチャージしてください）';
+  }
+  if (/\b524\b|timeout|timed out|ETIMEDOUT/i.test(m)) {
+    return 'AIの応答がタイムアウトしました。テーマを絞ってもう一度お試しください';
+  }
+  // callClaude / generate が投げる自前の日本語メッセージは安全なのでそのまま返す
+  if (/web_search|継続上限|JSON|拒否|refusal|必須|不正|空です/.test(m)) return m;
+  return '処理中にエラーが発生しました';
+}
+
+function streamJson(work: Promise<unknown>): Response {
+  const enc = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let done = false;
+      const hb = setInterval(() => {
+        if (!done) {
+          try {
+            controller.enqueue(enc.encode(' '));
+          } catch {
+            /* closed */
+          }
+        }
+      }, 5000);
+      const finish = (payload: unknown) => {
+        done = true;
+        clearInterval(hb);
+        try {
+          controller.enqueue(enc.encode('\n' + JSON.stringify(payload)));
+          controller.close();
+        } catch {
+          /* closed */
+        }
+      };
+      work.then(
+        (result) => finish(result),
+        (e) => {
+          console.error('yomimono error:', e instanceof Error ? e.message : String(e));
+          finish({ error: friendlyError(e) });
+        },
+      );
+    },
+  });
+  return new Response(stream, {
+    headers: { 'content-type': 'application/json; charset=utf-8', 'x-content-type-options': 'nosniff' },
+  });
+}
+
 // JSON ボディを解析。不正JSONは null（呼び出し側で400を返し、サイレント処理を避ける）。
 async function readJsonBody(req: Request): Promise<Record<string, unknown> | null> {
   try {
@@ -183,12 +237,13 @@ export default {
         return json(result);
       }
 
-      // ① 情報収集
+      // ① 情報収集（長時間化しうるため streamJson でハートビート送信＝524回避）
       if (req.method === 'POST' && path === '/api/collect') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
-        const candidates = await collectTopics(env, sanitizeTitles(body.recentTitles));
-        return json({ candidates });
+        return streamJson(
+          collectTopics(env, sanitizeTitles(body.recentTitles)).then((candidates) => ({ candidates })),
+        );
       }
 
       // ④ 記事生成（＋ガードレール検査結果を同梱して⑤レビューへ）
@@ -203,25 +258,27 @@ export default {
         };
         const title = sanitizeText(theme.title, 200);
         if (!title) return json({ error: 'theme.title は必須です' }, 400);
-        const octokit = makeOctokit(env);
-        const styleGuide = await getFileContent(env, octokit, env.STYLE_GUIDE_PATH);
-        const { article, markdown, violations } = await generateArticle(
-          env,
-          {
-            title,
-            summary: sanitizeText(theme.summary, 500),
-            sources: Array.isArray(theme.sources)
-              ? theme.sources
-                  .slice(0, 5)
-                  .map((s) => sanitizeText(s, 300))
-                  .filter((s) => /^https?:\/\//i.test(s)) // http(s) のみ（javascript: 等を排除）
-              : [],
-            freshnessHours: Number(theme.freshnessHours) || 0,
-          },
-          sanitizeTitles(body.recentTitles),
-          styleGuide,
+        const recentTitles = sanitizeTitles(body.recentTitles);
+        const sources = Array.isArray(theme.sources)
+          ? theme.sources
+              .slice(0, 5)
+              .map((s) => sanitizeText(s, 300))
+              .filter((s) => /^https?:\/\//i.test(s)) // http(s) のみ（javascript: 等を排除）
+          : [];
+        // 生成は最も長くかかるため streamJson でハートビート送信（524回避）
+        return streamJson(
+          (async () => {
+            const octokit = makeOctokit(env);
+            const styleGuide = await getFileContent(env, octokit, env.STYLE_GUIDE_PATH);
+            const { article, markdown, violations } = await generateArticle(
+              env,
+              { title, summary: sanitizeText(theme.summary, 500), sources, freshnessHours: Number(theme.freshnessHours) || 0 },
+              recentTitles,
+              styleGuide,
+            );
+            return { article, markdown, violations };
+          })(),
         );
-        return json({ article, markdown, violations });
       }
 
       // ⑤ レビュー: コミットせずガードレール検査のみ（編集後の再チェック用）

--- a/workers/yomimono/src/ui-ai.ts
+++ b/workers/yomimono/src/ui-ai.ts
@@ -42,7 +42,7 @@ const JS = `
   $('collectBtn').addEventListener('click', function(){
     var b = $('collectBtn'); b.disabled = true; b.innerHTML = '<span class="spin"></span>収集中…（30〜60秒）';
     $('collectErr').innerHTML = '';
-    api('/api/collect', { recentTitles: recentSlugs }).then(function(j){
+    apiLong('/api/collect', { recentTitles: recentSlugs }).then(function(j){
       renderCands(j.candidates || []);
       show('s2'); $('s2').scrollIntoView({behavior:'smooth'});
     }).catch(function(e){
@@ -92,7 +92,7 @@ const JS = `
       b.innerHTML = '<span class="spin"></span>生成中 ' + (i+1) + '/' + idx.length + '…';
       var slot = document.createElement('div'); slot.className='card'; slot.innerHTML='<div class="meta"><span class="spin" style="border-color:#1b2c40;border-top-color:transparent"></span>「'+esc(theme.title)+'」を生成中…</div>';
       $('arts').appendChild(slot);
-      api('/api/generate', { theme: theme, recentTitles: recentSlugs }).then(function(j){
+      apiLong('/api/generate', { theme: theme, recentTitles: recentSlugs }).then(function(j){
         renderArticle(slot, j.article, j.violations||[]);
       }).catch(function(e){
         slot.innerHTML = '<div class="err">生成に失敗しました（'+esc(theme.title)+'）: '+esc(e.message)+'</div>';

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -84,6 +84,8 @@ var esc=function(s){return String(s==null?'':s).replace(/[&<>"]/g,function(c){re
 var safeUrl=function(u){u=String(u==null?'':u).trim();return (/^https?:\\/\\//i.test(u)||/^\\/[a-z0-9_~-]/i.test(u))?u:'#';};
 var $=function(id){return document.getElementById(id);};
 function api(p,b){return fetch(BASE+p,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(b||{})}).then(function(r){return r.json().then(function(j){if(!r.ok){throw new Error(j&&j.error?j.error:('HTTP '+r.status));}return j;});});}
+// 長時間API（収集/生成）用: 本文は「空白ハートビート + 改行 + 最終JSON」。最終行をparse。
+function apiLong(p,b){return fetch(BASE+p,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(b||{})}).then(function(r){return r.text().then(function(t){var lines=String(t).split('\\n').filter(function(s){return s.trim();});var last=lines.length?lines[lines.length-1]:'';var j;try{j=JSON.parse(last);}catch(e){throw new Error('応答の解析に失敗しました（時間がかかりすぎた可能性）');}if(j&&j.error)throw new Error(j.error);return j;});});}
 `;
 
 function escHtml(s: string): string {


### PR DESCRIPTION
## 問題（本番ログで確定）
AI生成の「情報収集」が完了せず、ログに `POST /api/collect → 524 error code: 524`。**Cloudflare Workers のサブリクエスト上限(~100秒)を、Claude の web_search 呼び出しが超えてタイムアウト**していた（クレジットは正常）。手動作成はAI呼び出しが無いため無関係に動作。

## 修正（ストリーミング化）
1. **anthropic.ts**: `messages.create` → `messages.stream().finalMessage()`。SSEストリームで接続を保持し、web検索中も100秒の壁で切れない。`web_search` に `max_uses: 5`。
2. **index.ts**: `streamJson()` 追加 — 即ヘッダ返却 → 5秒ごとに空白ハートビート送信 → 完了時に最終行として JSON。Cloudflare の 524(無応答)を回避。エラーは200ボディ内 `{error}` で返す（`friendlyError` でクレジット不足/タイムアウト等を分かりやすい日本語に、未知は generic で内部情報を隠す）。`collect`/`generate` のみ streamJson 化（validate/publish 等はAI無しで従来 json）。
3. **ui-shared.ts**: `apiLong()` 追加（本文の最終行JSONをparse、`.error` で throw）。`ui-ai.ts` の collect/generate を apiLong に。

## 検証
- ✅ `tsc` clean / `vitest` 70 pass / `wrangler` バンドル成功
- ✅ **ブラウザ実機**（ストリーム形式=空白+改行+JSON のモック）で 収集→生成→公開 が `apiLong` で正常parse・コンソール違反ゼロ
- ⏳ 実際の `>100s` web検索での最終確認は **develop マージ→再デプロイ後にライブで実施**（code-reviewer 指摘のとおり、ストリーム非バッファリングは実機でのみ確認可能）

レビュー: code-reviewer **APPROVE**（CRITICAL/HIGH/MEDIUM 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> 認証済みの collect/generate の応答形式とエラー伝播が変わるが、validate/publish は従来の JSON のまま。実運用での 100 秒超の web 検索はデプロイ後の確認が前提。
> 
> **Overview**
> **Cloudflare 524**（約100秒無応答）で落ちていた AI の情報収集・記事生成を、サーバーとクライアント両方のストリーミングで長時間処理に耐えるように変更しています。
> 
> `callClaude` は `messages.create` から **`messages.stream().finalMessage()`** に切り替え、web 検索中も Anthropic 側の接続を維持します。`web_search` には **`max_uses: 5`** を付けて検索回数を抑えます。
> 
> Worker では **`streamJson`** を追加し、`/api/collect` と `/api/generate` は即レスポンス開始後、5秒ごとの空白ハートビートを送り、完了時に最終行だけ JSON を返します。失敗時は HTTP 200 の本文 **`{ error }`** と **`friendlyError`** で日本語メッセージを返します（クレジット不足・タイムアウト等）。管理 UI は共通の **`apiLong`** で最終行を `JSON.parse` し、収集・生成の fetch をそちらに差し替えています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8f811a15156da9a73f9cb3f2f7e2954fda9a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->