### PR TITLE
copy: Works ページを課題・設計・実装・運用軸へ更新（第2フェーズ）

### DIFF
--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -26,7 +26,7 @@ const t = getJaTranslations();
     <ul class="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {
         t.works.items.map((item) => {
-          const isNda = 'nda' in item && item.nda;
+          const isExternal = typeof item.href === 'string' && item.href.startsWith('http');
           const tag = (
             <span class="inline-flex w-fit rounded-full bg-primary-500/15 px-3 py-1 text-xs font-medium text-primary-950/70 dark:bg-primary-400/15 dark:text-primary-200/70">
               {item.tag}
@@ -38,17 +38,37 @@ const t = getJaTranslations();
                 {tag}
                 {!item.href && (
                   <span class="inline-flex w-fit rounded-full bg-primary-950/10 px-3 py-1 text-xs font-medium text-primary-950/50 dark:bg-primary-200/10 dark:text-primary-200/50">
-                    準備中
+                    {t.works.readyBadge}
                   </span>
                 )}
               </div>
-              <h2 class="text-lg font-medium tracking-tight">{item.name}</h2>
+              <h2 class="text-lg font-medium leading-snug tracking-tight">{item.title}</h2>
               <p class="text-base text-primary-950/70 dark:text-primary-200/70">
-                {item.description}
+                {item.oneLiner}
               </p>
-              {isNda && (
+              <dl class="mt-2 flex flex-col gap-2 text-sm">
+                <div class="flex flex-col gap-0.5">
+                  <dt class="font-medium text-primary-950/80 dark:text-primary-200/80">{t.works.detailLabels.problem}</dt>
+                  <dd class="text-primary-950/60 dark:text-primary-200/60">{item.detail.problem}</dd>
+                </div>
+                <div class="flex flex-col gap-0.5">
+                  <dt class="font-medium text-primary-950/80 dark:text-primary-200/80">{t.works.detailLabels.build}</dt>
+                  <dd class="text-primary-950/60 dark:text-primary-200/60">{item.detail.build}</dd>
+                </div>
+                <div class="flex flex-col gap-0.5">
+                  <dt class="font-medium text-primary-950/80 dark:text-primary-200/80">{t.works.detailLabels.ops}</dt>
+                  <dd class="text-primary-950/60 dark:text-primary-200/60">{item.detail.ops}</dd>
+                </div>
+              </dl>
+              {item.ndaNote && (
                 <p class="mt-auto text-xs text-primary-950/50 dark:text-primary-200/50">
-                  {t.works.ndaNote}
+                  {item.ndaNote}
+                </p>
+              )}
+              {item.href && (
+                <p class="mt-auto inline-flex items-center gap-1 text-sm font-medium text-primary-700 dark:text-primary-300">
+                  {item.ctaLabel}
+                  <span aria-hidden="true">→</span>
                 </p>
               )}
             </>
@@ -59,8 +79,8 @@ const t = getJaTranslations();
               <a
                 class="group relative flex h-full cursor-pointer flex-col gap-3 rounded-3xl bg-primary-500/10 p-6 shadow-sm transition duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:bg-primary-400/10 dark:focus-visible:ring-offset-primary-950"
                 href={item.href}
-                rel="noopener noreferrer"
-                target="_blank"
+                rel={isExternal ? 'noopener noreferrer' : undefined}
+                target={isExternal ? '_blank' : undefined}
               >
                 <span
                   aria-hidden="true"
@@ -93,8 +113,8 @@ const t = getJaTranslations();
   </div>
 
   <NextStep
-    heading="気になる実績がありましたか？"
-    lead="あなたの課題も、一緒に考えさせてください。"
-    ctas={[{ label: '課題から相談する', href: '/contact', primary: true }]}
+    heading={t.works.ctaHeading}
+    lead={t.works.ctaLead}
+    ctas={[{ label: t.works.ctaLabel, href: '/contact', primary: true }]}
   />
 </Layout>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -409,7 +409,7 @@ const translations = {
       "404": { title: "Not found · Cor.inc", description: "Page not found. Please check the URL in the address bar and try again." },
       privacy: { title: "個人情報保護方針 | Cor.inc", description: "Cor.株式会社の個人情報保護方針（プライバシーポリシー）。取得する個人情報と利用目的、第三者提供・委託、安全管理措置、開示等の請求、お問い合わせ窓口について。" },
       security: { title: "セキュリティ | Cor.inc", description: "Cor.株式会社の情報セキュリティ、ISMS取得に向けた体制、ローカルファーストと機密度ティアによるAI開発環境について。" },
-      works: { title: "実績 | Cor.inc", description: "Cor.株式会社の実績紹介。AI受託開発、基幹DB移行、多言語AI受付、建築AI、自社プロダクトGriftなど、領域の異なる実装実績を順次公開します。" },
+      works: { title: "実績 | Cor.inc", description: "Cor.株式会社の実績紹介。機密データAI・ローカルLLM・AI受託開発・基幹システム移行など、課題・設計・実装・運用の軸でご紹介します。" },
       industryMedical: { title: "医療・ヘルスケア向けAI伴走 | Cor.inc", description: "医療現場の課題——院内データ活用、患者対応、情報セキュリティ、AI活用方針、見積もりの整理——をCor.が一緒に進めます。AI受託開発・AI顧問・ローカルLLM・Griftで伴走。" },
       industryShigyo: { title: "士業向けAI伴走 | Cor.inc", description: "士業の課題——契約書精査、申請・登記、期日管理、補助金申請——をCor.が一緒に進めます。AI受託開発・AI顧問・ローカルLLM・Griftで伴走。" },
       industryConstruction: { title: "建設向けAI伴走 | Cor.inc", description: "建設現場の課題——労務管理、設計変更、安全確認、ノウハウ継承——をCor.が一緒に進めます。AI受託開発・AI顧問・ローカルLLM・Griftで伴走。" },
@@ -1001,19 +1001,96 @@ const translations = {
       }
     },
     works: {
-      title: "実装で語る、Cor.の実績。",
-      intro: "領域も立ち上げ方も異なる実装実績を掲載しています。自称ではなく、コード・運用・数字で示します。",
-      note: "※ 寄与率は git 実測のコミット比率です。機密案件はクライアント名・製品名を伏せ、内容を抽象化して掲載しています。",
+      title: "実装で語る、Cor.株式会社の実績。",
+      intro: "私たちがお客様と共に整理し、設計・実装し、運用へとつなげた業務課題の解決事例をご紹介します。「AIを使う前に、扱う情報を設計する」アプローチをご覧ください。",
+      note: "※機密保持の観点から、企業名・製品名・一部仕様を伏せ、課題・設計・実装・運用に焦点を当てて掲載しています。",
+      detailLabels: { problem: "課題", build: "設計・実装", ops: "運用" },
+      readyBadge: "記事準備中",
       moreLabel: "さらに実績を見る",
       moreHref: "/blog",
-      ndaNote: "※NDAのため一部内容を抽象化しています。",
+      ndaNote: "※NDAのため、企業名・製品名・一部仕様を抽象化して掲載しています。",
+      ctaHeading: "気になる実績がありましたか？",
+      ctaLead: "あなたの課題も、一緒に考えさせてください。",
+      ctaLabel: "AI開発・導入を相談する",
       items: [
-        { name: "Grift", tag: "自社プロダクト", description: "GitHub実績と市場相場から、説明できる参考見積もりを生成する自社AI見積・評価基盤。", href: "https://griftai.org" },
-        { name: "Engineer Cafe Navigator", tag: "OSS / 公開実績", description: "多言語音声AI受付のオープンソース。182,368行・8名貢献、自社寄与率87.7%（git実測）。", href: null },
-        { name: "マルチモーダル生成AI SaaS", tag: "AI受託開発", description: "画像・音声・テキストを扱う生成AI SaaSの本番開発（クライアント名は非公開）。", href: null },
-        { name: "アンケート基盤の刷新", tag: "AI受託開発", description: "引き継ぎ後のアンケート基盤を刷新・本番化。エージェント基盤移行、テスト・CI/CD整備まで対応。", href: null },
-        { name: "レガシー基幹システムのクラウド移行", tag: "セキュアAI開発", description: "教育系の基幹データベースをクラウドへ移行（詳細はNDAのため抽象化）。", href: null, nda: true },
-        { name: "建築図面・間取り生成AI", tag: "セキュアAI開発", description: "建築図面や間取りを扱うAI群を0→1で高速実装（建築系・NDAのため抽象化）。", href: null, nda: true }
+        {
+          tag: "自社プロダクト",
+          title: "見積根拠を会社資産にするAI見積支援ツール『Grift』",
+          oneLiner: "AIに見積もりを丸投げせず、人間が責任を持てる根拠を増やす検証中プロダクト。",
+          detail: {
+            problem: "受託開発における見積もりノウハウが属人化し、根拠がブラックボックス化しやすい。",
+            build: "過去のデータや前提条件をAIが整理し、人間が確認・修正しやすいUI/UXを設計・実装。",
+            ops: "担当者の頭の中にあったノウハウを会社の資産に変え、透明性のある見積もり運用を目指して Team Beta 検証中。"
+          },
+          ndaNote: null,
+          ctaLabel: "Griftについて聞く",
+          href: "https://griftai.org"
+        },
+        {
+          tag: "OSS公開実績",
+          title: "Engineer Cafe Navigator",
+          oneLiner: "施設情報をもとに、利用者からの質問に自然な対話で答えるAI案内システム。",
+          detail: {
+            problem: "施設に関する多様な質問への対応コストが高く、利用者が情報を探しにくい。",
+            build: "公開情報やFAQを整理し、適切な回答を生成するAIチャットボット基盤を設計・実装。",
+            ops: "オープンソースとして公開し、コミュニティ主導での継続的な改善・運用が可能な体制を目指した。"
+          },
+          ndaNote: null,
+          ctaLabel: "事例の詳細を見る",
+          href: null
+        },
+        {
+          tag: "AI基盤開発",
+          title: "画像・テキストを複合的に処理する生成AI SaaS基盤の開発",
+          oneLiner: "複数のAIモデルを組み合わせ、目的に応じたコンテンツ生成を自動化するSaaS基盤。",
+          detail: {
+            problem: "画像とテキストを組み合わせたコンテンツ制作に多大な人的コストがかかっている。",
+            build: "複数のマルチモーダルAIを統合し、要件に応じた出力を安定して生成するためのAPI連携基盤を設計。",
+            ops: "エンドユーザーが直感的に操作できるインターフェースを提供し、継続的な機能拡張が可能な運用体制を構築。"
+          },
+          ndaNote: "機密保持の観点から、特定につながる情報を伏せて掲載しています。",
+          ctaLabel: "事例の詳細を見る",
+          href: null
+        },
+        {
+          tag: "基幹システム刷新",
+          title: "大規模アンケート収集・分析基盤の刷新と運用設計",
+          oneLiner: "膨大な回答データを安全かつリアルタイムに処理・分析するためのシステム刷新。",
+          detail: {
+            problem: "既存システムのパフォーマンス低下と、データ分析までのタイムラグ・運用負荷の増大。",
+            build: "大量アクセスに耐えうる負荷分散と、セキュアなデータ保管ルールを設計・再実装。",
+            ops: "操作ログの取得や権限管理を整え、業務で運用する際の不安を減らすデータ管理体制へ移行。"
+          },
+          ndaNote: "NDAのため、企業名・製品名・一部仕様を抽象化して掲載しています。",
+          ctaLabel: "記事準備中",
+          href: null
+        },
+        {
+          tag: "基幹システム刷新",
+          title: "業務フローに寄り添う、レガシー基幹システムのクラウド移行",
+          oneLiner: "老朽化したオンプレミス環境から、運用を見据えたクラウド環境への移行支援。",
+          detail: {
+            problem: "既存の業務フローが複雑化しており、単なるクラウド移行では現場の混乱が予想された。",
+            build: "移行前に現場の業務課題を言語化・整理し、不要な機能を削ぎ落としたうえでクラウドアーキテクチャを設計・実装。",
+            ops: "運用時に確認すべき責任範囲を明確にし、現場が迷わず使える保守・運用フローを定着。"
+          },
+          ndaNote: "機密保持の観点から、特定につながる情報を伏せて掲載しています。",
+          ctaLabel: "記事準備中",
+          href: null
+        },
+        {
+          tag: "PoC / 0→1開発",
+          title: "建築図面および間取りの自動生成AIの実証実験",
+          oneLiner: "建築業界の専門知識とAIを掛け合わせ、設計初期段階の図面作成を支援する検証。",
+          detail: {
+            problem: "設計初期段階における間取り案の作成に時間がかかり、顧客提案のスピードが上がらない。",
+            build: "建築基準や特有の設計ルールをAIに扱わせるためのデータ整形ルールを定義し、プロトタイプを設計・実装。",
+            ops: "生成された図面を人間が最終確認するフローを策定し、実務への組み込み可否を判断。"
+          },
+          ndaNote: "NDAのため、企業名・製品名・一部仕様を抽象化して掲載しています。",
+          ctaLabel: "AI基盤PoCを相談する",
+          href: "/contact"
+        }
       ]
     },
     security: {


### PR DESCRIPTION
Part of #190 / Closes #195

Works / 実績ページを非エンジニアB2B顧客向けの「課題・設計・実装・運用」軸へ全面更新。

## 変更
- H1: 実装で語る、Cor.株式会社の実績。
- 実績カード6件を課題/設計・実装/運用breakdown構造へ再構築
- 旧訴求（18万行/87.7%/受託NDA）をjaから排除
- NDA注記を各カードに組み込み、クリック可/準備中カードUI区別
- 下部CTA: AI開発・導入を相談する

## 受け入れ条件
- [x] Works H1新文言
- [x] 6カード整理済み
- [x] 旧訴求排除（ja）
- [x] NDA注記・カードUI区別
- [x] npm run build 通過
- [x] en/zh/ko/es 既存値維持

Refs: #190 #195