### PR TITLE
fix(ui): 改行と整列の崩れを修正

### DIFF
--- a/.github/workflows/visual-text.yml
+++ b/.github/workflows/visual-text.yml
@@ -1,0 +1,55 @@
+name: Responsive visual text
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  visual_text:
+    name: Chromium visual text audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run responsive visual text audit
+        run: npm run verify:visual-text
+        env:
+          PUBLIC_GCAL_ID: ''
+          PUBLIC_GCAL_TZ: Asia/Tokyo
+          PUBLIC_GCAL_PARAMS: ''
+          PUBLIC_STRIPE_PAYMENT_LINK: ''
+          PUBLIC_YOUTUBE_API_KEY: ''
+
+      - name: Upload visual text artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-text-audit
+          path: |
+            test-results/visual-text/
+            playwright-report/visual-text/
+          if-no-files-found: ignore

--- a/e2e/visual-text.spec.ts
+++ b/e2e/visual-text.spec.ts
@@ -1,0 +1,627 @@
+import { test } from '@playwright/test';
+import { mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const VIEWPORTS = [
+  { name: 'mobile-390', width: 390, height: 844 },
+  { name: 'tablet-768', width: 768, height: 1024 },
+  { name: 'desktop-1440', width: 1440, height: 900 },
+] as const;
+
+const DIST_ROOT = path.resolve(process.cwd(), 'dist');
+const OUTPUT_ROOT = path.resolve(process.cwd(), 'test-results/visual-text');
+const SCREENSHOT_ROOT = path.join(OUTPUT_ROOT, 'screenshots');
+const EVIDENCE_SCREENSHOT_ROOT = path.join(OUTPUT_ROOT, 'evidence');
+
+const EVIDENCE_SCREENSHOT_ROUTES = new Set([
+  '/',
+  '/en',
+  '/zh',
+  '/ko',
+  '/es',
+  '/blog/ai-development-estimate-knowledge-asset',
+  '/privacy',
+  '/works',
+]);
+
+const FALLBACK_ROUTES = [
+  '/',
+  '/about',
+  '/works',
+  '/works/grift',
+  '/contact',
+  '/security',
+  '/privacy',
+  '/legal/tokushoho',
+  '/blog',
+  '/blog/ai-development-estimate-knowledge-asset',
+  '/industries/medical',
+  '/industries/shigyo',
+  '/industries/construction',
+  '/industries/manufacturing',
+  '/industries/education',
+  '/en',
+  '/en/about',
+  '/en/contact',
+  '/en/security',
+  '/en/privacy',
+  '/en/legal/tokushoho',
+  '/en/blog',
+  '/zh',
+  '/zh/about',
+  '/zh/contact',
+  '/zh/security',
+  '/zh/privacy',
+  '/zh/legal/tokushoho',
+  '/zh/blog',
+  '/ko',
+  '/ko/about',
+  '/ko/contact',
+  '/ko/security',
+  '/ko/privacy',
+  '/ko/legal/tokushoho',
+  '/ko/blog',
+  '/es',
+  '/es/about',
+  '/es/contact',
+  '/es/security',
+  '/es/privacy',
+  '/es/legal/tokushoho',
+  '/es/blog',
+];
+
+type AuditIssue = {
+  type: string;
+  selector?: string;
+  tagName?: string;
+  text?: string;
+  finalLine?: string;
+  lineTexts?: string[];
+  ratio?: number;
+  lastLineWidth?: number;
+  widestLineWidth?: number;
+  left?: number;
+  right?: number;
+  scrollWidth?: number;
+  clientWidth?: number;
+};
+
+type AuditObservation = {
+  route: string;
+  viewport: (typeof VIEWPORTS)[number]['name'];
+  url?: string;
+  status: number | null;
+  title: string;
+  scrollWidth: number | null;
+  clientWidth: number | null;
+  failures: AuditIssue[];
+  warnings: AuditIssue[];
+  screenshot?: string;
+  evidenceScreenshot?: string;
+};
+
+function collectHtmlFiles(directory: string): string[] {
+  try {
+    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return collectHtmlFiles(fullPath);
+      return entry.isFile() && entry.name.endsWith('.html') ? [fullPath] : [];
+    });
+  } catch {
+    return [];
+  }
+}
+
+function htmlFileToRoute(filePath: string): string | null {
+  const relativePath = path.relative(DIST_ROOT, filePath).split(path.sep).join('/');
+  if (!relativePath.endsWith('.html')) return null;
+  if (relativePath === 'index.html') return '/';
+  if (relativePath.endsWith('/index.html')) {
+    return `/${relativePath.slice(0, -'/index.html'.length)}`;
+  }
+  return `/${relativePath.slice(0, -'.html'.length)}`;
+}
+
+function shouldAuditRoute(route: string): boolean {
+  return !/^\/(?:styleguide|test-blog)(?:\/|$)/.test(route);
+}
+
+function discoverRoutes(): string[] {
+  const routes = collectHtmlFiles(DIST_ROOT)
+    .map(htmlFileToRoute)
+    .filter((route): route is string => Boolean(route))
+    .filter(shouldAuditRoute);
+
+  const discoveredRoutes = [...new Set(routes.length > 0 ? routes : FALLBACK_ROUTES)].sort((a, b) => {
+    if (a === '/') return -1;
+    if (b === '/') return 1;
+    return a.localeCompare(b);
+  });
+
+  const routeFilter = process.env.VISUAL_TEXT_ROUTES;
+  if (!routeFilter) return discoveredRoutes;
+
+  const allowedRoutes = new Set(
+    routeFilter
+      .split(',')
+      .map((route) => route.trim())
+      .filter(Boolean),
+  );
+
+  return discoveredRoutes.filter((route) => allowedRoutes.has(route));
+}
+
+function isExpectedNotFound(route: string): boolean {
+  return /^\/(?:(?:en|zh|ko|es)\/)?404$/.test(route);
+}
+
+function slugifyRoute(route: string): string {
+  return route.replace(/^\//, '').replace(/[^\w-]+/g, '_') || 'home';
+}
+
+function escapeMarkdown(value: string | undefined): string {
+  return (value ?? '').replace(/\s+/g, ' ').replace(/\|/g, '\\|').slice(0, 180);
+}
+
+function buildSummary(observations: AuditObservation[], routeCount: number): string {
+  const failures = observations.flatMap((observation) =>
+    observation.failures.map((issue) => ({ ...issue, route: observation.route, viewport: observation.viewport })),
+  );
+  const warnings = observations.flatMap((observation) =>
+    observation.warnings.map((issue) => ({ ...issue, route: observation.route, viewport: observation.viewport })),
+  );
+
+  const lines = [
+    '# Responsive visual text audit',
+    '',
+    `Generated: ${new Date().toISOString()}`,
+    `Routes: ${routeCount}`,
+    `Viewports: ${VIEWPORTS.map((viewport) => `${viewport.width}x${viewport.height}`).join(', ')}`,
+    `Observations: ${observations.length}`,
+    `Failures: ${failures.length}`,
+    `Warnings: ${warnings.length}`,
+    '',
+    '## Failures',
+    '',
+  ];
+
+  if (failures.length === 0) {
+    lines.push('No hard failures detected.', '');
+  } else {
+    lines.push('| Route | Viewport | Type | Text | Final line | Ratio |');
+    lines.push('| --- | --- | --- | --- | --- | --- |');
+    for (const failure of failures) {
+      lines.push(
+        `| ${failure.route} | ${failure.viewport} | ${failure.type} | ${escapeMarkdown(failure.text)} | ${escapeMarkdown(
+          failure.finalLine,
+        )} | ${failure.ratio ?? ''} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  lines.push('## Warnings');
+  lines.push('');
+
+  if (warnings.length === 0) {
+    lines.push('No advisory warnings detected.', '');
+  } else {
+    lines.push('| Route | Viewport | Type | Text | Lines |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const warning of warnings.slice(0, 200)) {
+      lines.push(
+        `| ${warning.route} | ${warning.viewport} | ${warning.type} | ${escapeMarkdown(warning.text)} | ${escapeMarkdown(
+          warning.lineTexts?.join(' / '),
+        )} |`,
+      );
+    }
+    if (warnings.length > 200) {
+      lines.push(`| ... | ... | ... | ${warnings.length - 200} additional warnings omitted from summary.md | ... |`);
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test('production pages do not have hard responsive text failures', async ({ page }) => {
+  const routes = discoverRoutes();
+  const observations: AuditObservation[] = [];
+
+  mkdirSync(SCREENSHOT_ROOT, { recursive: true });
+  mkdirSync(EVIDENCE_SCREENSHOT_ROOT, { recursive: true });
+  test.setTimeout(Math.max(180_000, routes.length * VIEWPORTS.length * 7_500));
+
+  for (const viewport of VIEWPORTS) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+
+    for (const route of routes) {
+      const response = await page.goto(route, { waitUntil: 'load', timeout: 60_000 });
+      await page.addStyleTag({
+        content: `
+          *, *::before, *::after {
+            animation-duration: 0s !important;
+            animation-delay: 0s !important;
+            transition-duration: 0s !important;
+            transition-delay: 0s !important;
+            scroll-behavior: auto !important;
+          }
+          html.js [data-reveal] {
+            opacity: 1 !important;
+            transform: none !important;
+          }
+        `,
+      });
+      await page.evaluate(async () => {
+        await (document as Document & { fonts?: FontFaceSet }).fonts?.ready;
+      });
+      await page.waitForTimeout(150);
+
+      const status = response?.status() ?? null;
+      const result = await page.evaluate(() => {
+        type LineFragment = {
+          text: string;
+          top: number;
+          bottom: number;
+          left: number;
+          right: number;
+        };
+        type MeasuredLine = {
+          text: string;
+          top: number;
+          bottom: number;
+          left: number;
+          right: number;
+          width: number;
+        };
+        type TargetIssue = AuditIssue;
+
+        const failures: TargetIssue[] = [];
+        const warnings: TargetIssue[] = [];
+        const clientWidth = document.documentElement.clientWidth;
+        const scrollWidth = Math.max(document.documentElement.scrollWidth, document.body?.scrollWidth ?? 0);
+        const overflowAmount = scrollWidth - clientWidth;
+
+        if (overflowAmount > 2) {
+          failures.push({
+            type: 'page-horizontal-overflow',
+            scrollWidth,
+            clientWidth,
+          });
+        }
+
+        const segmenter =
+          typeof (Intl as unknown as { Segmenter?: unknown }).Segmenter === 'function'
+            ? new ((Intl as unknown as { Segmenter: new (_locale: string, options: { granularity: string }) => { segment: (value: string) => Iterable<{ segment: string }> } }).Segmenter)(
+                document.documentElement.lang || navigator.language || 'ja',
+                { granularity: 'grapheme' },
+              )
+            : null;
+
+        function getGraphemes(value: string): string[] {
+          if (segmenter) return [...segmenter.segment(value)].map((item) => item.segment);
+          return Array.from(value);
+        }
+
+        function getLabel(element: Element): string {
+          const id = element.id ? `#${element.id}` : '';
+          const classes = Array.from(element.classList)
+            .slice(0, 3)
+            .map((className) => `.${className}`)
+            .join('');
+          return `${element.tagName.toLowerCase()}${id}${classes}`;
+        }
+
+        function isElementVisible(element: Element): boolean {
+          if (element.closest('[data-visual-ignore-linecheck], [hidden], [aria-hidden="true"]')) return false;
+          const style = window.getComputedStyle(element);
+          if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) return false;
+          const rect = element.getBoundingClientRect();
+          if (rect.width <= 0 || rect.height <= 0) return false;
+          return Boolean((element as HTMLElement).innerText?.trim() || element.textContent?.trim());
+        }
+
+        function isHiddenTextNode(node: Node): boolean {
+          const parent = node.parentElement;
+          if (!parent) return true;
+          if (parent.closest('[hidden], [aria-hidden="true"], .sr-only, script, style, template, svg')) return true;
+          const style = window.getComputedStyle(parent);
+          return style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0;
+        }
+
+        function clipsTextOverflow(element: Element): boolean {
+          const style = window.getComputedStyle(element);
+          const lineClamp = style.getPropertyValue('-webkit-line-clamp');
+          const hasLineClampClass = Array.from(element.classList).some((className) => className.startsWith('line-clamp-'));
+          return (
+            style.overflowX !== 'visible' ||
+            style.overflowY !== 'visible' ||
+            hasLineClampClass ||
+            (lineClamp !== '' && lineClamp !== 'none')
+          );
+        }
+
+        function isFragmentVisibleInClips(node: Node, rect: DOMRect, rootElement: Element): boolean {
+          let current = node.parentElement;
+
+          while (current) {
+            if (clipsTextOverflow(current)) {
+              const clipRect = current.getBoundingClientRect();
+              const intersectsClip =
+                rect.bottom > clipRect.top + 0.5 &&
+                rect.top < clipRect.bottom - 0.5 &&
+                rect.right >= clipRect.left - 2 &&
+                rect.left <= clipRect.right + 2;
+              if (!intersectsClip) return false;
+            }
+
+            if (current === rootElement) break;
+            current = current.parentElement;
+          }
+
+          return true;
+        }
+
+        function measureLines(element: Element): MeasuredLine[] {
+          const fragments: LineFragment[] = [];
+          const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+          let node = walker.nextNode();
+
+          while (node) {
+            if (!isHiddenTextNode(node)) {
+              const text = node.textContent ?? '';
+              let offset = 0;
+
+              for (const grapheme of getGraphemes(text)) {
+                const nextOffset = offset + grapheme.length;
+                const range = document.createRange();
+                range.setStart(node, offset);
+                range.setEnd(node, nextOffset);
+                const rect = range.getBoundingClientRect();
+                range.detach();
+
+                if (rect.width > 0 && rect.height > 0 && isFragmentVisibleInClips(node, rect, element)) {
+                  fragments.push({
+                    text: grapheme,
+                    top: rect.top,
+                    bottom: rect.bottom,
+                    left: rect.left,
+                    right: rect.right,
+                  });
+                }
+
+                offset = nextOffset;
+              }
+            }
+
+            node = walker.nextNode();
+          }
+
+          const sortedFragments = fragments.sort((a, b) => {
+            if (Math.abs(a.top - b.top) > 3) return a.top - b.top;
+            return a.left - b.left;
+          });
+
+          const lines: MeasuredLine[] = [];
+
+          for (const fragment of sortedFragments) {
+            let line = lines.find((candidate) => Math.abs(candidate.top - fragment.top) <= 3);
+            if (!line) {
+              line = {
+                text: '',
+                top: fragment.top,
+                bottom: fragment.bottom,
+                left: fragment.left,
+                right: fragment.right,
+                width: fragment.right - fragment.left,
+              };
+              lines.push(line);
+            }
+
+            line.text += fragment.text;
+            line.top = Math.min(line.top, fragment.top);
+            line.bottom = Math.max(line.bottom, fragment.bottom);
+            line.left = Math.min(line.left, fragment.left);
+            line.right = Math.max(line.right, fragment.right);
+            line.width = line.right - line.left;
+          }
+
+          return lines
+            .map((line) => ({
+              ...line,
+              text: line.text.replace(/\s+/g, ' ').trim(),
+              width: Math.max(0, line.right - line.left),
+            }))
+            .filter((line) => line.text.length > 0 && line.width > 0);
+        }
+
+        function isInsideHorizontalScrollContainer(element: Element): boolean {
+          let current = element.parentElement;
+          while (current && current !== document.documentElement) {
+            const style = window.getComputedStyle(current);
+            const canScroll = ['auto', 'scroll'].includes(style.overflowX);
+            if (canScroll && current.scrollWidth > current.clientWidth + 2) return true;
+            current = current.parentElement;
+          }
+          return false;
+        }
+
+        function getTerminalOrphanIssue(
+          element: Element,
+          lines: MeasuredLine[],
+          selector: string,
+          text: string,
+        ): TargetIssue | null {
+          if (lines.length < 2) return null;
+
+          const widestLineWidth = Math.max(...lines.map((line) => line.width));
+          const lastLine = lines[lines.length - 1];
+          const ratio = widestLineWidth > 0 ? lastLine.width / widestLineWidth : 1;
+
+          if (ratio >= 0.18) return null;
+
+          const finalLine = lastLine.text.trim();
+          const contentCharacters =
+            finalLine.match(/[\p{Letter}\p{Number}\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu) ?? [];
+          const cjkCharacters =
+            finalLine.match(/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/gu) ?? [];
+          const latinCharacters = finalLine.match(/[A-Za-z0-9]/g) ?? [];
+          const visibleCharacters = getGraphemes(finalLine.replace(/\s+/g, ''));
+          const isPunctuationOnly = contentCharacters.length === 0 && visibleCharacters.length <= 4;
+          const hasTerminalPunctuation = /[、。，．！？!?）)\]」』]$/.test(finalLine);
+          const isShortCjk =
+            cjkCharacters.length > 0 && (contentCharacters.length <= 1 || (contentCharacters.length <= 2 && hasTerminalPunctuation));
+          const isShortLatin =
+            cjkCharacters.length === 0 &&
+            latinCharacters.length > 0 &&
+            latinCharacters.length <= 2 &&
+            /[)\]]$/.test(finalLine);
+
+          if (!isPunctuationOnly && !isShortCjk && !isShortLatin) return null;
+
+          return {
+            type: 'terminal-orphan-fragment',
+            selector,
+            tagName: element.tagName.toLowerCase(),
+            text,
+            finalLine,
+            lineTexts: lines.map((line) => line.text),
+            ratio: Number(ratio.toFixed(3)),
+            lastLineWidth: Number(lastLine.width.toFixed(2)),
+            widestLineWidth: Number(widestLineWidth.toFixed(2)),
+          };
+        }
+
+        const targets = Array.from(document.querySelectorAll('h1,h2,h3,a[href],button,[role="button"]')).filter((element) => {
+          if (!isElementVisible(element)) return false;
+          if (element.tagName.toLowerCase() === 'a' && element.closest('h1,h2,h3')) return false;
+          return true;
+        });
+
+        for (const element of targets) {
+          const selector = getLabel(element);
+          const text = ((element as HTMLElement).innerText || element.textContent || '').replace(/\s+/g, ' ').trim();
+          const lines = measureLines(element);
+          const lineTexts = lines.map((line) => line.text);
+          if (lines.length === 0) continue;
+
+          const tagName = element.tagName.toLowerCase();
+          const isHeading = ['h1', 'h2', 'h3'].includes(tagName);
+          const isControl = element.matches('a[href],button,[role="button"]');
+
+          if (!isInsideHorizontalScrollContainer(element)) {
+            const outOfViewportLine = lines.find((line) => line.left < -2 || line.right > clientWidth + 2);
+            if (outOfViewportLine) {
+              failures.push({
+                type: 'text-horizontal-viewport-escape',
+                selector,
+                tagName,
+                text,
+                lineTexts,
+                left: Number(outOfViewportLine.left.toFixed(2)),
+                right: Number(outOfViewportLine.right.toFixed(2)),
+                clientWidth,
+              });
+            }
+          }
+
+          const orphanIssue = getTerminalOrphanIssue(element, lines, selector, text);
+          if (orphanIssue) failures.push(orphanIssue);
+
+          if (isHeading && lines.length >= 3) {
+            warnings.push({
+              type: 'heading-3plus-lines',
+              selector,
+              tagName,
+              text,
+              lineTexts,
+            });
+          }
+
+          if (isHeading && lines.length >= 2 && window.getComputedStyle(element).textAlign === 'center') {
+            warnings.push({
+              type: 'centered-multiline-heading',
+              selector,
+              tagName,
+              text,
+              lineTexts,
+            });
+          }
+
+          if (isControl && lines.length >= 2) {
+            warnings.push({
+              type: 'control-text-wraps',
+              selector,
+              tagName,
+              text,
+              lineTexts,
+            });
+          }
+        }
+
+        return {
+          title: document.title,
+          scrollWidth,
+          clientWidth,
+          failures,
+          warnings,
+        };
+      });
+
+      const failures = [...result.failures];
+      if (status !== null && status >= 400 && !isExpectedNotFound(route)) {
+        failures.unshift({ type: 'unexpected-http-status', text: String(status) });
+      }
+
+      const observation: AuditObservation = {
+        route,
+        viewport: viewport.name,
+        url: page.url(),
+        status,
+        title: result.title,
+        scrollWidth: result.scrollWidth,
+        clientWidth: result.clientWidth,
+        failures,
+        warnings: result.warnings,
+      };
+
+      if (failures.length > 0) {
+        const screenshotPath = path.join(SCREENSHOT_ROOT, `${viewport.name}_${slugifyRoute(route)}.png`);
+        await page.screenshot({ path: screenshotPath, fullPage: true });
+        observation.screenshot = screenshotPath;
+      }
+
+      if (EVIDENCE_SCREENSHOT_ROUTES.has(route)) {
+        const evidencePath = path.join(EVIDENCE_SCREENSHOT_ROOT, `${viewport.name}_${slugifyRoute(route)}.png`);
+        await page.screenshot({ path: evidencePath, fullPage: true });
+        observation.evidenceScreenshot = evidencePath;
+      }
+
+      observations.push(observation);
+    }
+  }
+
+  mkdirSync(OUTPUT_ROOT, { recursive: true });
+  writeFileSync(
+    path.join(OUTPUT_ROOT, 'audit.json'),
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4322',
+        routes,
+        viewports: VIEWPORTS,
+        observations,
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(path.join(OUTPUT_ROOT, 'summary.md'), buildSummary(observations, routes.length));
+
+  const failureCount = observations.reduce((count, observation) => count + observation.failures.length, 0);
+  if (failureCount > 0) {
+    throw new Error(`Responsive visual text audit failed with ${failureCount} hard failure(s). See test-results/visual-text/summary.md.`);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "./node_modules/.bin/astro dev",
     "build": "./node_modules/.bin/astro check && ./node_modules/.bin/astro build",
     "preview": "./node_modules/.bin/astro preview",
+    "preview:ci": "./node_modules/.bin/astro preview --host 127.0.0.1 --port 4322",
     "astro": "./node_modules/.bin/astro",
     "translate": "node scripts/translate-blog.js",
     "translate:all": "node scripts/translate-all-blog.js",
@@ -17,7 +18,9 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "test:visual-text": "playwright test --config=playwright.visual.config.ts",
+    "verify:visual-text": "npm run build && npm run test:visual-text"
   },
   "dependencies": {
     "@alpinejs/collapse": "3.12.3",

--- a/playwright.visual.config.ts
+++ b/playwright.visual.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4322';
+const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: /visual-text\.spec\.ts/,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  workers: 1,
+  retries: 0,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report/visual-text', open: 'never' }],
+    ['json', { outputFile: 'test-results/visual-text/playwright.json' }],
+  ],
+  use: {
+    baseURL,
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    launchOptions: executablePath ? { executablePath } : undefined,
+  },
+  projects: [
+    {
+      name: 'chromium-text',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run preview:ci',
+        url: baseURL,
+        reuseExistingServer: false,
+        timeout: 120_000,
+      },
+});

--- a/src/components/about/AboutHero.astro
+++ b/src/components/about/AboutHero.astro
@@ -8,8 +8,8 @@ const t = getTranslations(getCurrentLocale(Astro.url));
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="flex max-w-3xl flex-col gap-6">
       <p class="text-sm font-medium uppercase tracking-wide text-primary-600 dark:text-primary-400">{t.aboutPage.kicker}</p>
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl" set:html={emphasizeKyousou(t.aboutPage.title)} />
-      <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl lg:text-5xl" set:html={emphasizeKyousou(t.aboutPage.title)} />
+      <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70">
         {t.aboutPage.lead}
       </p>
     </div>

--- a/src/components/about/FounderNote.astro
+++ b/src/components/about/FounderNote.astro
@@ -8,19 +8,19 @@ const t = getTranslations(getCurrentLocale(Astro.url));
 <section id="founder-story" class="py-16 sm:py-20">
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="flex max-w-3xl flex-col gap-6">
-      <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+      <h2 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl">
         {t.aboutPage.founderTitle}
       </h2>
-      <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+      <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70">
         {t.aboutPage.founderLead}
       </p>
     </div>
 
     <div class="mt-12 flex max-w-4xl flex-col gap-6">
-      <h3 class="text-2xl font-medium tracking-tight sm:text-3xl">
+      <h3 class="type-heading text-2xl font-medium tracking-tight sm:text-3xl">
         {t.aboutPage.founderYoutubeTitle}
       </h3>
-      <p class="text-base text-primary-950/70 dark:text-primary-200/70">
+      <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">
         {t.aboutPage.founderYoutubeDescription}
       </p>
       <RandomPlayer messages={t.aboutPage.founderYoutubeMessages} />

--- a/src/components/about/KyousouDefinition.astro
+++ b/src/components/about/KyousouDefinition.astro
@@ -8,20 +8,20 @@ const t = getTranslations(getCurrentLocale(Astro.url));
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="flex flex-col gap-10 sm:gap-12">
       <div class="max-w-3xl">
-        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl" set:html={emphasizeKyousou(t.aboutPage.kyousouTitle)} />
-        <p class="mt-4 text-lg text-primary-950/70 dark:text-primary-200/70">{t.aboutPage.kyousouLead}</p>
+        <h2 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl" set:html={emphasizeKyousou(t.aboutPage.kyousouTitle)} />
+        <p class="type-copy mt-4 text-lg text-primary-950/70 dark:text-primary-200/70">{t.aboutPage.kyousouLead}</p>
       </div>
       <ul class="grid grid-cols-1 items-stretch gap-6 sm:grid-cols-2 lg:grid-cols-5">
         {
           t.aboutPage.kyousou.map((item) => (
             <li class="flex h-full flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
-              <h3 class="text-2xl font-medium tracking-tight">{item.word}</h3>
-              <p class="text-base text-primary-950/70 dark:text-primary-200/70">{item.usage}</p>
+              <h3 class="type-heading text-2xl font-medium tracking-tight">{item.word}</h3>
+              <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">{item.usage}</p>
             </li>
           ))
         }
       </ul>
-      <p class="max-w-3xl rounded-3xl bg-primary-600/10 p-6 text-xl font-medium tracking-tight text-primary-700 dark:bg-primary-400/10 dark:text-primary-300 sm:text-2xl" set:html={emphasizeKyousou(t.aboutPage.kyousouAxis)} />
+      <p class="type-heading max-w-3xl rounded-3xl bg-primary-600/10 p-6 text-xl font-medium tracking-tight text-primary-700 dark:bg-primary-400/10 dark:text-primary-300 sm:text-2xl" set:html={emphasizeKyousou(t.aboutPage.kyousouAxis)} />
     </div>
   </div>
 </section>

--- a/src/components/about/MvvSection.astro
+++ b/src/components/about/MvvSection.astro
@@ -10,7 +10,7 @@ const t = getTranslations(getCurrentLocale(Astro.url));
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="flex flex-col gap-10 sm:gap-12">
       <div class="max-w-3xl">
-        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+        <h2 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl">
           {t.aboutPage.mvvTitle}
         </h2>
       </div>
@@ -19,21 +19,21 @@ const t = getTranslations(getCurrentLocale(Astro.url));
           <h3 class="text-sm font-medium uppercase tracking-wide text-primary-600 dark:text-primary-400">
             Mission
           </h3>
-          <p class="text-lg text-primary-950/80 dark:text-primary-200/80" set:html={emphasizeKyousou(t.aboutPage.mission)}></p>
+          <p class="type-copy text-lg text-primary-950/80 dark:text-primary-200/80" set:html={emphasizeKyousou(t.aboutPage.mission)}></p>
         </div>
         <div class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
           <h3 class="text-sm font-medium uppercase tracking-wide text-primary-600 dark:text-primary-400">
             Vision
           </h3>
-          <p class="text-lg text-primary-950/80 dark:text-primary-200/80">{t.aboutPage.vision}</p>
+          <p class="type-copy text-lg text-primary-950/80 dark:text-primary-200/80">{t.aboutPage.vision}</p>
         </div>
       </div>
       <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {
           t.aboutPage.values.map((value) => (
             <li class="flex flex-col gap-2 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
-              <h3 class="text-xl font-medium tracking-tight">{value.title}</h3>
-              <p class="text-base text-primary-950/70 dark:text-primary-200/70">{value.description}</p>
+              <h3 class="type-heading text-xl font-medium tracking-tight">{value.title}</h3>
+              <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">{value.description}</p>
             </li>
           ))
         }

--- a/src/components/about/TeamIntro.astro
+++ b/src/components/about/TeamIntro.astro
@@ -7,10 +7,10 @@ const t = getTranslations(getCurrentLocale(Astro.url));
 <section class="py-16 sm:py-20">
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="max-w-3xl">
-      <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+      <h2 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl">
         {t.aboutPage.teamTitle}
       </h2>
-      <p class="mt-4 text-lg text-primary-950/70 dark:text-primary-200/70">
+      <p class="type-copy mt-4 text-lg text-primary-950/70 dark:text-primary-200/70">
         {t.aboutPage.teamBody}
       </p>
     </div>

--- a/src/components/about/WhyFocus.astro
+++ b/src/components/about/WhyFocus.astro
@@ -7,10 +7,10 @@ const t = getTranslations(getCurrentLocale(Astro.url));
 <section class="py-16 sm:py-20">
   <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="max-w-3xl">
-      <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+      <h2 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl">
         {t.aboutPage.whyFocusTitle}
       </h2>
-      <p class="mt-4 text-lg text-primary-950/70 dark:text-primary-200/70">
+      <p class="type-copy mt-4 text-lg text-primary-950/70 dark:text-primary-200/70">
         {t.aboutPage.whyFocusBody}
       </p>
     </div>

--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -35,7 +35,7 @@ const cleanSlug = post.slug.replace(/^[a-z]{2}\/|^[a-z]{2}-[A-Z]{2}\//, '');
 const postUrl = currentLocale === 'ja' ? `/blog/${cleanSlug}` : `/${currentLocale}/blog/${cleanSlug}`;
 ---
 
-<article class="group relative flex h-80 flex-col rounded-2xl bg-white shadow-sm transition-all duration-300 hover:shadow-lg dark:bg-stone-800">
+<article class="group relative flex h-full min-h-80 flex-col overflow-hidden rounded-2xl bg-white shadow-sm transition-all duration-300 hover:shadow-lg dark:bg-stone-800">
   <a href={postUrl} class="absolute inset-0 z-10" aria-label={title}>
     <span class="sr-only">{
       currentLocale === 'ja' ? '記事を読む' :
@@ -59,25 +59,25 @@ const postUrl = currentLocale === 'ja' ? `/blog/${cleanSlug}` : `/${currentLocal
   )}
   
   <div class="flex flex-1 flex-col p-6">
-    <div class="mb-3 flex items-center gap-2 text-sm">
+    <div class="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
       <CategoryBadge category={category} />
-      <time datetime={new Date(pubDate).toISOString()} class="text-stone-500 dark:text-stone-400">
+      <time datetime={new Date(pubDate).toISOString()} class="shrink-0 text-stone-500 dark:text-stone-400">
         {formattedDate}
       </time>
     </div>
     
-    <h3 class="mb-2 line-clamp-2 text-lg font-semibold text-stone-900 transition-colors group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+    <h3 class="mb-2 line-clamp-2 text-balance text-lg font-semibold leading-snug text-stone-900 transition-colors group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
       {title}
     </h3>
     
-    <p class="mb-4 line-clamp-3 flex-1 text-sm text-stone-600 dark:text-stone-300">
+    <p class="mb-4 line-clamp-3 flex-1 text-pretty text-sm leading-6 text-stone-600 dark:text-stone-300">
       {description}
     </p>
     
     {tags.length > 0 && (
-      <div class="mt-auto flex flex-wrap gap-1">
+      <div class="mt-auto flex flex-wrap items-center gap-1.5 pt-2">
         {tags.slice(0, 2).map(tag => (
-          <span class="rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 dark:bg-stone-700 dark:text-stone-300">
+          <span class="max-w-full rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 dark:bg-stone-700 dark:text-stone-300">
             #{tag}
           </span>
         ))}

--- a/src/components/blog/TableOfContents.astro
+++ b/src/components/blog/TableOfContents.astro
@@ -11,7 +11,13 @@ interface Props {
 
 const { headings } = Astro.props;
 const currentLocale = getCurrentLocale(Astro.url);
-const tocTitle = currentLocale === 'ja' ? '目次' : 'Table of Contents';
+const tocTitle = {
+  ja: '目次',
+  zh: '目录',
+  ko: '목차',
+  es: 'Tabla de contenidos',
+  en: 'Table of Contents',
+}[currentLocale] ?? 'Table of Contents';
 
 // h2 以上の見出しを対象に TOC を生成
 const tocHeadings = headings.filter(heading => heading.depth >= 2);
@@ -19,19 +25,17 @@ const tocHeadings = headings.filter(heading => heading.depth >= 2);
 
 {tocHeadings.length > 0 && (
   <nav class="rounded-lg border border-stone-200 bg-stone-50 p-4 dark:border-stone-700 dark:bg-stone-800" aria-label={tocTitle}>
-    <h2 class="mb-3 text-lg font-semibold text-stone-900 dark:text-stone-100">{tocTitle}</h2>
+    <h2 class="mb-3 text-balance text-lg font-semibold text-stone-900 dark:text-stone-100">{tocTitle}</h2>
     <ul class="space-y-2 text-sm">
       {tocHeadings.map(heading => {
-        // 深さに応じたインデントクラス (h3 以降を段階的に右寄せ)
-        const indentClasses = ['', 'ml-4', 'ml-8', 'ml-12', 'ml-16'];
+        // Keep indentation shallow so long headings still have room on mobile.
+        const indentClasses = ['', 'pl-3', 'pl-5', 'pl-7', 'pl-9'];
         const indentClass = heading.depth >= 3 ? indentClasses[Math.min(heading.depth - 2, indentClasses.length - 1)] : '';
         return (
-          <li
-            class={indentClass}
-          >
+          <li class={indentClass}>
             <a
               href={`#${heading.slug}`}
-              class="text-stone-600 transition-colors hover:text-blue-600 dark:text-stone-400 dark:hover:text-blue-400"
+              class="block break-words text-pretty leading-relaxed text-stone-600 transition-colors hover:text-blue-600 dark:text-stone-400 dark:hover:text-blue-400"
             >
               {heading.text}
             </a>

--- a/src/components/common/NextStep.astro
+++ b/src/components/common/NextStep.astro
@@ -21,9 +21,9 @@ const { heading, lead, ctas } = Astro.props;
       class="flex flex-col items-center gap-8 rounded-3xl bg-primary-500/10 px-6 py-12 text-center dark:bg-primary-400/10 sm:px-12 sm:py-16"
     >
       <div class="flex max-w-2xl flex-col gap-4">
-        <h2 class="text-2xl font-medium tracking-tight sm:text-3xl">{heading}</h2>
+        <h2 class="text-balance text-2xl font-medium tracking-tight sm:text-3xl">{heading}</h2>
         {lead && (
-          <p class="text-lg text-primary-950/70 dark:text-primary-200/70">{lead}</p>
+          <p class="text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70">{lead}</p>
         )}
       </div>
       <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
@@ -34,7 +34,7 @@ const { heading, lead, ctas } = Astro.props;
                 href={cta.href}
                 target={cta.isExternal ? '_blank' : undefined}
                 rel={cta.isExternal ? 'noopener noreferrer' : undefined}
-                class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+                class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-5 py-3 text-center text-base font-medium text-white transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b] sm:w-auto"
               >
                 {cta.label}
               </a>
@@ -43,7 +43,7 @@ const { heading, lead, ctas } = Astro.props;
                 href={cta.href}
                 target={cta.isExternal ? '_blank' : undefined}
                 rel={cta.isExternal ? 'noopener noreferrer' : undefined}
-                class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+                class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-center text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10 sm:w-auto"
               >
                 {cta.label}
               </a>

--- a/src/components/contact/Heading.astro
+++ b/src/components/contact/Heading.astro
@@ -6,12 +6,12 @@ const t = getTranslations(currentLocale);
 ---
 
 <section class="py-16 sm:py-20">
-  <div class="mx-auto max-w-2xl px-4 text-center sm:px-6 lg:max-w-7xl lg:px-8">
+  <div class="mx-auto max-w-2xl px-4 text-left sm:px-6 lg:max-w-7xl lg:px-8">
     <div class="flex flex-col gap-4 sm:gap-6">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
+      <h1 class="max-w-3xl text-balance text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
         {t.contact?.heading?.title ?? 'お問い合わせ'}
       </h1>
-      <p class="mx-auto max-w-xl text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
+      <p class="max-w-2xl text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
         {t.contact?.heading?.description ?? 'ご質問・ご相談・お見積もり依頼など、お気軽にご連絡ください。'}
       </p>
     </div>

--- a/src/components/home/ChallengeGrid.astro
+++ b/src/components/home/ChallengeGrid.astro
@@ -16,7 +16,7 @@ const griftUrl = 'https://griftai.org';
         >
           {t.homeChallenges.eyebrow}
         </p>
-        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+        <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
           {t.homeChallenges.title}
         </h2>
       </div>
@@ -28,27 +28,27 @@ const griftUrl = 'https://griftai.org';
               data-reveal
               style={`--reveal-delay:${(0.1 + i * 0.08).toFixed(2)}s`}
             >
-              <h3 class="text-lg font-medium tracking-tight">{item.title}</h3>
-              <p class="text-center text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
+              <h3 class="text-balance text-lg font-medium tracking-tight">{item.title}</h3>
+              <p class="text-pretty text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
                 {item.description}
               </p>
             </li>
           ))
         }
       </ul>
-      <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-start" data-reveal style="--reveal-delay:0.6s">
+      <div class="flex flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-start" data-reveal style="--reveal-delay:0.6s">
         {/* 主役=Grift体験(外部)を大きく塗りつぶしネイビーで、脇役=相談は控えめに（凪沙さん #71）。 */}
         <a
           href={griftUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+          class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-6 py-4 text-center text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b] sm:w-auto sm:px-8"
         >
           {t.homeChallenges.ctaPrimary}
         </a>
         <a
           href={getLocalizedUrl('/contact', currentLocale)}
-          class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+          class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-center text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10 sm:w-auto"
         >
           {t.homeChallenges.ctaSecondary}
         </a>

--- a/src/components/home/IndustryTable.astro
+++ b/src/components/home/IndustryTable.astro
@@ -14,10 +14,10 @@ const t = getTranslations(currentLocale);
         >
           {t.homeIndustries.eyebrow}
         </p>
-        <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+        <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
           {t.homeIndustries.title}
         </h2>
-        <p class="text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70">
+        <p class="text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70">
           {t.homeIndustries.description}
         </p>
       </div>
@@ -47,9 +47,10 @@ const t = getTranslations(currentLocale);
                     {row.link && row.linkLabel ? (
                       <a
                         href={getLocalizedUrl(row.link, currentLocale)}
-                        class="inline-flex items-center gap-1 font-medium text-[#2d4a6b] underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b] dark:text-[#7ba3cc]"
+                        class="inline-flex items-center gap-1.5 font-medium text-[#2d4a6b] underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b] dark:text-[#7ba3cc]"
                       >
                         {row.linkLabel}
+                        <span aria-hidden="true">→</span>
                       </a>
                     ) : (
                       <span class="text-primary-950/40 dark:text-primary-200/40">—</span>

--- a/src/components/home/ProblemHero.astro
+++ b/src/components/home/ProblemHero.astro
@@ -28,24 +28,24 @@ const griftUrl = 'https://griftai.org';
       <div class="flex max-w-5xl flex-col items-center gap-6 sm:gap-8">
         {/* 巨大タイポ＝「視覚で止まる」主役。即描画(LCP死守)のため演出は付けない。 */}
         <h1
-          class="font-semibold leading-[1.05] tracking-tight text-[clamp(2.25rem,8vw,6.5rem)]"
+          class="text-balance font-semibold leading-[1.05] tracking-tight text-[clamp(2.15rem,7vw,5.75rem)]"
           set:html={t.homeHero.title}
         />
-        <p class="max-w-3xl text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl" set:html={t.homeHero.subtitle} data-reveal style="--reveal-delay:0.15s"></p>
+        <p class="max-w-3xl text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl" set:html={t.homeHero.subtitle} data-reveal style="--reveal-delay:0.15s"></p>
       </div>
-      <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center" data-reveal style="--reveal-delay:0.3s">
+      <div class="flex w-full flex-col items-center gap-4 sm:w-auto sm:flex-row sm:justify-center" data-reveal style="--reveal-delay:0.3s">
         {/* パターンA(凪沙さん #64): 主役=Grift体験を大きく塗りつぶしで、脇役=相談はテキストリンクで。最初の一歩を1つに絞る。 */}
         <a
           href={griftUrl}
           target="_blank"
           rel="noopener noreferrer"
-          class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-8 py-4 text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b]"
+          class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-transparent bg-[#2d4a6b] px-6 py-4 text-center text-lg font-semibold text-white shadow-sm transition hover:bg-[#1e3350] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#2d4a6b] sm:w-auto sm:px-8"
         >
           {t.homeHero.primaryCta}
         </a>
         <a
           href={getLocalizedUrl('/contact', currentLocale)}
-          class="inline-flex min-h-[48px] items-center justify-center rounded-full px-5 py-3 text-base font-medium text-primary-950 underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200"
+          class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full px-5 py-3 text-center text-base font-medium text-primary-950 underline-offset-4 transition hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200 sm:w-auto"
         >
           {t.homeHero.secondaryCta}
         </a>
@@ -63,7 +63,7 @@ const griftUrl = 'https://griftai.org';
       }
       {/* ファーストビュー直下の補助文（#175）: 事業内容を一文で補足する控えめなライン。 */}
       <p
-        class="max-w-3xl text-sm leading-relaxed text-primary-950/60 dark:text-primary-200/60 sm:text-base"
+        class="max-w-3xl text-pretty text-sm leading-relaxed text-primary-950/60 dark:text-primary-200/60 sm:text-base"
         data-reveal
         style="--reveal-delay:0.55s"
       >

--- a/src/components/home/ProofHighlights.astro
+++ b/src/components/home/ProofHighlights.astro
@@ -18,10 +18,10 @@ const cardStep = 0.12;
         >
           {t.proof.eyebrow}
         </p>
-        <h2 class="text-4xl font-semibold tracking-tight sm:text-5xl">
+        <h2 class="text-balance text-4xl font-semibold tracking-tight sm:text-5xl">
           {t.proof.title}
         </h2>
-        <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+        <p class="text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70">
           {t.proof.description}
         </p>
       </div>
@@ -45,8 +45,8 @@ const cardStep = 0.12;
         style={`--reveal-delay:${(cardBaseDelay + t.proof.stats.length * cardStep).toFixed(2)}s`}
       >
         <a
-          href={getLocalizedUrl('/works', currentLocale)}
-          class="inline-flex items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+          href={getLocalizedUrl('/contact', currentLocale)}
+          class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-center text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10 sm:w-auto"
         >
           {t.proof.cta}
         </a>

--- a/src/components/industry/ConstructionBody.astro
+++ b/src/components/industry/ConstructionBody.astro
@@ -12,7 +12,7 @@ const griftUrl = 'https://griftai.org';
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">
     <div class="motion-bg" aria-hidden="true"></div>
     <div class="relative z-10 mx-auto w-full max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
-      <div class="flex flex-col items-center gap-8 text-center sm:gap-10">
+      <div class="flex flex-col items-start gap-8 text-left sm:gap-10">
         <p
           class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
           data-reveal
@@ -20,16 +20,16 @@ const griftUrl = 'https://griftai.org';
         >
           {page.hero.eyebrow}
         </p>
-        <div class="flex max-w-4xl flex-col items-center gap-6 sm:gap-8">
+        <div class="flex max-w-4xl flex-col items-start gap-6 sm:gap-8">
           <h1
-            class="text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
+            class="text-balance text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
             data-reveal
             style="--reveal-delay:0.1s"
           >
             {page.hero.title}
           </h1>
           <p
-            class="max-w-3xl text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
+            class="max-w-3xl text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
             data-reveal
             style="--reveal-delay:0.2s"
           >
@@ -50,7 +50,7 @@ const griftUrl = 'https://griftai.org';
           >
             {page.challenges.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.challenges.title}
           </h2>
         </div>
@@ -82,13 +82,13 @@ const griftUrl = 'https://griftai.org';
                     </svg>
                   </span>
                   <div class="flex flex-col gap-4">
-                    <h3 class="text-lg font-medium tracking-tight">{item.title}</h3>
+                    <h3 class="text-balance text-lg font-medium tracking-tight">{item.title}</h3>
                     <div class="flex flex-col gap-3">
                       <div>
                         <p class="mb-1 text-sm font-medium text-stone-700 dark:text-stone-300">
                           {page.challenges.labels.reality}
                         </p>
-                        <p class="text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
+                        <p class="text-pretty text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
                           {item.reality}
                         </p>
                       </div>
@@ -96,7 +96,7 @@ const griftUrl = 'https://griftai.org';
                         <p class="mb-1 text-sm font-medium text-stone-700 dark:text-stone-300">
                           {page.challenges.labels.risk}
                         </p>
-                        <p class="text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
+                        <p class="text-pretty text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
                           {item.risk}
                         </p>
                       </div>
@@ -119,10 +119,10 @@ const griftUrl = 'https://griftai.org';
           <p class="text-sm font-medium uppercase tracking-widest text-[#7ba3cc]">
             {page.support.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight text-white sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight text-white sm:text-4xl">
             {page.support.title}
           </h2>
-          <p class="text-lg leading-relaxed text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.support.intro}
           </p>
         </div>
@@ -157,10 +157,10 @@ const griftUrl = 'https://griftai.org';
                     <span class="inline-flex w-fit rounded-full bg-[#2d4a6b] px-3 py-1 text-xs font-medium text-white">
                       {item.service}
                     </span>
-                    <h3 class="text-lg font-medium tracking-tight text-primary-950">
+                    <h3 class="text-balance text-lg font-medium tracking-tight text-primary-950">
                       {item.title}
                     </h3>
-                    <p class="text-base leading-relaxed text-primary-950/70">
+                    <p class="text-pretty text-base leading-relaxed text-primary-950/70">
                       {item.description}
                     </p>
                   </div>
@@ -181,30 +181,30 @@ const griftUrl = 'https://griftai.org';
         data-reveal
       >
         <div class="flex max-w-2xl flex-col gap-4">
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.cta.title}
           </h2>
-          <p class="text-lg text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.cta.description}
           </p>
         </div>
-        <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <div class="flex w-full flex-col items-center gap-4 sm:w-auto sm:flex-row sm:justify-center">
           <a
             href={griftUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-white px-8 py-4 text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-transparent bg-white px-6 py-4 text-center text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto sm:px-8"
           >
             {page.cta.primary}
           </a>
           <a
             href={getLocalizedUrl('/contact', currentLocale)}
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-white/30 px-5 py-3 text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-white/30 px-5 py-3 text-center text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto"
           >
             {page.cta.secondary}
           </a>
         </div>
-        <p class="max-w-xl text-sm text-white/70">
+        <p class="max-w-xl text-pretty text-sm leading-relaxed text-white/70">
           {page.cta.note}
         </p>
       </div>

--- a/src/components/industry/EducationBody.astro
+++ b/src/components/industry/EducationBody.astro
@@ -12,7 +12,7 @@ const griftUrl = 'https://griftai.org';
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">
     <div class="motion-bg" aria-hidden="true"></div>
     <div class="relative z-10 mx-auto w-full max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
-      <div class="flex flex-col items-center gap-8 text-center sm:gap-10">
+      <div class="flex flex-col items-start gap-8 text-left sm:gap-10">
         <p
           class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
           data-reveal
@@ -20,16 +20,16 @@ const griftUrl = 'https://griftai.org';
         >
           {page.hero.eyebrow}
         </p>
-        <div class="flex max-w-4xl flex-col items-center gap-6 sm:gap-8">
+        <div class="flex max-w-4xl flex-col items-start gap-6 sm:gap-8">
           <h1
-            class="text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
+            class="text-balance text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
             data-reveal
             style="--reveal-delay:0.1s"
           >
             {page.hero.title}
           </h1>
           <p
-            class="max-w-3xl text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
+            class="max-w-3xl text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
             data-reveal
             style="--reveal-delay:0.2s"
           >
@@ -50,7 +50,7 @@ const griftUrl = 'https://griftai.org';
           >
             {page.challenges.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.challenges.title}
           </h2>
         </div>
@@ -82,8 +82,8 @@ const griftUrl = 'https://griftai.org';
                     </svg>
                   </span>
                   <div class="flex flex-col gap-3">
-                    <h3 class="text-lg font-medium tracking-tight">{item.title}</h3>
-                    <p class="text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
+                    <h3 class="text-balance text-lg font-medium tracking-tight">{item.title}</h3>
+                    <p class="text-pretty text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
                       {item.description}
                     </p>
                   </div>
@@ -104,10 +104,10 @@ const griftUrl = 'https://griftai.org';
           <p class="text-sm font-medium uppercase tracking-widest text-[#7ba3cc]">
             {page.support.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight text-white sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight text-white sm:text-4xl">
             {page.support.title}
           </h2>
-          <p class="text-lg leading-relaxed text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.support.intro}
           </p>
         </div>
@@ -142,10 +142,10 @@ const griftUrl = 'https://griftai.org';
                     <span class="inline-flex w-fit rounded-full bg-[#2d4a6b] px-3 py-1 text-xs font-medium text-white">
                       {item.service}
                     </span>
-                    <h3 class="text-lg font-medium tracking-tight text-primary-950">
+                    <h3 class="text-balance text-lg font-medium tracking-tight text-primary-950">
                       {item.title}
                     </h3>
-                    <p class="text-base leading-relaxed text-primary-950/70">
+                    <p class="text-pretty text-base leading-relaxed text-primary-950/70">
                       {item.description}
                     </p>
                   </div>
@@ -166,30 +166,30 @@ const griftUrl = 'https://griftai.org';
         data-reveal
       >
         <div class="flex max-w-2xl flex-col gap-4">
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.cta.title}
           </h2>
-          <p class="text-lg text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.cta.description}
           </p>
         </div>
-        <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <div class="flex w-full flex-col items-center gap-4 sm:w-auto sm:flex-row sm:justify-center">
           <a
             href={griftUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-white px-8 py-4 text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-transparent bg-white px-6 py-4 text-center text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto sm:px-8"
           >
             {page.cta.primary}
           </a>
           <a
             href={getLocalizedUrl('/contact', currentLocale)}
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-white/30 px-5 py-3 text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-white/30 px-5 py-3 text-center text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto"
           >
             {page.cta.secondary}
           </a>
         </div>
-        <p class="max-w-xl text-sm text-white/70">
+        <p class="max-w-xl text-pretty text-sm leading-relaxed text-white/70">
           {page.cta.note}
         </p>
       </div>

--- a/src/components/industry/ManufacturingBody.astro
+++ b/src/components/industry/ManufacturingBody.astro
@@ -12,7 +12,7 @@ const griftUrl = 'https://griftai.org';
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">
     <div class="motion-bg" aria-hidden="true"></div>
     <div class="relative z-10 mx-auto w-full max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
-      <div class="flex flex-col items-center gap-8 text-center sm:gap-10">
+      <div class="flex flex-col items-start gap-8 text-left sm:gap-10">
         <p
           class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
           data-reveal
@@ -20,16 +20,16 @@ const griftUrl = 'https://griftai.org';
         >
           {page.hero.eyebrow}
         </p>
-        <div class="flex max-w-4xl flex-col items-center gap-6 sm:gap-8">
+        <div class="flex max-w-4xl flex-col items-start gap-6 sm:gap-8">
           <h1
-            class="text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
+            class="text-balance text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
             data-reveal
             style="--reveal-delay:0.1s"
           >
             {page.hero.title}
           </h1>
           <p
-            class="max-w-3xl text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
+            class="max-w-3xl text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
             data-reveal
             style="--reveal-delay:0.2s"
           >
@@ -50,7 +50,7 @@ const griftUrl = 'https://griftai.org';
           >
             {page.challenges.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.challenges.title}
           </h2>
         </div>
@@ -82,8 +82,8 @@ const griftUrl = 'https://griftai.org';
                     </svg>
                   </span>
                   <div class="flex flex-col gap-3">
-                    <h3 class="text-lg font-medium tracking-tight">{item.title}</h3>
-                    <p class="text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
+                    <h3 class="text-balance text-lg font-medium tracking-tight">{item.title}</h3>
+                    <p class="text-pretty text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
                       {item.description}
                     </p>
                   </div>
@@ -104,10 +104,10 @@ const griftUrl = 'https://griftai.org';
           <p class="text-sm font-medium uppercase tracking-widest text-[#7ba3cc]">
             {page.support.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight text-white sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight text-white sm:text-4xl">
             {page.support.title}
           </h2>
-          <p class="text-lg leading-relaxed text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.support.intro}
           </p>
         </div>
@@ -142,10 +142,10 @@ const griftUrl = 'https://griftai.org';
                     <span class="inline-flex w-fit rounded-full bg-[#2d4a6b] px-3 py-1 text-xs font-medium text-white">
                       {item.service}
                     </span>
-                    <h3 class="text-lg font-medium tracking-tight text-primary-950">
+                    <h3 class="text-balance text-lg font-medium tracking-tight text-primary-950">
                       {item.title}
                     </h3>
-                    <p class="text-base leading-relaxed text-primary-950/70">
+                    <p class="text-pretty text-base leading-relaxed text-primary-950/70">
                       {item.description}
                     </p>
                   </div>
@@ -166,30 +166,30 @@ const griftUrl = 'https://griftai.org';
         data-reveal
       >
         <div class="flex max-w-2xl flex-col gap-4">
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.cta.title}
           </h2>
-          <p class="text-lg text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.cta.description}
           </p>
         </div>
-        <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <div class="flex w-full flex-col items-center gap-4 sm:w-auto sm:flex-row sm:justify-center">
           <a
             href={griftUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-white px-8 py-4 text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-transparent bg-white px-6 py-4 text-center text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto sm:px-8"
           >
             {page.cta.primary}
           </a>
           <a
             href={getLocalizedUrl('/contact', currentLocale)}
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-white/30 px-5 py-3 text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-white/30 px-5 py-3 text-center text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto"
           >
             {page.cta.secondary}
           </a>
         </div>
-        <p class="max-w-xl text-sm text-white/70">
+        <p class="max-w-xl text-pretty text-sm leading-relaxed text-white/70">
           {page.cta.note}
         </p>
       </div>

--- a/src/components/industry/MedicalBody.astro
+++ b/src/components/industry/MedicalBody.astro
@@ -12,7 +12,7 @@ const griftUrl = 'https://griftai.org';
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">
     <div class="motion-bg" aria-hidden="true"></div>
     <div class="relative z-10 mx-auto w-full max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
-      <div class="flex flex-col items-center gap-8 text-center sm:gap-10">
+      <div class="flex flex-col items-start gap-8 text-left sm:gap-10">
         <p
           class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
           data-reveal
@@ -20,16 +20,16 @@ const griftUrl = 'https://griftai.org';
         >
           {page.hero.eyebrow}
         </p>
-        <div class="flex max-w-4xl flex-col items-center gap-6 sm:gap-8">
+        <div class="flex max-w-4xl flex-col items-start gap-6 sm:gap-8">
           <h1
-            class="text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
+            class="text-balance text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
             data-reveal
             style="--reveal-delay:0.1s"
           >
             {page.hero.title}
           </h1>
           <p
-            class="max-w-3xl text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
+            class="max-w-3xl text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
             data-reveal
             style="--reveal-delay:0.2s"
           >
@@ -50,7 +50,7 @@ const griftUrl = 'https://griftai.org';
           >
             {page.challenges.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.challenges.title}
           </h2>
         </div>
@@ -62,8 +62,8 @@ const griftUrl = 'https://griftai.org';
                 data-reveal
                 style={`--reveal-delay:${(0.1 + i * 0.08).toFixed(2)}s`}
               >
-                <h3 class="text-lg font-medium tracking-tight">{item.title}</h3>
-                <p class="text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
+                <h3 class="text-balance text-lg font-medium tracking-tight">{item.title}</h3>
+                <p class="text-pretty text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
                   {item.description}
                 </p>
               </li>
@@ -84,10 +84,10 @@ const griftUrl = 'https://griftai.org';
           >
             {page.support.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight text-white sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight text-white sm:text-4xl">
             {page.support.title}
           </h2>
-          <p class="text-lg leading-relaxed text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.support.intro}
           </p>
         </div>
@@ -108,7 +108,7 @@ const griftUrl = 'https://griftai.org';
                     {item.service}
                   </span>
                 </div>
-                <p class="text-base leading-relaxed text-primary-950/70">
+                <p class="text-pretty text-base leading-relaxed text-primary-950/70">
                   {item.description}
                 </p>
               </li>
@@ -127,30 +127,30 @@ const griftUrl = 'https://griftai.org';
         data-reveal
       >
         <div class="flex max-w-2xl flex-col gap-4">
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.cta.title}
           </h2>
-          <p class="text-lg text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.cta.description}
           </p>
         </div>
-        <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <div class="flex w-full flex-col items-center gap-4 sm:w-auto sm:flex-row sm:justify-center">
           <a
             href={griftUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-white px-8 py-4 text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-transparent bg-white px-6 py-4 text-center text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto sm:px-8"
           >
             {page.cta.primary}
           </a>
           <a
             href={getLocalizedUrl('/contact', currentLocale)}
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-white/30 px-5 py-3 text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-white/30 px-5 py-3 text-center text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto"
           >
             {page.cta.secondary}
           </a>
         </div>
-        <p class="max-w-xl text-sm text-white/70">
+        <p class="max-w-xl text-pretty text-sm leading-relaxed text-white/70">
           {page.cta.note}
         </p>
       </div>

--- a/src/components/industry/ShigyoBody.astro
+++ b/src/components/industry/ShigyoBody.astro
@@ -12,7 +12,7 @@ const griftUrl = 'https://griftai.org';
   <section class="relative isolate flex min-h-[70vh] items-center overflow-hidden py-20 sm:py-28">
     <div class="motion-bg" aria-hidden="true"></div>
     <div class="relative z-10 mx-auto w-full max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
-      <div class="flex flex-col items-center gap-8 text-center sm:gap-10">
+      <div class="flex flex-col items-start gap-8 text-left sm:gap-10">
         <p
           class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400"
           data-reveal
@@ -20,16 +20,16 @@ const griftUrl = 'https://griftai.org';
         >
           {page.hero.eyebrow}
         </p>
-        <div class="flex max-w-4xl flex-col items-center gap-6 sm:gap-8">
+        <div class="flex max-w-4xl flex-col items-start gap-6 sm:gap-8">
           <h1
-            class="text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
+            class="text-balance text-4xl font-semibold leading-[1.1] tracking-tight sm:text-5xl lg:text-6xl"
             data-reveal
             style="--reveal-delay:0.1s"
           >
             {page.hero.title}
           </h1>
           <p
-            class="max-w-3xl text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
+            class="max-w-3xl text-pretty text-lg leading-relaxed text-primary-950/70 dark:text-primary-200/70 sm:text-xl"
             data-reveal
             style="--reveal-delay:0.2s"
           >
@@ -50,7 +50,7 @@ const griftUrl = 'https://griftai.org';
           >
             {page.challenges.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.challenges.title}
           </h2>
         </div>
@@ -82,8 +82,8 @@ const griftUrl = 'https://griftai.org';
                     </svg>
                   </span>
                   <div class="flex flex-col gap-3">
-                    <h3 class="text-lg font-medium tracking-tight">{item.title}</h3>
-                    <p class="text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
+                    <h3 class="text-balance text-lg font-medium tracking-tight">{item.title}</h3>
+                    <p class="text-pretty text-base leading-relaxed text-primary-950/70 dark:text-primary-200/70">
                       {item.description}
                     </p>
                   </div>
@@ -104,10 +104,10 @@ const griftUrl = 'https://griftai.org';
           <p class="text-sm font-medium uppercase tracking-widest text-[#7ba3cc]">
             {page.support.eyebrow}
           </p>
-          <h2 class="text-3xl font-medium tracking-tight text-white sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight text-white sm:text-4xl">
             {page.support.title}
           </h2>
-          <p class="text-lg leading-relaxed text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.support.intro}
           </p>
         </div>
@@ -142,10 +142,10 @@ const griftUrl = 'https://griftai.org';
                     <span class="inline-flex w-fit rounded-full bg-[#2d4a6b] px-3 py-1 text-xs font-medium text-white">
                       {item.service}
                     </span>
-                    <h3 class="text-lg font-medium tracking-tight text-primary-950">
+                    <h3 class="text-balance text-lg font-medium tracking-tight text-primary-950">
                       {item.title}
                     </h3>
-                    <p class="text-base leading-relaxed text-primary-950/70">
+                    <p class="text-pretty text-base leading-relaxed text-primary-950/70">
                       {item.description}
                     </p>
                   </div>
@@ -166,30 +166,30 @@ const griftUrl = 'https://griftai.org';
         data-reveal
       >
         <div class="flex max-w-2xl flex-col gap-4">
-          <h2 class="text-3xl font-medium tracking-tight sm:text-4xl">
+          <h2 class="text-balance text-3xl font-medium tracking-tight sm:text-4xl">
             {page.cta.title}
           </h2>
-          <p class="text-lg text-white/80">
+          <p class="text-pretty text-lg leading-relaxed text-white/80">
             {page.cta.description}
           </p>
         </div>
-        <div class="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+        <div class="flex w-full flex-col items-center gap-4 sm:w-auto sm:flex-row sm:justify-center">
           <a
             href={griftUrl}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-transparent bg-white px-8 py-4 text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-transparent bg-white px-6 py-4 text-center text-lg font-semibold text-[#2d4a6b] shadow-sm transition hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto sm:px-8"
           >
             {page.cta.primary}
           </a>
           <a
             href={getLocalizedUrl('/contact', currentLocale)}
-            class="inline-flex min-h-[48px] items-center justify-center rounded-full border border-white/30 px-5 py-3 text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            class="inline-flex min-h-[48px] w-full max-w-sm items-center justify-center rounded-full border border-white/30 px-5 py-3 text-center text-base font-medium text-white transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white sm:w-auto"
           >
             {page.cta.secondary}
           </a>
         </div>
-        <p class="max-w-xl text-sm text-white/70">
+        <p class="max-w-xl text-pretty text-sm leading-relaxed text-white/70">
           {page.cta.note}
         </p>
       </div>

--- a/src/components/products/Faq.astro
+++ b/src/components/products/Faq.astro
@@ -23,7 +23,7 @@ const t = getTranslations(currentLocale);
                 x-bind:class="{ 'bg-primary-500/10 dark:bg-primary-400/10': open }"
               >
                 <dt
-                  class="border-b text-lg transition"
+                  class="border-b text-base transition sm:text-lg"
                   x-cloak
                   x-bind:class="{ 'border-transparent': open, 'border-primary-900/10 dark:border-primary-300/10': !open }"
                 >
@@ -36,8 +36,8 @@ const t = getTranslations(currentLocale);
                     x-bind:aria-expanded="open.toString()"
                   >
                     <div class="flex items-center justify-between rounded-3xl group-focus-visible:outline group-focus-visible:outline-2 group-focus-visible:outline-offset-2 group-focus-visible:outline-primary-950 dark:group-focus-visible:outline-primary-200">
-                      <span class="font-medium">{question.question}</span>
-                      <span class="ml-6 flex h-7 items-center">
+                      <span class="type-action font-medium leading-relaxed">{question.question}</span>
+                      <span class="ml-4 flex h-7 items-center sm:ml-6">
                         <svg
                           class="h-6 w-6 rotate-0 transform text-primary-600 transition duration-200 ease-in-out dark:text-primary-400"
                           x-bind:class="{ '-rotate-180': open, 'rotate-0': !open }"

--- a/src/content/blog/zh/zundamon-lt-project.md
+++ b/src/content/blog/zh/zundamon-lt-project.md
@@ -1,5 +1,5 @@
 ---
-title: "【Marp×VOICEVOX×VTubeStudio】让ずんだもん来做 LT（短演讲）発表的故事"
+title: "【Marp×VOICEVOX×VTubeStudio】让ずんだもん做LT发表"
 description: "这个项目源于“想用 AI 做些无聊的事情！”的纯粹好奇心。作为一项有趣且富有创造性地利用技术的实验，我们构建了一个能让ずんだもん自动进行 LT 発表（短演讲）的系统。"
 pubDate: 2024-01-30
 author: "Terisuke"
@@ -8,7 +8,7 @@ tags: ["Marp", "VOICEVOX", "VTubeStudio", "自動化", "創造的プロジェク
 lang: "zh"
 ---
 
-# 【Marp×VOICEVOX×VTubeStudio】让ずんだもん来做 LT（短演讲）発表的故事
+# 【Marp×VOICEVOX×VTubeStudio】让ずんだもん做LT发表
 
 这个项目源于“想用 AI 做些无聊的事情！”的纯粹好奇心。作为一项有趣且富有创造性地利用技术的实验，我们构建了一个能让ずんだもん自动进行 LT 発表（短演讲）的系统。
 

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -307,6 +307,45 @@ const websiteJsonLd = {
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
       }
+
+      /* CJK/多言語の改行制御を通常Layoutと揃える。 */
+      h1, h2, h3,
+      .type-heading {
+        word-break: auto-phrase;
+        overflow-wrap: anywhere;
+        line-break: strict;
+        text-wrap: balance;
+      }
+      p, li, dd, figcaption,
+      .type-copy {
+        word-break: auto-phrase;
+        overflow-wrap: break-word;
+        line-break: strict;
+        text-wrap: pretty;
+      }
+      .type-action {
+        word-break: auto-phrase;
+        overflow-wrap: anywhere;
+        line-break: strict;
+        text-wrap: balance;
+      }
+      /* ブランド語「きょうそう」など、語の途中で折らない範囲に使う。 */
+      .nowrap,
+      .type-keep {
+        white-space: nowrap;
+      }
+      .line-clamp-2,
+      .line-clamp-3 {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .line-clamp-2 {
+        -webkit-line-clamp: 2;
+      }
+      .line-clamp-3 {
+        -webkit-line-clamp: 3;
+      }
       
       @font-face {
         font-family: 'Inter';
@@ -333,6 +372,24 @@ const websiteJsonLd = {
       [x-cloak] { display: none !important; }
       
       /* Blog specific styles */
+      .prose :where(h1, h2, h3) {
+        word-break: auto-phrase;
+        overflow-wrap: anywhere;
+        line-break: strict;
+        text-wrap: balance;
+      }
+
+      .prose :where(p, li, dd, figcaption) {
+        word-break: auto-phrase;
+        overflow-wrap: break-word;
+        line-break: strict;
+        text-wrap: pretty;
+      }
+
+      .prose :where(a) {
+        overflow-wrap: anywhere;
+      }
+
       .prose pre {
         background-color: #282a36;
         border-radius: 0.5rem;
@@ -416,14 +473,16 @@ const websiteJsonLd = {
       
       .remark-link-card-plus__card {
         display: flex;
+        flex-direction: column;
         text-decoration: none;
         color: inherit;
-        min-height: 120px;
+        min-height: 0;
       }
       
       .remark-link-card-plus__main {
         padding: 1rem;
         flex: 1;
+        min-width: 0;
         display: flex;
         flex-direction: column;
         justify-content: space-between;
@@ -431,8 +490,8 @@ const websiteJsonLd = {
       
       .remark-link-card-plus__thumbnail {
         flex-shrink: 0;
-        width: 120px;
-        height: 120px;
+        width: 100%;
+        height: 10rem;
         overflow: hidden;
       }
       
@@ -449,6 +508,7 @@ const websiteJsonLd = {
       
       .remark-link-card-plus__content {
         margin-bottom: 0.75rem;
+        min-width: 0;
       }
       
       .remark-link-card-plus__title {
@@ -457,6 +517,10 @@ const websiteJsonLd = {
         margin-bottom: 0.5rem;
         font-size: 1rem;
         line-height: 1.5;
+        word-break: auto-phrase;
+        overflow-wrap: anywhere;
+        line-break: strict;
+        text-wrap: balance;
       }
       
       .dark .remark-link-card-plus__title {
@@ -467,6 +531,10 @@ const websiteJsonLd = {
         color: #57534e;
         font-size: 0.875rem;
         line-height: 1.4;
+        word-break: auto-phrase;
+        overflow-wrap: break-word;
+        line-break: strict;
+        text-wrap: pretty;
         display: -webkit-box;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;
@@ -480,7 +548,9 @@ const websiteJsonLd = {
       .remark-link-card-plus__meta {
         display: flex;
         align-items: center;
+        flex-wrap: wrap;
         gap: 0.5rem;
+        min-width: 0;
       }
       
       .remark-link-card-plus__favicon {
@@ -493,10 +563,26 @@ const websiteJsonLd = {
         color: #78716c;
         font-size: 0.75rem;
         font-weight: 500;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       
       .dark .remark-link-card-plus__url {
         color: #a8a29e;
+      }
+
+      @media (min-width: 640px) {
+        .remark-link-card-plus__card {
+          flex-direction: row;
+          min-height: 120px;
+        }
+
+        .remark-link-card-plus__thumbnail {
+          width: 120px;
+          height: 120px;
+        }
       }
     </style>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -220,20 +220,43 @@ const ogImage = ogImageProp
         -moz-osx-font-smoothing: grayscale;
       }
 
-      /* 日本語の改行を読みやすく: 見出しは文節単位で折り(auto-phrase, 非対応ブラウザは従来動作)、
-         行を均等割り(balance)。本文は孤立行(widow)を回避(pretty)。 */
-      h1, h2, h3, p, li, dd, figcaption {
+      /* CJK/多言語の改行制御をLayout間で揃える。 */
+      h1, h2, h3,
+      .type-heading {
         word-break: auto-phrase;
-      }
-      h1, h2, h3 {
+        overflow-wrap: anywhere;
+        line-break: strict;
         text-wrap: balance;
       }
-      p {
+      p, li, dd, figcaption,
+      .type-copy {
+        word-break: auto-phrase;
+        overflow-wrap: break-word;
+        line-break: strict;
         text-wrap: pretty;
       }
-      /* ブランド語「きょうそう」は語の途中で折らない（見出し・本文共通）。 */
-      .nowrap {
+      .type-action {
+        word-break: auto-phrase;
+        overflow-wrap: anywhere;
+        line-break: strict;
+        text-wrap: balance;
+      }
+      /* ブランド語「きょうそう」など、語の途中で折らない範囲に使う。 */
+      .nowrap,
+      .type-keep {
         white-space: nowrap;
+      }
+      .line-clamp-2,
+      .line-clamp-3 {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .line-clamp-2 {
+        -webkit-line-clamp: 2;
+      }
+      .line-clamp-3 {
+        -webkit-line-clamp: 3;
       }
 
       /* Inter font with optional display - won't block render */

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,17 +17,17 @@ const t = getTranslations(currentLocale);
     <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
       <div class="flex flex-col items-start gap-8 sm:gap-10">
         <div class="flex flex-col gap-4 sm:gap-6">
-          <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
+          <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl lg:text-5xl">
             <div>{t["404"].title}</div>
             <div>{t["404"].subtitle}</div>
           </h1>
-          <p class="text-primary-950/70 dark:text-primary-200/70 text-lg sm:text-xl">
+          <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
             {t["404"].description}
           </p>
         </div>
         <a
           href="/"
-          class="bg-primary-600 dark:bg-primary-400 hover:bg-primary-700 dark:hover:bg-primary-300 focus-visible:outline-primary-600 dark:focus-visible:outline-primary-400 dark:text-primary-950 inline-flex items-center justify-center rounded-full border border-transparent px-5 py-3 text-base font-medium text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          class="type-action inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
         >
           {t["404"].cta}
         </a>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -46,10 +46,10 @@ const categories = [
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         {currentLocale === 'ja' ? 'ブログ' : 'Blog'}
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -108,7 +108,7 @@ const categories = [
 
     <!-- Pagination Navigation -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <!-- Previous Page -->
         <a
           href={page.url.prev || '#'}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -137,45 +137,47 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
   <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
-      <ol class="flex items-center space-x-2 text-sm text-stone-600 dark:text-stone-400">
-        <li>
+      <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
+        <li class="shrink-0">
           <a href={currentLocale === 'ja' ? '/' : '/en'} class="hover:text-blue-600 dark:hover:text-blue-400">
             {currentLocale === 'ja' ? 'ホーム' : 'Home'}
           </a>
         </li>
-        <li class="before:content-['/'] before:mx-2">
+        <li class="flex shrink-0 items-center gap-2">
+          <span aria-hidden="true" class="text-stone-400 dark:text-stone-500">/</span>
           <a href={currentLocale === 'ja' ? '/blog' : '/en/blog'} class="hover:text-blue-600 dark:hover:text-blue-400">
             {currentLocale === 'ja' ? 'ブログ' : 'Blog'}
           </a>
         </li>
-        <li class="before:content-['/'] before:mx-2">
-          <span class="text-stone-900 dark:text-stone-100">{post.data.title}</span>
+        <li class="hidden min-w-0 flex-1 items-center gap-2 sm:flex">
+          <span aria-hidden="true" class="shrink-0 text-stone-400 dark:text-stone-500">/</span>
+          <span class="truncate text-stone-900 dark:text-stone-100">{post.data.title}</span>
         </li>
       </ol>
     </nav>
 
     <!-- Article Header -->
     <header class="mb-8">
-      <div class="mb-4 flex items-center gap-4 text-sm">
+      <div class="mb-5 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
         <CategoryBadge category={post.data.category} />
-        <time datetime={post.data.pubDate.toISOString()} class="text-stone-500 dark:text-stone-400">
+        <time datetime={post.data.pubDate.toISOString()} class="shrink-0 text-stone-500 dark:text-stone-400">
           {formattedPubDate}
         </time>
-        <span class="text-stone-500 dark:text-stone-400">
+        <span class="shrink-0 text-stone-500 dark:text-stone-400">
           {readingTime} {currentLocale === 'ja' ? '分で読了' : 'min read'}
         </span>
       </div>
       
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 max-w-3xl text-balance text-3xl font-bold leading-tight text-stone-900 dark:text-stone-100 sm:text-4xl">
         {post.data.title}
       </h1>
       
-      <p class="mb-6 text-lg text-stone-600 dark:text-stone-300">
+      <p class="mb-6 max-w-3xl text-pretty text-lg leading-8 text-stone-600 dark:text-stone-300">
         {post.data.description}
       </p>
       
-      <div class="flex items-center justify-between border-b border-stone-200 pb-6 dark:border-stone-700">
-        <div class="flex items-center gap-3">
+      <div class="flex flex-col gap-4 border-b border-stone-200 pb-6 dark:border-stone-700 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-w-0 items-center gap-3">
           <div class="text-sm">
             <p class="font-medium text-stone-900 dark:text-stone-100">{post.data.author}</p>
             {formattedUpdatedDate && (
@@ -235,12 +237,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {prevPost && (
         <a
           href={`/blog/${prevPost.slug.replace('ja/', '')}`}
-          class="group flex flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
+          class="group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             ← {currentLocale === 'ja' ? '前の記事' : 'Previous'}
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={prevPost.data.title}>
             {prevPost.data.title}
           </span>
         </a>
@@ -249,12 +251,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {nextPost && (
         <a
           href={`/blog/${nextPost.slug.replace('ja/', '')}`}
-          class={`group flex flex-col rounded-lg border border-stone-200 p-4 text-right transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 ${!prevPost ? 'sm:col-start-2' : ''}`}
+          class={`group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 sm:text-right ${!prevPost ? 'sm:col-start-2' : ''}`}
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             {currentLocale === 'ja' ? '次の記事' : 'Next'} →
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={nextPost.data.title}>
             {nextPost.data.title}
           </span>
         </a>

--- a/src/pages/blog/category/[id]/[...page].astro
+++ b/src/pages/blog/category/[id]/[...page].astro
@@ -59,10 +59,10 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         {categoryLabel}
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -112,7 +112,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
 
     <!-- ページネーション -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         {page.url.prev ? (
           <a
             href={`${base}blog/category/${id}${page.url.prev}`}
@@ -161,4 +161,4 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
       </nav>
     )}
   </div>
-</Layout> 
+</Layout>

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -63,15 +63,15 @@ const categories = [
         </a>
       </div>
       
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        <span class="inline-flex items-center gap-2">
+      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
+        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
           <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
             #{tag}
           </span>
           タグの記事
         </span>
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -115,7 +115,7 @@ const categories = [
 
     <!-- Pagination Navigation -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <!-- Previous Page -->
         <a
           href={page.url.prev || '#'}

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -4,19 +4,12 @@ import ContactChat from '../components/contact/ContactChat.astro';
 import ContactForm from '../components/contact/ContactForm.astro';
 import ContactInfo from '../components/contact/ContactInfo.astro';
 import Heading from '../components/contact/Heading.astro';
-import NextStep from '../components/common/NextStep.astro';
 import Layout from '../layouts/Layout.astro';
 import { CONTACT_CHAT_ENABLED } from '../config/contact';
-import { getCurrentLocale, getLocalizedUrl, getTranslations } from '../utils/i18n';
+import { getCurrentLocale, getTranslations } from '../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
-
-// /works は ja のみ存在。ja は実績ページへ、非ja は 404 回避のため同言語の相談ページへ誘導する。
-const nextStepHref =
-  currentLocale === 'ja'
-    ? getLocalizedUrl('/works', currentLocale)
-    : getLocalizedUrl('/contact', currentLocale);
 ---
 
 {!CONTACT_CHAT_ENABLED && (
@@ -39,10 +32,4 @@ const nextStepHref =
       </>
     )
   }
-
-  <NextStep
-    heading={t.nextStep.contact.heading}
-    lead={t.nextStep.contact.lead}
-    ctas={[{ label: t.nextStep.contact.ctaLabel, href: nextStepHref, primary: true }]}
-  />
 </Layout>

--- a/src/pages/en/404.astro
+++ b/src/pages/en/404.astro
@@ -17,17 +17,17 @@ const t = getTranslations(currentLocale);
     <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
       <div class="flex flex-col items-start gap-8 sm:gap-10">
         <div class="flex flex-col gap-4 sm:gap-6">
-          <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
+          <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl lg:text-5xl">
             <div>{t["404"].title}</div>
             <div>{t["404"].subtitle}</div>
           </h1>
-          <p class="text-primary-950/70 dark:text-primary-200/70 text-lg sm:text-xl">
+          <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
             {t["404"].description}
           </p>
         </div>
         <a
           href={getLocalizedUrl('/', currentLocale)}
-          class="bg-primary-600 dark:bg-primary-400 hover:bg-primary-700 dark:hover:bg-primary-300 focus-visible:outline-primary-600 dark:focus-visible:outline-primary-400 dark:text-primary-950 inline-flex items-center justify-center rounded-full border border-transparent px-5 py-3 text-base font-medium text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          class="type-action inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
         >
           {t["404"].cta}
         </a>

--- a/src/pages/en/blog/[...page].astro
+++ b/src/pages/en/blog/[...page].astro
@@ -42,10 +42,10 @@ const categories = [
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         Blog
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -101,7 +101,7 @@ const categories = [
 
     <!-- Pagination Navigation -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <!-- Previous Page -->
         <a
           href={page.url.prev || '#'}

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -64,24 +64,30 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
   <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
-      <ol class="flex items-center space-x-2 text-sm text-stone-600 dark:text-stone-400">
-        <li><a href="/en" class="hover:text-blue-600 dark:hover:text-blue-400">Home</a></li>
-        <li class="before:content-['/'] before:mx-2"><a href="/en/blog" class="hover:text-blue-600 dark:hover:text-blue-400">Blog</a></li>
-        <li class="before:content-['/'] before:mx-2"><span class="text-stone-900 dark:text-stone-100">{post.data.title}</span></li>
+      <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
+        <li class="shrink-0"><a href="/en" class="hover:text-blue-600 dark:hover:text-blue-400">Home</a></li>
+        <li class="flex shrink-0 items-center gap-2">
+          <span aria-hidden="true" class="text-stone-400 dark:text-stone-500">/</span>
+          <a href="/en/blog" class="hover:text-blue-600 dark:hover:text-blue-400">Blog</a>
+        </li>
+        <li class="hidden min-w-0 flex-1 items-center gap-2 sm:flex">
+          <span aria-hidden="true" class="shrink-0 text-stone-400 dark:text-stone-500">/</span>
+          <span class="truncate text-stone-900 dark:text-stone-100">{post.data.title}</span>
+        </li>
       </ol>
     </nav>
 
     <!-- Header -->
     <header class="mb-8">
-      <div class="mb-4 flex items-center gap-4 text-sm">
+      <div class="mb-5 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
         <CategoryBadge category={post.data.category} />
-        <time datetime={post.data.pubDate.toISOString()} class="text-stone-500 dark:text-stone-400">{formattedPubDate}</time>
-        <span class="text-stone-500 dark:text-stone-400">{readingTime} min read</span>
+        <time datetime={post.data.pubDate.toISOString()} class="shrink-0 text-stone-500 dark:text-stone-400">{formattedPubDate}</time>
+        <span class="shrink-0 text-stone-500 dark:text-stone-400">{readingTime} min read</span>
       </div>
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">{post.data.title}</h1>
-      <p class="mb-6 text-lg text-stone-600 dark:text-stone-300">{post.data.description}</p>
-      <div class="flex items-center justify-between border-b border-stone-200 pb-6 dark:border-stone-700">
-        <div class="text-sm font-medium text-stone-900 dark:text-stone-100">{post.data.author}</div>
+      <h1 class="mb-4 max-w-3xl text-balance text-3xl font-bold leading-tight text-stone-900 dark:text-stone-100 sm:text-4xl">{post.data.title}</h1>
+      <p class="mb-6 max-w-3xl text-pretty text-lg leading-8 text-stone-600 dark:text-stone-300">{post.data.description}</p>
+      <div class="flex flex-col gap-4 border-b border-stone-200 pb-6 dark:border-stone-700 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0 text-sm font-medium text-stone-900 dark:text-stone-100">{post.data.author}</div>
         <ShareButtons title={post.data.title} url={fullUrl} />
       </div>
     </header>
@@ -124,12 +130,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {prevPost && (
         <a
           href={`/en/blog/${prevPost.slug.replace('en/', '')}`}
-          class="group flex flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
+          class="group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             ← Previous
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={prevPost.data.title}>
             {prevPost.data.title}
           </span>
         </a>
@@ -138,12 +144,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {nextPost && (
         <a
           href={`/en/blog/${nextPost.slug.replace('en/', '')}`}
-          class={`group flex flex-col rounded-lg border border-stone-200 p-4 text-right transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 ${!prevPost ? 'sm:col-start-2' : ''}`}
+          class={`group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 sm:text-right ${!prevPost ? 'sm:col-start-2' : ''}`}
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             Next →
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={nextPost.data.title}>
             {nextPost.data.title}
           </span>
         </a>
@@ -164,4 +170,4 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       </section>
     )}
   </article>
-</BlogLayout> 
+</BlogLayout>

--- a/src/pages/en/blog/category/[id]/[...page].astro
+++ b/src/pages/en/blog/category/[id]/[...page].astro
@@ -57,10 +57,10 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         {categoryLabel}
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -110,7 +110,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
 
     <!-- ページネーション -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <a
           href={page.url.prev ? `${currentLocale === 'ja' ? '' : '/en'}/blog/category/${id}/${page.url.prev.replace(/^\//, '')}` : '#'}
           class={`rounded-lg px-3 py-2 text-sm font-medium ${

--- a/src/pages/en/blog/tags/[tag]/[...page].astro
+++ b/src/pages/en/blog/tags/[tag]/[...page].astro
@@ -56,15 +56,15 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
         </a>
       </div>
       
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        <span class="inline-flex items-center gap-2">
+      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
+        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
           <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
             #{tag}
           </span>
           Tag Articles
         </span>
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -102,7 +102,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           <p class="text-sm text-stone-500 dark:text-stone-400">
             You can:
           </p>
-          <div class="flex justify-center gap-4">
+          <div class="flex flex-wrap justify-center gap-4">
             <a href="/en/blog" class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">Browse All Articles</a>
             <a href="/en/blog" class="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600">Popular Tags</a>
           </div>
@@ -112,7 +112,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
 
     <!-- Pagination Navigation -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <!-- Previous Page -->
         <a
           href={page.url.prev || '#'}

--- a/src/pages/en/contact.astro
+++ b/src/pages/en/contact.astro
@@ -4,10 +4,9 @@ import ContactChat from '../../components/contact/ContactChat.astro';
 import ContactForm from '../../components/contact/ContactForm.astro';
 import ContactInfo from '../../components/contact/ContactInfo.astro';
 import Heading from '../../components/contact/Heading.astro';
-import NextStep from '../../components/common/NextStep.astro';
 import Layout from '../../layouts/Layout.astro';
 import { CONTACT_CHAT_ENABLED } from '../../config/contact';
-import { getCurrentLocale, getLocalizedUrl, getTranslations } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
@@ -33,10 +32,4 @@ const t = getTranslations(currentLocale);
       </>
     )
   }
-
-  <NextStep
-    heading={t.nextStep.contact.heading}
-    lead={t.nextStep.contact.lead}
-    ctas={[{ label: t.nextStep.contact.ctaLabel, href: getLocalizedUrl('/contact', currentLocale), primary: true }]}
-  />
 </Layout>

--- a/src/pages/en/legal/tokushoho.astro
+++ b/src/pages/en/legal/tokushoho.astro
@@ -9,9 +9,10 @@ import Layout from '../../../layouts/Layout.astro';
   description="Legal disclosures required under the Japanese Specified Commercial Transactions Act (SCTA). Includes seller information, payment terms, delivery, and return policies."
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <h1 class="mb-10 text-4xl font-medium tracking-tight sm:text-5xl">Legal Notice</h1>
+    <h1 class="type-heading mb-10 text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">Legal Notice</h1>
 
-    <table class="w-full table-auto border-collapse text-left">
+    <div class="overflow-x-auto">
+    <table class="min-w-[42rem] table-auto border-collapse text-left">
       <caption class="sr-only">Seller information required under the Japanese Specified Commercial Transactions Act</caption>
       <tbody class="divide-y divide-primary-200 dark:divide-primary-800">
         <tr><th class="py-4 pr-6 align-top font-medium">Seller</th><td class="py-4">Cor Inc. (Cor.inc)</td></tr>
@@ -39,5 +40,6 @@ import Layout from '../../../layouts/Layout.astro';
         <tr><th class="py-4 pr-6 align-top font-medium">Secondhand Dealer License</th><td class="py-4">Not applicable</td></tr>
       </tbody>
     </table>
+    </div>
   </div>
-</Layout> 
+</Layout>

--- a/src/pages/en/privacy.astro
+++ b/src/pages/en/privacy.astro
@@ -14,12 +14,22 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
   title={t.meta.privacy.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="flex flex-col gap-4 pb-16 text-center sm:pb-20">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{p.title}</h1>
-      <p class="text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">
+        {currentLocale === 'ja' ? (
+          <>
+            個人情報保護方針
+            <span class="type-keep inline-block">（プライバシー</span>
+            <span class="type-keep inline-block">ポリシー）</span>
+          </>
+        ) : (
+          p.title
+        )}
+      </h1>
+      <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
     </div>
 
-    <div class="text-base leading-[1.8]">
+    <div class="type-copy text-base leading-[1.8]">
       {
         p.note && (
           <p class="mb-6 rounded-md border border-primary-900/15 bg-primary-900/[0.03] px-4 py-3 text-sm dark:border-primary-300/15 dark:bg-primary-300/[0.04]">
@@ -30,7 +40,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
 
       <p class="mb-4">{p.intro}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
           <tbody>
@@ -46,13 +56,13 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
       <p class="mb-6">{p.purposeLead}</p>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(p.purposeGroups) && p.purposeGroups.map((group) => (
             <div>
-              <h3 class="mb-3 text-lg font-medium">{group.title}</h3>
+              <h3 class="type-heading mb-3 text-lg font-medium">{group.title}</h3>
               <dl class="flex flex-col gap-2">
                 {group.lines.map((line) => (
                   <div>
@@ -70,7 +80,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
       {
         Array.isArray(p.sections) && p.sections.map((section) => (
           <section>
-            <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
+            <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
             {Array.isArray(section.body) && section.body.map((para) => <p class="mb-4">{para}</p>)}
             {Array.isArray(section.list) && (
               <ul class="mb-4 list-inside list-disc space-y-3">
@@ -84,7 +94,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         ))
       }
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
       <p class="mb-6">{p.inquiryLead}</p>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
@@ -109,7 +119,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
       {Array.isArray(p.revisionBody) && p.revisionBody.map((para) => <p class="mb-4">{para}</p>)}
 
       <p class="mb-4 mt-8">

--- a/src/pages/en/security.astro
+++ b/src/pages/en/security.astro
@@ -12,37 +12,37 @@ const t = getTranslations(locale);
   title={t.meta.security.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="sm:pb-20 flex flex-col gap-4 pb-16 text-center">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{t.security.title}</h1>
-      <p class="text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">{t.security.title}</h1>
+      <p class="type-copy text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
     </div>
-    <div>
+    <div class="type-copy text-base leading-[1.8]">
       <p class="mb-4">
         {t.security.lead}
       </p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(t.security?.pillars) && t.security.pillars.map((pillar) => (
             <div>
-              <h3 class="mb-2 text-lg font-medium">{pillar.title}</h3>
+              <h3 class="type-heading mb-2 text-lg font-medium">{pillar.title}</h3>
               <p>{pillar.description}</p>
             </div>
           ))
         }
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
       <ul class="list-inside list-disc space-y-4">
         <li>{t.security.status.legal}</li>
         <li>{t.security.status.isms}</li>
       </ul>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
       <p class="mb-4">{t.security.aiDescription}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full border-collapse text-left text-sm sm:text-base">
           <thead>
@@ -66,7 +66,7 @@ const t = getTranslations(locale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
       <p class="mb-4">
         {t.security.privacyDescription}<span class="font-medium"><a href={getLocalizedUrl('/privacy', locale)}>{t.security.privacyLinkText}</a></span>{t.security.privacySuffix}
       </p>

--- a/src/pages/es/404.astro
+++ b/src/pages/es/404.astro
@@ -17,17 +17,17 @@ const t = getTranslations(currentLocale);
     <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
       <div class="flex flex-col items-start gap-8 sm:gap-10">
         <div class="flex flex-col gap-4 sm:gap-6">
-          <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
+          <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl lg:text-5xl">
             <div>{t["404"].title}</div>
             <div>{t["404"].subtitle}</div>
           </h1>
-          <p class="text-primary-950/70 dark:text-primary-200/70 text-lg sm:text-xl">
+          <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
             {t["404"].description}
           </p>
         </div>
         <a
           href={getLocalizedUrl('/', currentLocale)}
-          class="bg-primary-600 dark:bg-primary-400 hover:bg-primary-700 dark:hover:bg-primary-300 focus-visible:outline-primary-600 dark:focus-visible:outline-primary-400 dark:text-primary-950 inline-flex items-center justify-center rounded-full border border-transparent px-5 py-3 text-base font-medium text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          class="type-action inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
         >
           {t["404"].cta}
         </a>

--- a/src/pages/es/blog/[...page].astro
+++ b/src/pages/es/blog/[...page].astro
@@ -42,10 +42,10 @@ const categories = [
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         Blog
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
 
@@ -86,7 +86,7 @@ const categories = [
 
     <!-- Blog Posts Grid -->
     {page.data.length > 0 ? (
-      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
         {page.data.map(post => (
           <PostCard post={post} />
         ))}
@@ -101,7 +101,7 @@ const categories = [
 
     <!-- Pagination Controls -->
     {page.total > page.size && (
-      <div class="mt-12 flex justify-center gap-2">
+      <div class="mt-12 flex flex-wrap items-center justify-center gap-2">
         {page.url.prev && (
           <a
             href={page.url.prev}

--- a/src/pages/es/blog/[...slug].astro
+++ b/src/pages/es/blog/[...slug].astro
@@ -64,24 +64,30 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
   <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
-      <ol class="flex items-center space-x-2 text-sm text-stone-600 dark:text-stone-400">
-        <li><a href="/es" class="hover:text-blue-600 dark:hover:text-blue-400">Inicio</a></li>
-        <li class="before:content-['/'] before:mx-2"><a href="/es/blog" class="hover:text-blue-600 dark:hover:text-blue-400">Blog</a></li>
-        <li class="before:content-['/'] before:mx-2"><span class="text-stone-900 dark:text-stone-100">{post.data.title}</span></li>
+      <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
+        <li class="shrink-0"><a href="/es" class="hover:text-blue-600 dark:hover:text-blue-400">Inicio</a></li>
+        <li class="flex shrink-0 items-center gap-2">
+          <span aria-hidden="true" class="text-stone-400 dark:text-stone-500">/</span>
+          <a href="/es/blog" class="hover:text-blue-600 dark:hover:text-blue-400">Blog</a>
+        </li>
+        <li class="hidden min-w-0 flex-1 items-center gap-2 sm:flex">
+          <span aria-hidden="true" class="shrink-0 text-stone-400 dark:text-stone-500">/</span>
+          <span class="truncate text-stone-900 dark:text-stone-100">{post.data.title}</span>
+        </li>
       </ol>
     </nav>
 
     <!-- Header -->
     <header class="mb-8">
-      <div class="mb-4 flex items-center gap-4 text-sm">
+      <div class="mb-5 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
         <CategoryBadge category={post.data.category} />
-        <time datetime={post.data.pubDate.toISOString()} class="text-stone-500 dark:text-stone-400">{formattedPubDate}</time>
-        <span class="text-stone-500 dark:text-stone-400">{readingTime} min de lectura</span>
+        <time datetime={post.data.pubDate.toISOString()} class="shrink-0 text-stone-500 dark:text-stone-400">{formattedPubDate}</time>
+        <span class="shrink-0 text-stone-500 dark:text-stone-400">{readingTime} min de lectura</span>
       </div>
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">{post.data.title}</h1>
-      <p class="mb-6 text-lg text-stone-600 dark:text-stone-300">{post.data.description}</p>
-      <div class="flex items-center justify-between border-b border-stone-200 pb-6 dark:border-stone-700">
-        <div class="text-sm font-medium text-stone-900 dark:text-stone-100">{post.data.author}</div>
+      <h1 class="mb-4 max-w-3xl text-balance text-3xl font-bold leading-tight text-stone-900 dark:text-stone-100 sm:text-4xl">{post.data.title}</h1>
+      <p class="mb-6 max-w-3xl text-pretty text-lg leading-8 text-stone-600 dark:text-stone-300">{post.data.description}</p>
+      <div class="flex flex-col gap-4 border-b border-stone-200 pb-6 dark:border-stone-700 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0 text-sm font-medium text-stone-900 dark:text-stone-100">{post.data.author}</div>
         <ShareButtons title={post.data.title} url={fullUrl} />
       </div>
     </header>
@@ -124,12 +130,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {prevPost && (
         <a
           href={`/es/blog/${prevPost.slug.replace('es/', '')}`}
-          class="group flex flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
+          class="group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             ← Anterior
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={prevPost.data.title}>
             {prevPost.data.title}
           </span>
         </a>
@@ -138,12 +144,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {nextPost && (
         <a
           href={`/es/blog/${nextPost.slug.replace('es/', '')}`}
-          class={`group flex flex-col rounded-lg border border-stone-200 p-4 text-right transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 ${!prevPost ? 'sm:col-start-2' : ''}`}
+          class={`group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 sm:text-right ${!prevPost ? 'sm:col-start-2' : ''}`}
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             Siguiente →
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={nextPost.data.title}>
             {nextPost.data.title}
           </span>
         </a>
@@ -161,7 +167,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     {relatedPosts.length > 0 && (
       <div class="mt-12 border-t border-stone-200 pt-8 dark:border-stone-700">
         <h2 class="mb-6 text-2xl font-bold text-stone-900 dark:text-stone-100">Artículos Relacionados</h2>
-        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="grid gap-8 md:grid-cols-3">
           {relatedPosts.map(relPost => (
             <PostCard post={relPost} />
           ))}

--- a/src/pages/es/blog/category/[id]/[...page].astro
+++ b/src/pages/es/blog/category/[id]/[...page].astro
@@ -56,10 +56,10 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         {categoryLabel}
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -106,7 +106,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
 
     <!-- ページネーション -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <a
           href={page.url.prev ? `/es/blog/category/${id}/${page.url.prev.replace(/^\//, '')}` : '#'}
           class={`rounded-lg px-3 py-2 text-sm font-medium ${

--- a/src/pages/es/blog/tags/[tag]/[...page].astro
+++ b/src/pages/es/blog/tags/[tag]/[...page].astro
@@ -56,15 +56,15 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
         </a>
       </div>
       
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        <span class="inline-flex items-center gap-2">
+      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
+        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
           <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
             #{tag}
           </span>
           Artículos con Etiqueta
         </span>
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -102,7 +102,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           <p class="text-sm text-stone-500 dark:text-stone-400">
             Puedes:
           </p>
-          <div class="flex justify-center gap-4">
+          <div class="flex flex-wrap justify-center gap-4">
             <a href="/es/blog" class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">Ver Todos los Artículos</a>
             <a href="/es/blog" class="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600">Etiquetas Populares</a>
           </div>
@@ -112,7 +112,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
 
     <!-- Pagination Navigation -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <!-- Previous Page -->
         <a
           href={page.url.prev || '#'}

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -4,10 +4,9 @@ import ContactChat from '../../components/contact/ContactChat.astro';
 import ContactForm from '../../components/contact/ContactForm.astro';
 import ContactInfo from '../../components/contact/ContactInfo.astro';
 import Heading from '../../components/contact/Heading.astro';
-import NextStep from '../../components/common/NextStep.astro';
 import Layout from '../../layouts/Layout.astro';
 import { CONTACT_CHAT_ENABLED } from '../../config/contact';
-import { getCurrentLocale, getLocalizedUrl, getTranslations } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
@@ -33,10 +32,4 @@ const t = getTranslations(currentLocale);
       </>
     )
   }
-
-  <NextStep
-    heading={t.nextStep.contact.heading}
-    lead={t.nextStep.contact.lead}
-    ctas={[{ label: t.nextStep.contact.ctaLabel, href: getLocalizedUrl('/contact', currentLocale), primary: true }]}
-  />
 </Layout>

--- a/src/pages/es/legal/tokushoho.astro
+++ b/src/pages/es/legal/tokushoho.astro
@@ -8,9 +8,10 @@ import Layout from '../../../layouts/Layout.astro';
   description="Divulgaciones legales requeridas bajo la Ley de Transacciones Comerciales Específicas de Japón. Incluye información del vendedor, términos de pago, entrega y políticas de devolución."
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <h1 class="mb-10 text-4xl font-medium tracking-tight sm:text-5xl">Aviso Legal</h1>
+    <h1 class="type-heading mb-10 text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">Aviso Legal</h1>
 
-    <table class="w-full table-auto border-collapse text-left">
+    <div class="overflow-x-auto">
+    <table class="min-w-[42rem] table-auto border-collapse text-left">
       <caption class="sr-only">Información del vendedor requerida bajo la Ley de Transacciones Comerciales Específicas de Japón</caption>
       <tbody class="divide-y divide-primary-200 dark:divide-primary-800">
         <tr><th class="py-4 pr-6 align-top font-medium">Vendedor</th><td class="py-4">Cor Inc. (Cor.inc)</td></tr>
@@ -38,5 +39,6 @@ import Layout from '../../../layouts/Layout.astro';
         <tr><th class="py-4 pr-6 align-top font-medium">Licencia de Comerciante de Segunda Mano</th><td class="py-4">No aplica</td></tr>
       </tbody>
     </table>
+    </div>
   </div>
 </Layout>

--- a/src/pages/es/privacy.astro
+++ b/src/pages/es/privacy.astro
@@ -14,12 +14,22 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
   title={t.meta.privacy.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="flex flex-col gap-4 pb-16 text-center sm:pb-20">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{p.title}</h1>
-      <p class="text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">
+        {currentLocale === 'ja' ? (
+          <>
+            個人情報保護方針
+            <span class="type-keep inline-block">（プライバシー</span>
+            <span class="type-keep inline-block">ポリシー）</span>
+          </>
+        ) : (
+          p.title
+        )}
+      </h1>
+      <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
     </div>
 
-    <div class="text-base leading-[1.8]">
+    <div class="type-copy text-base leading-[1.8]">
       {
         p.note && (
           <p class="mb-6 rounded-md border border-primary-900/15 bg-primary-900/[0.03] px-4 py-3 text-sm dark:border-primary-300/15 dark:bg-primary-300/[0.04]">
@@ -30,7 +40,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
 
       <p class="mb-4">{p.intro}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
           <tbody>
@@ -46,13 +56,13 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
       <p class="mb-6">{p.purposeLead}</p>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(p.purposeGroups) && p.purposeGroups.map((group) => (
             <div>
-              <h3 class="mb-3 text-lg font-medium">{group.title}</h3>
+              <h3 class="type-heading mb-3 text-lg font-medium">{group.title}</h3>
               <dl class="flex flex-col gap-2">
                 {group.lines.map((line) => (
                   <div>
@@ -70,7 +80,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
       {
         Array.isArray(p.sections) && p.sections.map((section) => (
           <section>
-            <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
+            <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
             {Array.isArray(section.body) && section.body.map((para) => <p class="mb-4">{para}</p>)}
             {Array.isArray(section.list) && (
               <ul class="mb-4 list-inside list-disc space-y-3">
@@ -84,7 +94,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         ))
       }
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
       <p class="mb-6">{p.inquiryLead}</p>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
@@ -109,7 +119,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
       {Array.isArray(p.revisionBody) && p.revisionBody.map((para) => <p class="mb-4">{para}</p>)}
 
       <p class="mb-4 mt-8">

--- a/src/pages/es/security.astro
+++ b/src/pages/es/security.astro
@@ -12,37 +12,37 @@ const t = getTranslations(locale);
   title={t.meta.security.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="sm:pb-20 flex flex-col gap-4 pb-16 text-center">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{t.security.title}</h1>
-      <p class="text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">{t.security.title}</h1>
+      <p class="type-copy text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
     </div>
-    <div>
+    <div class="type-copy text-base leading-[1.8]">
       <p class="mb-4">
         {t.security.lead}
       </p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(t.security?.pillars) && t.security.pillars.map((pillar) => (
             <div>
-              <h3 class="mb-2 text-lg font-medium">{pillar.title}</h3>
+              <h3 class="type-heading mb-2 text-lg font-medium">{pillar.title}</h3>
               <p>{pillar.description}</p>
             </div>
           ))
         }
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
       <ul class="list-inside list-disc space-y-4">
         <li>{t.security.status.legal}</li>
         <li>{t.security.status.isms}</li>
       </ul>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
       <p class="mb-4">{t.security.aiDescription}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full border-collapse text-left text-sm sm:text-base">
           <thead>
@@ -66,7 +66,7 @@ const t = getTranslations(locale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
       <p class="mb-4">
         {t.security.privacyDescription}<span class="font-medium"><a href={getLocalizedUrl('/privacy', locale)}>{t.security.privacyLinkText}</a></span>{t.security.privacySuffix}
       </p>

--- a/src/pages/ko/404.astro
+++ b/src/pages/ko/404.astro
@@ -17,17 +17,17 @@ const t = getTranslations(currentLocale);
     <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
       <div class="flex flex-col items-start gap-8 sm:gap-10">
         <div class="flex flex-col gap-4 sm:gap-6">
-          <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
+          <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl lg:text-5xl">
             <div>{t["404"].title}</div>
             <div>{t["404"].subtitle}</div>
           </h1>
-          <p class="text-primary-950/70 dark:text-primary-200/70 text-lg sm:text-xl">
+          <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
             {t["404"].description}
           </p>
         </div>
         <a
           href={getLocalizedUrl('/', currentLocale)}
-          class="bg-primary-600 dark:bg-primary-400 hover:bg-primary-700 dark:hover:bg-primary-300 focus-visible:outline-primary-600 dark:focus-visible:outline-primary-400 dark:text-primary-950 inline-flex items-center justify-center rounded-full border border-transparent px-5 py-3 text-base font-medium text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          class="type-action inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
         >
           {t["404"].cta}
         </a>

--- a/src/pages/ko/blog/[...page].astro
+++ b/src/pages/ko/blog/[...page].astro
@@ -42,10 +42,10 @@ const categories = [
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         블로그
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
 
@@ -86,7 +86,7 @@ const categories = [
 
     <!-- Blog Posts Grid -->
     {page.data.length > 0 ? (
-      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
         {page.data.map(post => (
           <PostCard post={post} />
         ))}
@@ -101,7 +101,7 @@ const categories = [
 
     <!-- Pagination Controls -->
     {page.total > page.size && (
-      <div class="mt-12 flex justify-center gap-2">
+      <div class="mt-12 flex flex-wrap items-center justify-center gap-2">
         {page.url.prev && (
           <a
             href={page.url.prev}

--- a/src/pages/ko/blog/[...slug].astro
+++ b/src/pages/ko/blog/[...slug].astro
@@ -64,24 +64,30 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
   <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
-      <ol class="flex items-center space-x-2 text-sm text-stone-600 dark:text-stone-400">
-        <li><a href="/ko" class="hover:text-blue-600 dark:hover:text-blue-400">홈</a></li>
-        <li class="before:content-['/'] before:mx-2"><a href="/ko/blog" class="hover:text-blue-600 dark:hover:text-blue-400">블로그</a></li>
-        <li class="before:content-['/'] before:mx-2"><span class="text-stone-900 dark:text-stone-100">{post.data.title}</span></li>
+      <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
+        <li class="shrink-0"><a href="/ko" class="hover:text-blue-600 dark:hover:text-blue-400">홈</a></li>
+        <li class="flex shrink-0 items-center gap-2">
+          <span aria-hidden="true" class="text-stone-400 dark:text-stone-500">/</span>
+          <a href="/ko/blog" class="hover:text-blue-600 dark:hover:text-blue-400">블로그</a>
+        </li>
+        <li class="hidden min-w-0 flex-1 items-center gap-2 sm:flex">
+          <span aria-hidden="true" class="shrink-0 text-stone-400 dark:text-stone-500">/</span>
+          <span class="truncate text-stone-900 dark:text-stone-100">{post.data.title}</span>
+        </li>
       </ol>
     </nav>
 
     <!-- Header -->
     <header class="mb-8">
-      <div class="mb-4 flex items-center gap-4 text-sm">
+      <div class="mb-5 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
         <CategoryBadge category={post.data.category} />
-        <time datetime={post.data.pubDate.toISOString()} class="text-stone-500 dark:text-stone-400">{formattedPubDate}</time>
-        <span class="text-stone-500 dark:text-stone-400">{readingTime}분 소요</span>
+        <time datetime={post.data.pubDate.toISOString()} class="shrink-0 text-stone-500 dark:text-stone-400">{formattedPubDate}</time>
+        <span class="shrink-0 text-stone-500 dark:text-stone-400">{readingTime}분 소요</span>
       </div>
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">{post.data.title}</h1>
-      <p class="mb-6 text-lg text-stone-600 dark:text-stone-300">{post.data.description}</p>
-      <div class="flex items-center justify-between border-b border-stone-200 pb-6 dark:border-stone-700">
-        <div class="text-sm font-medium text-stone-900 dark:text-stone-100">{post.data.author}</div>
+      <h1 class="mb-4 max-w-3xl text-balance text-3xl font-bold leading-tight text-stone-900 dark:text-stone-100 sm:text-4xl">{post.data.title}</h1>
+      <p class="mb-6 max-w-3xl text-pretty text-lg leading-8 text-stone-600 dark:text-stone-300">{post.data.description}</p>
+      <div class="flex flex-col gap-4 border-b border-stone-200 pb-6 dark:border-stone-700 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0 text-sm font-medium text-stone-900 dark:text-stone-100">{post.data.author}</div>
         <ShareButtons title={post.data.title} url={fullUrl} />
       </div>
     </header>
@@ -124,12 +130,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {prevPost && (
         <a
           href={`/ko/blog/${prevPost.slug.replace('ko/', '')}`}
-          class="group flex flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
+          class="group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             ← 이전 글
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={prevPost.data.title}>
             {prevPost.data.title}
           </span>
         </a>
@@ -138,12 +144,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {nextPost && (
         <a
           href={`/ko/blog/${nextPost.slug.replace('ko/', '')}`}
-          class={`group flex flex-col rounded-lg border border-stone-200 p-4 text-right transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 ${!prevPost ? 'sm:col-start-2' : ''}`}
+          class={`group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 sm:text-right ${!prevPost ? 'sm:col-start-2' : ''}`}
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             다음 글 →
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={nextPost.data.title}>
             {nextPost.data.title}
           </span>
         </a>
@@ -161,7 +167,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     {relatedPosts.length > 0 && (
       <div class="mt-12 border-t border-stone-200 pt-8 dark:border-stone-700">
         <h2 class="mb-6 text-2xl font-bold text-stone-900 dark:text-stone-100">관련 글</h2>
-        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="grid gap-8 md:grid-cols-3">
           {relatedPosts.map(relPost => (
             <PostCard post={relPost} />
           ))}

--- a/src/pages/ko/blog/category/[id]/[...page].astro
+++ b/src/pages/ko/blog/category/[id]/[...page].astro
@@ -56,10 +56,10 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         {categoryLabel}
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -106,7 +106,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
 
     <!-- ページネーション -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <a
           href={page.url.prev ? `/ko/blog/category/${id}/${page.url.prev.replace(/^\//, '')}` : '#'}
           class={`rounded-lg px-3 py-2 text-sm font-medium ${

--- a/src/pages/ko/blog/tags/[tag]/[...page].astro
+++ b/src/pages/ko/blog/tags/[tag]/[...page].astro
@@ -56,15 +56,15 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
         </a>
       </div>
       
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        <span class="inline-flex items-center gap-2">
+      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
+        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
           <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
             #{tag}
           </span>
           태그 글
         </span>
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -102,7 +102,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           <p class="text-sm text-stone-500 dark:text-stone-400">
             다음을 시도해보세요:
           </p>
-          <div class="flex justify-center gap-4">
+          <div class="flex flex-wrap justify-center gap-4">
             <a href="/ko/blog" class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">모든 글 보기</a>
             <a href="/ko/blog" class="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600">인기 태그</a>
           </div>
@@ -112,7 +112,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
 
     <!-- Pagination Navigation -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <!-- Previous Page -->
         <a
           href={page.url.prev || '#'}

--- a/src/pages/ko/contact.astro
+++ b/src/pages/ko/contact.astro
@@ -4,10 +4,9 @@ import ContactChat from '../../components/contact/ContactChat.astro';
 import ContactForm from '../../components/contact/ContactForm.astro';
 import ContactInfo from '../../components/contact/ContactInfo.astro';
 import Heading from '../../components/contact/Heading.astro';
-import NextStep from '../../components/common/NextStep.astro';
 import Layout from '../../layouts/Layout.astro';
 import { CONTACT_CHAT_ENABLED } from '../../config/contact';
-import { getCurrentLocale, getLocalizedUrl, getTranslations } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
@@ -33,10 +32,4 @@ const t = getTranslations(currentLocale);
       </>
     )
   }
-
-  <NextStep
-    heading={t.nextStep.contact.heading}
-    lead={t.nextStep.contact.lead}
-    ctas={[{ label: t.nextStep.contact.ctaLabel, href: getLocalizedUrl('/contact', currentLocale), primary: true }]}
-  />
 </Layout>

--- a/src/pages/ko/legal/tokushoho.astro
+++ b/src/pages/ko/legal/tokushoho.astro
@@ -8,9 +8,10 @@ import Layout from '../../../layouts/Layout.astro';
   description="일본 특정상거래법에 따라 요구되는 법적 공시. 판매자 정보, 결제 조건, 배송 및 반품 정책을 포함합니다."
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <h1 class="mb-10 text-4xl font-medium tracking-tight sm:text-5xl">법적 고지</h1>
+    <h1 class="type-heading mb-10 text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">법적 고지</h1>
 
-    <table class="w-full table-auto border-collapse text-left">
+    <div class="overflow-x-auto">
+    <table class="min-w-[42rem] table-auto border-collapse text-left">
       <caption class="sr-only">일본 특정상거래법에 따라 요구되는 판매자 정보</caption>
       <tbody class="divide-y divide-primary-200 dark:divide-primary-800">
         <tr><th class="py-4 pr-6 align-top font-medium">판매자</th><td class="py-4">Cor Inc. (Cor.inc)</td></tr>
@@ -38,5 +39,6 @@ import Layout from '../../../layouts/Layout.astro';
         <tr><th class="py-4 pr-6 align-top font-medium">중고품 영업법 허가번호</th><td class="py-4">해당 없음</td></tr>
       </tbody>
     </table>
+    </div>
   </div>
 </Layout>

--- a/src/pages/ko/privacy.astro
+++ b/src/pages/ko/privacy.astro
@@ -14,12 +14,22 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
   title={t.meta.privacy.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="flex flex-col gap-4 pb-16 text-center sm:pb-20">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{p.title}</h1>
-      <p class="text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">
+        {currentLocale === 'ja' ? (
+          <>
+            個人情報保護方針
+            <span class="type-keep inline-block">（プライバシー</span>
+            <span class="type-keep inline-block">ポリシー）</span>
+          </>
+        ) : (
+          p.title
+        )}
+      </h1>
+      <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
     </div>
 
-    <div class="text-base leading-[1.8]">
+    <div class="type-copy text-base leading-[1.8]">
       {
         p.note && (
           <p class="mb-6 rounded-md border border-primary-900/15 bg-primary-900/[0.03] px-4 py-3 text-sm dark:border-primary-300/15 dark:bg-primary-300/[0.04]">
@@ -30,7 +40,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
 
       <p class="mb-4">{p.intro}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
           <tbody>
@@ -46,13 +56,13 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
       <p class="mb-6">{p.purposeLead}</p>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(p.purposeGroups) && p.purposeGroups.map((group) => (
             <div>
-              <h3 class="mb-3 text-lg font-medium">{group.title}</h3>
+              <h3 class="type-heading mb-3 text-lg font-medium">{group.title}</h3>
               <dl class="flex flex-col gap-2">
                 {group.lines.map((line) => (
                   <div>
@@ -70,7 +80,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
       {
         Array.isArray(p.sections) && p.sections.map((section) => (
           <section>
-            <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
+            <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
             {Array.isArray(section.body) && section.body.map((para) => <p class="mb-4">{para}</p>)}
             {Array.isArray(section.list) && (
               <ul class="mb-4 list-inside list-disc space-y-3">
@@ -84,7 +94,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         ))
       }
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
       <p class="mb-6">{p.inquiryLead}</p>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
@@ -109,7 +119,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
       {Array.isArray(p.revisionBody) && p.revisionBody.map((para) => <p class="mb-4">{para}</p>)}
 
       <p class="mb-4 mt-8">

--- a/src/pages/ko/security.astro
+++ b/src/pages/ko/security.astro
@@ -12,37 +12,37 @@ const t = getTranslations(locale);
   title={t.meta.security.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="sm:pb-20 flex flex-col gap-4 pb-16 text-center">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{t.security.title}</h1>
-      <p class="text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">{t.security.title}</h1>
+      <p class="type-copy text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
     </div>
-    <div>
+    <div class="type-copy text-base leading-[1.8]">
       <p class="mb-4">
         {t.security.lead}
       </p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(t.security?.pillars) && t.security.pillars.map((pillar) => (
             <div>
-              <h3 class="mb-2 text-lg font-medium">{pillar.title}</h3>
+              <h3 class="type-heading mb-2 text-lg font-medium">{pillar.title}</h3>
               <p>{pillar.description}</p>
             </div>
           ))
         }
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
       <ul class="list-inside list-disc space-y-4">
         <li>{t.security.status.legal}</li>
         <li>{t.security.status.isms}</li>
       </ul>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
       <p class="mb-4">{t.security.aiDescription}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full border-collapse text-left text-sm sm:text-base">
           <thead>
@@ -66,7 +66,7 @@ const t = getTranslations(locale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
       <p class="mb-4">
         {t.security.privacyDescription}<span class="font-medium"><a href={getLocalizedUrl('/privacy', locale)}>{t.security.privacyLinkText}</a></span>{t.security.privacySuffix}
       </p>

--- a/src/pages/legal/tokushoho.astro
+++ b/src/pages/legal/tokushoho.astro
@@ -8,9 +8,10 @@ import Layout from '../../layouts/Layout.astro';
   description="Cor株式会社（Cor.inc）の特定商取引法に基づくビジネス情報開示ページ。所在地・連絡先・支払方法などの法定事項を記載しています。"
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <h1 class="mb-10 text-4xl font-medium tracking-tight sm:text-5xl">特定商取引法に基づく表記</h1>
+    <h1 class="type-heading mb-10 text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">特定商取引法に基づく表記</h1>
 
-    <table class="w-full table-auto border-collapse text-left">
+    <div class="overflow-x-auto">
+    <table class="min-w-[42rem] table-auto border-collapse text-left">
       <tbody class="divide-y divide-primary-200 dark:divide-primary-800">
         <tr><th class="py-4 pr-6 align-top font-medium">販売業者</th><td class="py-4">Cor株式会社（Cor.inc）</td></tr>
         <tr><th class="py-4 pr-6 align-top font-medium">運営責任者</th><td class="py-4">代表取締役&nbsp;寺田&nbsp;康佑</td></tr>
@@ -37,5 +38,6 @@ import Layout from '../../layouts/Layout.astro';
         <tr><th class="py-4 pr-6 align-top font-medium">古物営業法の許可番号</th><td class="py-4">該当なし</td></tr>
       </tbody>
     </table>
+    </div>
   </div>
-</Layout> 
+</Layout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -14,12 +14,22 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
   title={t.meta.privacy.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="flex flex-col gap-4 pb-16 text-center sm:pb-20">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{p.title}</h1>
-      <p class="text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">
+        {currentLocale === 'ja' ? (
+          <>
+            個人情報保護方針
+            <span class="type-keep inline-block">（プライバシー</span>
+            <span class="type-keep inline-block">ポリシー）</span>
+          </>
+        ) : (
+          p.title
+        )}
+      </h1>
+      <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
     </div>
 
-    <div class="text-base leading-[1.8]">
+    <div class="type-copy text-base leading-[1.8]">
       {
         p.note && (
           <p class="mb-6 rounded-md border border-primary-900/15 bg-primary-900/[0.03] px-4 py-3 text-sm dark:border-primary-300/15 dark:bg-primary-300/[0.04]">
@@ -30,7 +40,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
 
       <p class="mb-4">{p.intro}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
           <tbody>
@@ -46,13 +56,13 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
       <p class="mb-6">{p.purposeLead}</p>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(p.purposeGroups) && p.purposeGroups.map((group) => (
             <div>
-              <h3 class="mb-3 text-lg font-medium">{group.title}</h3>
+              <h3 class="type-heading mb-3 text-lg font-medium">{group.title}</h3>
               <dl class="flex flex-col gap-2">
                 {group.lines.map((line) => (
                   <div>
@@ -70,7 +80,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
       {
         Array.isArray(p.sections) && p.sections.map((section) => (
           <section>
-            <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
+            <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
             {Array.isArray(section.body) && section.body.map((para) => <p class="mb-4">{para}</p>)}
             {Array.isArray(section.list) && (
               <ul class="mb-4 list-inside list-disc space-y-3">
@@ -84,7 +94,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         ))
       }
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
       <p class="mb-6">{p.inquiryLead}</p>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
@@ -109,7 +119,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
       {Array.isArray(p.revisionBody) && p.revisionBody.map((para) => <p class="mb-4">{para}</p>)}
 
       <p class="mb-4 mt-8">

--- a/src/pages/security.astro
+++ b/src/pages/security.astro
@@ -12,34 +12,34 @@ const t = getTranslations(currentLocale);
   title={t.meta.security.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="sm:pb-20 flex flex-col gap-4 pb-16 text-center">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{t.security.title}</h1>
-      <p class="text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">{t.security.title}</h1>
+      <p class="type-copy text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
     </div>
-    <div>
-      <p class="mb-4 text-base leading-[1.8]">
+    <div class="type-copy text-base leading-[1.8]">
+      <p class="mb-4">
         {t.security.lead}
       </p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(t.security?.pillars) && t.security.pillars.map((pillar) => (
             <div>
-              <h3 class="mb-2 text-lg font-medium">{pillar.title}</h3>
-              <p class="text-base leading-[1.8]">{pillar.description}</p>
+              <h3 class="type-heading mb-2 text-lg font-medium">{pillar.title}</h3>
+              <p>{pillar.description}</p>
             </div>
           ))
         }
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
-      <p class="mb-4 text-base leading-[1.8]">{t.security.aiDescription}</p>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
+      <p class="mb-4">{t.security.aiDescription}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.governanceTitle}</h2>
-      <p class="mb-4 text-base leading-[1.8]">{t.security.governanceDescription}</p>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.governanceTitle}</h2>
+      <p class="mb-4">{t.security.governanceDescription}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full border-collapse text-left text-sm sm:text-base">
           <thead>
@@ -63,9 +63,9 @@ const t = getTranslations(currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
       <p class="mb-2 text-sm text-primary-950/50 dark:text-primary-200/50">{t.security.privacyLead}</p>
-      <p class="mb-4 text-base leading-[1.8]">
+      <p class="mb-4">
         {t.security.privacyDescription}<span class="font-medium"><a href={getLocalizedUrl('/privacy', currentLocale)}>{t.security.privacyLinkText}</a></span>{t.security.privacySuffix}
       </p>
     </div>

--- a/src/pages/works.astro
+++ b/src/pages/works.astro
@@ -12,14 +12,14 @@ const t = getJaTranslations();
   availableLocales={['ja']}
 >
   <div class="mx-auto max-w-2xl px-4 py-16 sm:px-6 sm:py-20 lg:max-w-7xl lg:px-8">
-    <div class="mx-auto flex max-w-3xl flex-col gap-4 pb-10 text-center sm:pb-12">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{t.works.title}</h1>
-      <p class="text-lg text-primary-950/70 dark:text-primary-200/70">
+    <div class="mx-auto flex max-w-3xl flex-col gap-4 pb-10 text-start sm:pb-12">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">{t.works.title}</h1>
+      <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70">
         {t.works.intro}
       </p>
     </div>
 
-    <p class="mx-auto mb-12 max-w-3xl text-center text-sm text-primary-950/50 dark:text-primary-200/50">
+    <p class="type-copy mx-auto mb-12 max-w-3xl text-start text-sm text-primary-950/50 dark:text-primary-200/50">
       {t.works.note}
     </p>
 
@@ -42,12 +42,12 @@ const t = getJaTranslations();
                   </span>
                 )}
               </div>
-              <h2 class="text-lg font-medium tracking-tight">{item.name}</h2>
-              <p class="text-base text-primary-950/70 dark:text-primary-200/70">
+              <h2 class="type-heading text-lg font-medium tracking-tight">{item.name}</h2>
+              <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">
                 {item.description}
               </p>
               {isNda && (
-                <p class="mt-auto text-xs text-primary-950/50 dark:text-primary-200/50">
+                <p class="type-copy mt-auto text-xs text-primary-950/50 dark:text-primary-200/50">
                   {('note' in item && item.note) || t.works.ndaNote}
                 </p>
               )}
@@ -82,7 +82,7 @@ const t = getJaTranslations();
 
     <div class="mt-10 text-center">
       <a
-        class="inline-flex items-center gap-1 text-sm text-primary-950/60 underline-offset-4 transition hover:text-primary-950 hover:underline dark:text-primary-200/60 dark:hover:text-primary-100"
+        class="type-action inline-flex items-center gap-1 text-sm text-primary-950/60 underline-offset-4 transition hover:text-primary-950 hover:underline dark:text-primary-200/60 dark:hover:text-primary-100"
         href={t.works.moreHref}
       >
         {t.works.moreLabel}

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -150,13 +150,13 @@ const articleJsonLd = {
   <article class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
-      <ol class="flex items-center gap-2 text-sm text-primary-950/60 dark:text-primary-200/60">
+      <ol class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-sm text-primary-950/60 dark:text-primary-200/60">
         <li><a href="/" class="hover:text-primary-950 dark:hover:text-primary-100">ホーム</a></li>
         <li class="before:mx-2 before:content-['/']">
           <a href="/works" class="hover:text-primary-950 dark:hover:text-primary-100">実績</a>
         </li>
-        <li class="before:mx-2 before:content-['/']">
-          <span class="text-primary-950 dark:text-primary-100">{data.title}</span>
+        <li class="hidden min-w-0 before:mx-2 before:content-['/'] sm:block">
+          <span class="block max-w-md truncate text-primary-950 dark:text-primary-100">{data.title}</span>
         </li>
       </ol>
     </nav>
@@ -177,8 +177,8 @@ const articleJsonLd = {
         )}
       </div>
 
-      <h1 class="mb-4 text-4xl font-medium tracking-tight sm:text-5xl">{data.title}</h1>
-      <p class="text-lg text-primary-950/70 dark:text-primary-200/70">{data.summary}</p>
+      <h1 class="type-heading mb-4 text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">{data.title}</h1>
+      <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70">{data.summary}</p>
     </header>
 
     <!-- Hero image -->
@@ -191,8 +191,8 @@ const articleJsonLd = {
     <!-- NDA / 機密案件の注記 -->
     {data.securityNote && (
       <aside class="mb-10 rounded-2xl bg-primary-950/5 p-5 text-sm text-primary-950/70 dark:bg-primary-200/5 dark:text-primary-200/70">
-        <p class="font-medium">※ NDA・機密案件のため一部を抽象化しています。</p>
-        <p class="mt-2">{data.securityNote}</p>
+        <p class="type-copy font-medium">※ NDA・機密案件のため一部を抽象化しています。</p>
+        <p class="type-copy mt-2">{data.securityNote}</p>
       </aside>
     )}
 
@@ -213,7 +213,7 @@ const articleJsonLd = {
     <!-- 関連記事 -->
     {relatedCases.length > 0 && (
       <section class="mt-16 border-t border-primary-950/10 pt-12 dark:border-primary-200/10">
-        <h2 class="mb-8 text-2xl font-medium tracking-tight">関連する実績</h2>
+        <h2 class="type-heading mb-8 text-2xl font-medium tracking-tight">関連する実績</h2>
         <ul class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {relatedCases.map((c) => (
             <li>
@@ -221,10 +221,10 @@ const articleJsonLd = {
                 href={`/works/${c.slug}`}
                 class="group flex h-full flex-col gap-3 rounded-3xl bg-primary-500/10 p-6 shadow-sm transition duration-200 hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:bg-primary-400/10"
               >
-                <h3 class="text-lg font-medium tracking-tight group-hover:text-primary-950 dark:group-hover:text-primary-100">
+                <h3 class="type-heading text-lg font-medium tracking-tight group-hover:text-primary-950 dark:group-hover:text-primary-100">
                   {c.data.title}
                 </h3>
-                <p class="text-sm text-primary-950/70 dark:text-primary-200/70">{c.data.summary}</p>
+                <p class="type-copy text-sm text-primary-950/70 dark:text-primary-200/70">{c.data.summary}</p>
               </a>
             </li>
           ))}

--- a/src/pages/zh/404.astro
+++ b/src/pages/zh/404.astro
@@ -17,17 +17,17 @@ const t = getTranslations(currentLocale);
     <div class="mx-auto max-w-2xl px-4 sm:px-6 lg:max-w-7xl lg:px-8">
       <div class="flex flex-col items-start gap-8 sm:gap-10">
         <div class="flex flex-col gap-4 sm:gap-6">
-          <h1 class="text-4xl font-medium tracking-tight sm:text-5xl lg:text-6xl">
+          <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl lg:text-5xl">
             <div>{t["404"].title}</div>
             <div>{t["404"].subtitle}</div>
           </h1>
-          <p class="text-primary-950/70 dark:text-primary-200/70 text-lg sm:text-xl">
+          <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70 sm:text-xl">
             {t["404"].description}
           </p>
         </div>
         <a
           href={getLocalizedUrl('/', currentLocale)}
-          class="bg-primary-600 dark:bg-primary-400 hover:bg-primary-700 dark:hover:bg-primary-300 focus-visible:outline-primary-600 dark:focus-visible:outline-primary-400 dark:text-primary-950 inline-flex items-center justify-center rounded-full border border-transparent px-5 py-3 text-base font-medium text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+          class="type-action inline-flex items-center justify-center rounded-full border border-transparent bg-primary-600 px-5 py-3 text-base font-medium text-white transition hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300 dark:focus-visible:outline-primary-400"
         >
           {t["404"].cta}
         </a>

--- a/src/pages/zh/blog/[...page].astro
+++ b/src/pages/zh/blog/[...page].astro
@@ -42,10 +42,10 @@ const categories = [
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         博客
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
 
@@ -86,7 +86,7 @@ const categories = [
 
     <!-- Blog Posts Grid -->
     {page.data.length > 0 ? (
-      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
         {page.data.map(post => (
           <PostCard post={post} />
         ))}
@@ -101,7 +101,7 @@ const categories = [
 
     <!-- Pagination Controls -->
     {page.total > page.size && (
-      <div class="mt-12 flex justify-center gap-2">
+      <div class="mt-12 flex flex-wrap items-center justify-center gap-2">
         {page.url.prev && (
           <a
             href={page.url.prev}

--- a/src/pages/zh/blog/[...slug].astro
+++ b/src/pages/zh/blog/[...slug].astro
@@ -64,24 +64,30 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
   <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
-      <ol class="flex items-center space-x-2 text-sm text-stone-600 dark:text-stone-400">
-        <li><a href="/zh" class="hover:text-blue-600 dark:hover:text-blue-400">首页</a></li>
-        <li class="before:content-['/'] before:mx-2"><a href="/zh/blog" class="hover:text-blue-600 dark:hover:text-blue-400">博客</a></li>
-        <li class="before:content-['/'] before:mx-2"><span class="text-stone-900 dark:text-stone-100">{post.data.title}</span></li>
+      <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
+        <li class="shrink-0"><a href="/zh" class="hover:text-blue-600 dark:hover:text-blue-400">首页</a></li>
+        <li class="flex shrink-0 items-center gap-2">
+          <span aria-hidden="true" class="text-stone-400 dark:text-stone-500">/</span>
+          <a href="/zh/blog" class="hover:text-blue-600 dark:hover:text-blue-400">博客</a>
+        </li>
+        <li class="hidden min-w-0 flex-1 items-center gap-2 sm:flex">
+          <span aria-hidden="true" class="shrink-0 text-stone-400 dark:text-stone-500">/</span>
+          <span class="truncate text-stone-900 dark:text-stone-100">{post.data.title}</span>
+        </li>
       </ol>
     </nav>
 
     <!-- Header -->
     <header class="mb-8">
-      <div class="mb-4 flex items-center gap-4 text-sm">
+      <div class="mb-5 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
         <CategoryBadge category={post.data.category} />
-        <time datetime={post.data.pubDate.toISOString()} class="text-stone-500 dark:text-stone-400">{formattedPubDate}</time>
-        <span class="text-stone-500 dark:text-stone-400">{readingTime} 分钟阅读</span>
+        <time datetime={post.data.pubDate.toISOString()} class="shrink-0 text-stone-500 dark:text-stone-400">{formattedPubDate}</time>
+        <span class="shrink-0 text-stone-500 dark:text-stone-400">{readingTime} 分钟阅读</span>
       </div>
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">{post.data.title}</h1>
-      <p class="mb-6 text-lg text-stone-600 dark:text-stone-300">{post.data.description}</p>
-      <div class="flex items-center justify-between border-b border-stone-200 pb-6 dark:border-stone-700">
-        <div class="text-sm font-medium text-stone-900 dark:text-stone-100">{post.data.author}</div>
+      <h1 class="mb-4 max-w-3xl text-balance text-3xl font-bold leading-tight text-stone-900 dark:text-stone-100 sm:text-4xl">{post.data.title}</h1>
+      <p class="mb-6 max-w-3xl text-pretty text-lg leading-8 text-stone-600 dark:text-stone-300">{post.data.description}</p>
+      <div class="flex flex-col gap-4 border-b border-stone-200 pb-6 dark:border-stone-700 sm:flex-row sm:items-center sm:justify-between">
+        <div class="min-w-0 text-sm font-medium text-stone-900 dark:text-stone-100">{post.data.author}</div>
         <ShareButtons title={post.data.title} url={fullUrl} />
       </div>
     </header>
@@ -124,12 +130,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {prevPost && (
         <a
           href={`/zh/blog/${prevPost.slug.replace('zh/', '')}`}
-          class="group flex flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
+          class="group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400"
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             ← 上一篇
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={prevPost.data.title}>
             {prevPost.data.title}
           </span>
         </a>
@@ -138,12 +144,12 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
       {nextPost && (
         <a
           href={`/zh/blog/${nextPost.slug.replace('zh/', '')}`}
-          class={`group flex flex-col rounded-lg border border-stone-200 p-4 text-right transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 ${!prevPost ? 'sm:col-start-2' : ''}`}
+          class={`group flex min-w-0 flex-col rounded-lg border border-stone-200 p-4 transition-colors hover:border-blue-600 dark:border-stone-700 dark:hover:border-blue-400 sm:text-right ${!prevPost ? 'sm:col-start-2' : ''}`}
         >
           <span class="mb-1 text-sm text-stone-500 dark:text-stone-400">
             下一篇 →
           </span>
-          <span class="font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
+          <span class="block truncate text-sm font-medium text-stone-900 group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400 sm:text-base" title={nextPost.data.title}>
             {nextPost.data.title}
           </span>
         </a>
@@ -161,7 +167,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     {relatedPosts.length > 0 && (
       <div class="mt-12 border-t border-stone-200 pt-8 dark:border-stone-700">
         <h2 class="mb-6 text-2xl font-bold text-stone-900 dark:text-stone-100">相关文章</h2>
-        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="grid gap-8 md:grid-cols-3">
           {relatedPosts.map(relPost => (
             <PostCard post={relPost} />
           ))}

--- a/src/pages/zh/blog/category/[id]/[...page].astro
+++ b/src/pages/zh/blog/category/[id]/[...page].astro
@@ -56,10 +56,10 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
   <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
     <!-- Page Header -->
     <div class="mb-12 text-center">
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
+      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
         {categoryLabel}
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -106,7 +106,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
 
     <!-- 分页 -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <a
           href={page.url.prev ? `/zh/blog/category/${id}/${page.url.prev.replace(/^\//, '')}` : '#'}
           class={`rounded-lg px-3 py-2 text-sm font-medium ${

--- a/src/pages/zh/blog/tags/[tag]/[...page].astro
+++ b/src/pages/zh/blog/tags/[tag]/[...page].astro
@@ -56,15 +56,15 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
         </a>
       </div>
       
-      <h1 class="mb-4 text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        <span class="inline-flex items-center gap-2">
+      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
+        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
           <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
             #{tag}
           </span>
           标签文章
         </span>
       </h1>
-      <p class="mx-auto max-w-2xl text-lg text-stone-600 dark:text-stone-300">
+      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
         {pageDescription}
       </p>
       
@@ -102,7 +102,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           <p class="text-sm text-stone-500 dark:text-stone-400">
             您可以：
           </p>
-          <div class="flex justify-center gap-4">
+          <div class="flex flex-wrap justify-center gap-4">
             <a href="/zh/blog" class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">浏览所有文章</a>
             <a href="/zh/blog" class="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600">热门标签</a>
           </div>
@@ -112,7 +112,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
 
     <!-- Pagination Navigation -->
     {page.lastPage > 1 && (
-      <nav class="mt-12 flex items-center justify-center gap-2" aria-label="Pagination">
+      <nav class="mt-12 flex flex-wrap items-center justify-center gap-2" aria-label="Pagination">
         <!-- Previous Page -->
         <a
           href={page.url.prev || '#'}

--- a/src/pages/zh/contact.astro
+++ b/src/pages/zh/contact.astro
@@ -4,10 +4,9 @@ import ContactChat from '../../components/contact/ContactChat.astro';
 import ContactForm from '../../components/contact/ContactForm.astro';
 import ContactInfo from '../../components/contact/ContactInfo.astro';
 import Heading from '../../components/contact/Heading.astro';
-import NextStep from '../../components/common/NextStep.astro';
 import Layout from '../../layouts/Layout.astro';
 import { CONTACT_CHAT_ENABLED } from '../../config/contact';
-import { getCurrentLocale, getLocalizedUrl, getTranslations } from '../../utils/i18n';
+import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
@@ -33,10 +32,4 @@ const t = getTranslations(currentLocale);
       </>
     )
   }
-
-  <NextStep
-    heading={t.nextStep.contact.heading}
-    lead={t.nextStep.contact.lead}
-    ctas={[{ label: t.nextStep.contact.ctaLabel, href: getLocalizedUrl('/contact', currentLocale), primary: true }]}
-  />
 </Layout>

--- a/src/pages/zh/legal/tokushoho.astro
+++ b/src/pages/zh/legal/tokushoho.astro
@@ -8,9 +8,10 @@ import Layout from '../../../layouts/Layout.astro';
   description="根据日本特定商业交易法要求的法律披露。包括卖方信息、付款条件、交付和退货政策。"
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <h1 class="mb-10 text-4xl font-medium tracking-tight sm:text-5xl">法律声明</h1>
+    <h1 class="type-heading mb-10 text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">法律声明</h1>
 
-    <table class="w-full table-auto border-collapse text-left">
+    <div class="overflow-x-auto">
+    <table class="min-w-[42rem] table-auto border-collapse text-left">
       <caption class="sr-only">根据日本特定商业交易法要求的卖方信息</caption>
       <tbody class="divide-y divide-primary-200 dark:divide-primary-800">
         <tr><th class="py-4 pr-6 align-top font-medium">卖方</th><td class="py-4">Cor Inc. (Cor.inc)</td></tr>
@@ -38,5 +39,6 @@ import Layout from '../../../layouts/Layout.astro';
         <tr><th class="py-4 pr-6 align-top font-medium">二手经销商许可证</th><td class="py-4">不适用</td></tr>
       </tbody>
     </table>
+    </div>
   </div>
 </Layout>

--- a/src/pages/zh/privacy.astro
+++ b/src/pages/zh/privacy.astro
@@ -14,12 +14,22 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
   title={t.meta.privacy.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="flex flex-col gap-4 pb-16 text-center sm:pb-20">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{p.title}</h1>
-      <p class="text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">
+        {currentLocale === 'ja' ? (
+          <>
+            個人情報保護方針
+            <span class="type-keep inline-block">（プライバシー</span>
+            <span class="type-keep inline-block">ポリシー）</span>
+          </>
+        ) : (
+          p.title
+        )}
+      </h1>
+      <p class="type-copy text-base text-primary-950/70 dark:text-primary-200/70">{p.lastUpdate}</p>
     </div>
 
-    <div class="text-base leading-[1.8]">
+    <div class="type-copy text-base leading-[1.8]">
       {
         p.note && (
           <p class="mb-6 rounded-md border border-primary-900/15 bg-primary-900/[0.03] px-4 py-3 text-sm dark:border-primary-300/15 dark:bg-primary-300/[0.04]">
@@ -30,7 +40,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
 
       <p class="mb-4">{p.intro}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.businessTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
           <tbody>
@@ -46,13 +56,13 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.purposeTitle}</h2>
       <p class="mb-6">{p.purposeLead}</p>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(p.purposeGroups) && p.purposeGroups.map((group) => (
             <div>
-              <h3 class="mb-3 text-lg font-medium">{group.title}</h3>
+              <h3 class="type-heading mb-3 text-lg font-medium">{group.title}</h3>
               <dl class="flex flex-col gap-2">
                 {group.lines.map((line) => (
                   <div>
@@ -70,7 +80,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
       {
         Array.isArray(p.sections) && p.sections.map((section) => (
           <section>
-            <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
+            <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{section.title}</h2>
             {Array.isArray(section.body) && section.body.map((para) => <p class="mb-4">{para}</p>)}
             {Array.isArray(section.list) && (
               <ul class="mb-4 list-inside list-disc space-y-3">
@@ -84,7 +94,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         ))
       }
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.inquiryTitle}</h2>
       <p class="mb-6">{p.inquiryLead}</p>
       <div class="overflow-x-auto">
         <table class="w-full max-w-full border-collapse text-left text-sm sm:text-base">
@@ -109,7 +119,7 @@ const securityUrl = getLocalizedUrl('/security', currentLocale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{p.revisionTitle}</h2>
       {Array.isArray(p.revisionBody) && p.revisionBody.map((para) => <p class="mb-4">{para}</p>)}
 
       <p class="mb-4 mt-8">

--- a/src/pages/zh/security.astro
+++ b/src/pages/zh/security.astro
@@ -12,37 +12,37 @@ const t = getTranslations(locale);
   title={t.meta.security.title}
 >
   <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
-    <div class="sm:pb-20 flex flex-col gap-4 pb-16 text-center">
-      <h1 class="text-4xl font-medium tracking-tight sm:text-5xl">{t.security.title}</h1>
-      <p class="text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
+    <div class="flex flex-col gap-4 pb-16 text-start sm:pb-20">
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">{t.security.title}</h1>
+      <p class="type-copy text-base italic text-primary-950/70 dark:text-primary-200/70">{t.security.tagline}</p>
     </div>
-    <div>
+    <div class="type-copy text-base leading-[1.8]">
       <p class="mb-4">
         {t.security.lead}
       </p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.pillarsTitle}</h2>
       <div class="flex flex-col gap-8">
         {
           Array.isArray(t.security?.pillars) && t.security.pillars.map((pillar) => (
             <div>
-              <h3 class="mb-2 text-lg font-medium">{pillar.title}</h3>
+              <h3 class="type-heading mb-2 text-lg font-medium">{pillar.title}</h3>
               <p>{pillar.description}</p>
             </div>
           ))
         }
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.statusTitle}</h2>
       <ul class="list-inside list-disc space-y-4">
         <li>{t.security.status.legal}</li>
         <li>{t.security.status.isms}</li>
       </ul>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.aiTitle}</h2>
       <p class="mb-4">{t.security.aiDescription}</p>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.tableTitle}</h2>
       <div class="overflow-x-auto">
         <table class="w-full border-collapse text-left text-sm sm:text-base">
           <thead>
@@ -66,7 +66,7 @@ const t = getTranslations(locale);
         </table>
       </div>
 
-      <h2 class="mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
+      <h2 class="type-heading mb-6 mt-12 text-xl font-medium sm:text-2xl">{t.security.privacyTitle}</h2>
       <p class="mb-4">
         {t.security.privacyDescription}<span class="font-medium"><a href={getLocalizedUrl('/privacy', locale)}>{t.security.privacyLinkText}</a></span>{t.security.privacySuffix}
       </p>

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -544,17 +544,17 @@ const translations = {
     },
     homeHero: {
       kicker: "想像の先まで、共に実装する。",
-      title: "業務の「進まない」を、<br />共に実装で越える。",
+      title: "<span class='nowrap'>「進まない」業務を</span><br /><span class='nowrap'>共に実装で越える。</span>",
       subtitle: "Cor.株式会社は、機密データAI・ローカルLLM・Griftを軸に、<br class='sm:hidden' />課題の整理から設計・実装・運用まで一気通貫で伴走します。<br />御用聞きではなく、必要なら「まだ作らない」選択肢も提案します。",
       support: "機密データAI・ローカルLLM・Griftを軸に、課題の整理から設計・実装・運用まで一気通貫で伴走する、福岡発のAI実装会社です。",
-      primaryCta: "AIで見積もりを試す（30秒・登録不要）",
+      primaryCta: "AI見積もりを試す（30秒）",
       secondaryCta: "無料で相談する",
       philosophyCta: "「きょうそう」の思想を読む",
       trustBadges: ["AI駆動開発 4〜5倍（内部実測）", "ローカルLLM・情報を外に出さない", "セキュリティ体制構築", "福岡発・全国対応"]
     },
     homeChallenges: {
       eyebrow: "01 / あなたの課題",
-      title: "「やりたいのに進まない」業務の壁、一緒に整理しませんか？",
+      title: "進まない業務の壁を、一緒に整理します。",
       items: [
         { title: "老朽化した基幹システムをクラウド化したい", description: "今使っているデータの整理から、クラウド上への移行・運用設計まで一緒に進めます。" },
         { title: "多言語対応のAI受付・チャットを導入したい", description: "音声対応や社内資料で学習したAI、自動で動くAIの仕組みを使って、施設・自治体向けの案内体験を設計します。" },
@@ -629,7 +629,7 @@ const translations = {
       cta: "代表ストーリーを読む"
     },
     finalCta: {
-      title: "業務の「進まない」を、共に実装で越える。",
+      title: "進まない業務を、実装で越える。",
       description: "課題の整理からAIの実装・運用まで、福岡発のAI実装パートナーが一気通貫で伴走します。",
       primary: "AIで見積もりを試す",
       secondary: "まず課題を相談する"
@@ -654,31 +654,31 @@ const translations = {
           industry: "医療",
           theme: "院内データの整理、患者対応、情報セキュリティ、AI活用方針",
           link: "/industries/medical",
-          linkLabel: "医療関連の方はこちら →"
+          linkLabel: "医療向けページ"
         },
         {
           industry: "士業",
           theme: "契約書精査、申請・登記、期日管理、補助金申請",
           link: "/industries/shigyo",
-          linkLabel: "士業関連の方はこちら →"
+          linkLabel: "士業向けページ"
         },
         {
           industry: "建設",
           theme: "労務管理、設計変更、安全確認、ノウハウ継承",
           link: "/industries/construction",
-          linkLabel: "建設関連の方はこちら →"
+          linkLabel: "建設向けページ"
         },
         {
           industry: "製造",
           theme: "目視検査、ノウハウ継承、設備保全、在庫管理",
           link: "/industries/manufacturing",
-          linkLabel: "製造関連の方はこちら →"
+          linkLabel: "製造向けページ"
         },
         {
           industry: "教育",
           theme: "テスト作業、保護者連絡、調査報告、ICT名簿管理",
           link: "/industries/education",
-          linkLabel: "教育関連の方はこちら →"
+          linkLabel: "教育向けページ"
         }
       ]
     },
@@ -745,7 +745,7 @@ const translations = {
       cta: {
         title: "まずは、30秒で参考見積もりを試してみませんか？",
         description: "Griftは、過去の開発実績と市場相場をもとに、参考となる費用・納期・似た事例を出します。相談前の整理にもお使いください。",
-        primary: "GriftでAI見積もりを試す（30秒・登録不要）",
+        primary: "Griftで試す（30秒）",
         secondary: "無料で相談する",
         note: "Griftの結果は相談前の参考見積もりです。正式な金額・納期は要件確認後に確定します。"
       }
@@ -808,7 +808,7 @@ const translations = {
       cta: {
         title: "まずは、30秒で参考見積もりを試してみませんか？",
         description: "Griftは、過去の開発実績と市場相場をもとに、参考となる費用・納期・似た事例を出します。相談前の整理にもお使いください。",
-        primary: "Griftで30秒、AI見積もりを試す",
+        primary: "Griftで試す（30秒）",
         secondary: "無料で相談する",
         note: "Griftの結果は相談前の参考見積もりです。正式な金額・納期は要件確認後に確定します。"
       }
@@ -876,7 +876,7 @@ const translations = {
       cta: {
         title: "まずは、30秒で参考見積もりを試してみませんか？",
         description: "Griftは、過去の開発実績と市場相場をもとに、参考となる費用・納期・似た事例を出します。相談前の整理にもお使いください。",
-        primary: "Griftで30秒、AI見積もりを試す",
+        primary: "Griftで試す（30秒）",
         secondary: "無料で相談する",
         note: "Griftの結果は相談前の参考見積もりです。正式な金額・納期は要件確認後に確定します。"
       }
@@ -939,7 +939,7 @@ const translations = {
       cta: {
         title: "まずは、30秒で参考見積もりを試してみませんか？",
         description: "Griftは、過去の開発実績と市場相場をもとに、参考となる費用・納期・似た事例を出します。相談前の整理にもお使いください。",
-        primary: "Griftで30秒、AI見積もりを試す",
+        primary: "Griftで試す（30秒）",
         secondary: "無料で相談する",
         note: "Griftの結果は相談前の参考見積もりです。正式な金額・納期は要件確認後に確定します。"
       }
@@ -1002,7 +1002,7 @@ const translations = {
       cta: {
         title: "まずは、30秒で参考見積もりを試してみませんか？",
         description: "Griftは、過去の開発実績と市場相場をもとに、参考となる費用・納期・似た事例を出します。相談前の整理にもお使いください。",
-        primary: "Griftで30秒、AI見積もりを試す",
+        primary: "Griftで試す（30秒）",
         secondary: "無料で相談する",
         note: "Griftの結果は相談前の参考見積もりです。正式な金額・納期は要件確認後に確定します。"
       }
@@ -1083,10 +1083,10 @@ const translations = {
     homeBlog: {"eyebrow":"Insights","title":"The \"how\" of AI, in articles.","description":"AI adoption, the safe use of confidential data, how to think about estimates — practical perspectives you can use on the ground.","cta":"See all articles"},
     homeHero: {
       kicker: "Building with you, beyond what you imagined.",
-      title: "Turn \"stuck\" work into <br />things we build together.",
+      title: "<span class='nowrap'>Turn stuck work</span><br />into what we build together.",
       subtitle: "Built around confidential-data AI, local LLMs, and Grift,<br class='sm:hidden' />Cor. Inc. walks with you end to end — from framing the problem to design, build, and operations.<br />We don't just take orders: when it's right, we'll even propose <em>not</em> building yet.",
       support: "A Fukuoka-born AI implementation company that walks with you end to end — from framing the problem to design, build, and operations — built around confidential-data AI, local LLMs, and Grift.",
-      primaryCta: "Try an AI estimate (30 sec, no sign-up)",
+      primaryCta: "Try AI estimate (30 sec)",
       secondaryCta: "Get a free consultation",
       philosophyCta: "Read about our \"Kyousou\" philosophy",
       trustBadges: ["AI-driven development, 4–5× (internal measurement)", "Local LLM — your data stays in", "Secure Infrastructure", "Born in Fukuoka, serving all of Japan"]
@@ -1133,7 +1133,7 @@ const translations = {
         { label: "Initial Assessment", value: "¥100k - ¥300k", note: "Confidential Data AI Assessment" },
         { label: "PoC Development", value: "From 3 Mos / ¥3M", note: "Local LLM & AI Infrastructure PoC" }
       ],
-      cta: "See our work"
+      cta: "Discuss an AI platform PoC"
     },
     securityTrust: {
       title: "Build freely. Protect responsibly.",
@@ -1183,31 +1183,31 @@ const translations = {
           industry: "Healthcare",
           theme: "Organizing clinical data, patient response, information security, AI strategy",
           link: "/industries/medical",
-          linkLabel: "For healthcare →"
+          linkLabel: "Healthcare page"
         },
         {
           industry: "Professional services",
           theme: "Contract review, applications & registration, deadline management, subsidy applications",
           link: "/industries/shigyo",
-          linkLabel: "For professional services →"
+          linkLabel: "Professional services page"
         },
         {
           industry: "Construction",
           theme: "Labor management, design changes, safety checks, passing on know-how",
           link: "/industries/construction",
-          linkLabel: "For construction →"
+          linkLabel: "Construction page"
         },
         {
           industry: "Manufacturing",
           theme: "Visual inspection, passing on know-how, equipment maintenance, inventory management",
           link: "/industries/manufacturing",
-          linkLabel: "For manufacturing →"
+          linkLabel: "Manufacturing page"
         },
         {
           industry: "Education",
           theme: "Test workload, parent communication, surveys & reports, ICT roster management",
           link: "/industries/education",
-          linkLabel: "For education →"
+          linkLabel: "Education page"
         }
       ]
     },
@@ -1274,7 +1274,7 @@ const translations = {
       cta: {
         title: "Why not start with a 30-second reference estimate?",
         description: "Based on our past development track record and market rates, Grift gives you reference cost, timeline, and similar cases. Use it to organize your thoughts before we even talk.",
-        primary: "Try an AI estimate with Grift (30 sec, no sign-up)",
+        primary: "Try Grift in 30 seconds",
         secondary: "Get a free consultation",
         note: "Grift's results are a reference estimate for before we talk. The formal price and timeline are confirmed after we review your requirements."
       }
@@ -1337,7 +1337,7 @@ const translations = {
       cta: {
         title: "Why not start with a 30-second reference estimate?",
         description: "Based on our past development track record and market rates, Grift gives you reference cost, timeline, and similar cases. Use it to organize your thoughts before we even talk.",
-        primary: "Try an AI estimate with Grift in 30 seconds",
+        primary: "Try Grift in 30 seconds",
         secondary: "Get a free consultation",
         note: "Grift's results are a reference estimate for before we talk. The formal price and timeline are confirmed after we review your requirements."
       }
@@ -1405,7 +1405,7 @@ const translations = {
       cta: {
         title: "Why not start with a 30-second reference estimate?",
         description: "Based on our past development track record and market rates, Grift gives you reference cost, timeline, and similar cases. Use it to organize your thoughts before we even talk.",
-        primary: "Try an AI estimate with Grift in 30 seconds",
+        primary: "Try Grift in 30 seconds",
         secondary: "Get a free consultation",
         note: "Grift's results are a reference estimate for before we talk. The formal price and timeline are confirmed after we review your requirements."
       }
@@ -1468,7 +1468,7 @@ const translations = {
       cta: {
         title: "Why not start with a 30-second reference estimate?",
         description: "Based on our past development track record and market rates, Grift gives you reference cost, timeline, and similar cases. Use it to organize your thoughts before we even talk.",
-        primary: "Try an AI estimate with Grift in 30 seconds",
+        primary: "Try Grift in 30 seconds",
         secondary: "Get a free consultation",
         note: "Grift's results are a reference estimate for before we talk. The formal price and timeline are confirmed after we review your requirements."
       }
@@ -1531,7 +1531,7 @@ const translations = {
       cta: {
         title: "Why not start with a 30-second reference estimate?",
         description: "Based on our past development track record and market rates, Grift gives you reference cost, timeline, and similar cases. Use it to organize your thoughts before we even talk.",
-        primary: "Try an AI estimate with Grift in 30 seconds",
+        primary: "Try Grift in 30 seconds",
         secondary: "Get a free consultation",
         note: "Grift's results are a reference estimate for before we talk. The formal price and timeline are confirmed after we review your requirements."
       }
@@ -1617,8 +1617,8 @@ const translations = {
       description1: "After reviewing your inquiry, our representative will contact you within 3 business days. Please wait a moment.",
       description2: "If you do not receive a reply within the above period, there may be a transmission problem. We apologize for the inconvenience, but please contact us again.",
       heading: {
-        title: "Contact Us",
-        description: "For questions, consultations, quote requests, and more, please feel free to contact us."
+        title: "Tell us what is stuck.",
+        description: "No fixed requirements needed. Share the issue, constraints, or idea; we reply within 3 business days."
       },
       form: {
         title: "Feel free to contact us!",
@@ -2155,10 +2155,10 @@ const translations = {
     homeBlog: {"eyebrow":"读物","title":"AI 的「推进方式」，用文章讲清楚。","description":"AI 导入、机密数据的安全运用、报价的思路等，汇总了现场可用的视角。","cta":"查看全部文章"},
     homeHero: {
       kicker: "超越想象，与你共同实现。",
-      title: "让业务中「推进不下去」的难题，<br />与你共同实现、一同跨越。",
+      title: "<span class='nowrap'>让停滞的业务</span><br /><span class='nowrap'>一起实现突破。</span>",
       subtitle: "Cor.株式会社以机密数据AI、本地LLM与Grift为核心，<br class='sm:hidden' />从梳理课题到设计、实现、运维，全程一体化陪伴。<br />我们不做被动接单，必要时也会提出「暂不开发」的选择。",
       support: "以机密数据AI、本地LLM与Grift为核心，从梳理课题到设计、实现、运维全程一体化陪伴，源自福冈的AI实现公司。",
-      primaryCta: "用 AI 试算报价（30 秒・无需注册）",
+      primaryCta: "AI 试算报价（30 秒）",
       secondaryCta: "免费咨询",
       philosophyCta: "阅读「きょうそう」的理念",
       trustBadges: ["AI 驱动开发 4～5 倍（内部实测）", "本地 LLM・信息不外泄", "构建安全体系", "源自福冈・服务全国"]
@@ -2205,7 +2205,7 @@ const translations = {
         { label: "入局诊断", value: "10万〜30万日元", note: "机密数据AI应用诊断" },
         { label: "PoC构建", value: "3个月300万日元起", note: "本地LLM / AI基础设施PoC" }
       ],
-      cta: "查看实绩"
+      cta: "咨询 AI 基础设施 PoC"
     },
     services2026: {
       title: "在事业现场，落地实装 AI（代替人去思考、行动的技术）。",
@@ -2264,31 +2264,31 @@ const translations = {
           industry: "医疗",
           theme: "院内数据整理、患者对应、信息安全、AI 应用方针",
           link: "/industries/medical",
-          linkLabel: "医疗相关请点这里 →"
+          linkLabel: "医疗页面"
         },
         {
           industry: "士业",
           theme: "合同精查、申请・登记、期限管理、补助金申请",
           link: "/industries/shigyo",
-          linkLabel: "士业相关请点这里 →"
+          linkLabel: "士业页面"
         },
         {
           industry: "建设",
           theme: "劳务管理、设计变更、安全确认、经验传承",
           link: "/industries/construction",
-          linkLabel: "建设相关请点这里 →"
+          linkLabel: "建设页面"
         },
         {
           industry: "制造",
           theme: "目视检查、经验传承、设备保全、库存管理",
           link: "/industries/manufacturing",
-          linkLabel: "制造相关请点这里 →"
+          linkLabel: "制造页面"
         },
         {
           industry: "教育",
           theme: "考试作业、家长联络、调查报告、ICT 名册管理",
           link: "/industries/education",
-          linkLabel: "教育相关请点这里 →"
+          linkLabel: "教育页面"
         }
       ]
     },
@@ -2355,7 +2355,7 @@ const translations = {
       cta: {
         title: "先花 30 秒，试算一份参考报价吧？",
         description: "Grift 基于过往开发实绩与市场行情，给出可供参考的费用、工期与相似案例。也可用于咨询前的梳理。",
-        primary: "用 Grift 试算 AI 报价（30 秒・无需注册）",
+        primary: "用 Grift 试算（30 秒）",
         secondary: "免费咨询",
         note: "Grift 的结果是咨询前的参考报价。正式金额与工期将在确认需求后确定。"
       }
@@ -2418,7 +2418,7 @@ const translations = {
       cta: {
         title: "先花 30 秒，试算一份参考报价吧？",
         description: "Grift 基于过往开发实绩与市场行情，给出可供参考的费用、工期与相似案例。也可用于咨询前的梳理。",
-        primary: "用 Grift 花 30 秒试算 AI 报价",
+        primary: "用 Grift 试算（30 秒）",
         secondary: "免费咨询",
         note: "Grift 的结果是咨询前的参考报价。正式金额与工期将在确认需求后确定。"
       }
@@ -2486,7 +2486,7 @@ const translations = {
       cta: {
         title: "先花 30 秒，试算一份参考报价吧？",
         description: "Grift 基于过往开发实绩与市场行情，给出可供参考的费用、工期与相似案例。也可用于咨询前的梳理。",
-        primary: "用 Grift 花 30 秒试算 AI 报价",
+        primary: "用 Grift 试算（30 秒）",
         secondary: "免费咨询",
         note: "Grift 的结果是咨询前的参考报价。正式金额与工期将在确认需求后确定。"
       }
@@ -2549,7 +2549,7 @@ const translations = {
       cta: {
         title: "先花 30 秒，试算一份参考报价吧？",
         description: "Grift 基于过往开发实绩与市场行情，给出可供参考的费用、工期与相似案例。也可用于咨询前的梳理。",
-        primary: "用 Grift 花 30 秒试算 AI 报价",
+        primary: "用 Grift 试算（30 秒）",
         secondary: "免费咨询",
         note: "Grift 的结果是咨询前的参考报价。正式金额与工期将在确认需求后确定。"
       }
@@ -2612,7 +2612,7 @@ const translations = {
       cta: {
         title: "先花 30 秒，试算一份参考报价吧？",
         description: "Grift 基于过往开发实绩与市场行情，给出可供参考的费用、工期与相似案例。也可用于咨询前的梳理。",
-        primary: "用 Grift 花 30 秒试算 AI 报价",
+        primary: "用 Grift 试算（30 秒）",
         secondary: "免费咨询",
         note: "Grift 的结果是咨询前的参考报价。正式金额与工期将在确认需求后确定。"
       }
@@ -2689,8 +2689,8 @@ const translations = {
       description1: "确认咨询内容后，我们将在3个工作日内由负责人联系您。请稍等片刻。",
       description2: "如上述期间内未收到回复，可能存在发送故障。麻烦您再次联系我们。",
       heading: {
-        title: "联系我们",
-        description: "如有疑问、咨询、估价请求等，请随时联系我们。"
+        title: "请告诉我们卡住的地方。",
+        description: "不需要已经整理好的需求。请告诉我们课题、限制或想法，我们将在 3 个工作日内回复。"
       },
       form: {
         title: "请随时咨询！",
@@ -3227,10 +3227,10 @@ const translations = {
     homeBlog: {"eyebrow":"읽을거리","title":"AI의 ‘진행 방법’을, 글로.","description":"AI 도입, 기밀 데이터의 안전한 활용, 견적에 대한 사고방식 등 현장에서 바로 쓸 수 있는 관점을 정리했습니다.","cta":"블로그 전체 보기"},
     homeHero: {
       kicker: "상상 그 너머까지, 함께 구현합니다.",
-      title: "업무의 「진행되지 않음」을, <br />함께 구현으로 넘어섭니다.",
+      title: "<span class='nowrap'>멈춘 업무를</span><br /><span class='nowrap'>함께 구현으로 넘습니다.</span>",
       subtitle: "Cor.주식회사는 기밀 데이터 AI・로컬 LLM・Grift를 축으로,<br class='sm:hidden' />과제 정리부터 설계・구현・운용까지 하나로 이어 동반합니다.<br />단순한 주문 대응이 아니라, 필요하다면 「아직 만들지 않는」 선택지도 제안합니다.",
       support: "기밀 데이터 AI・로컬 LLM・Grift를 축으로, 과제 정리부터 설계・구현・운용까지 하나로 이어 동반하는, 후쿠오카발 AI 구현 회사입니다.",
-      primaryCta: "AI로 견적을 체험하기 (30초・가입 불필요)",
+      primaryCta: "AI 견적 체험하기 (30초)",
       secondaryCta: "무료로 상담하기",
       philosophyCta: "「きょうそう」의 사상을 읽기",
       trustBadges: ["AI 주도 개발 4~5배 (내부 실측)", "로컬 LLM・정보를 외부로 내보내지 않음", "보안 체계 구축", "후쿠오카발・전국 대응"]
@@ -3277,7 +3277,7 @@ const translations = {
         { label: "초기 진단", value: "10만~30만엔", note: "기밀 데이터 AI 활용 진단" },
         { label: "PoC 구축", value: "3개월 300만엔~", note: "로컬 LLM / AI 기반 PoC" }
       ],
-      cta: "실적 보기"
+      cta: "AI 기반 PoC 상담하기"
     },
     securityTrust: {
       title: "자유롭게 만들고, 책임지고 지킵니다.",
@@ -3327,31 +3327,31 @@ const translations = {
           industry: "의료",
           theme: "원내 데이터 정리, 환자 대응, 정보 보안, AI 활용 방침",
           link: "/industries/medical",
-          linkLabel: "의료 관련 분이라면 이쪽 →"
+          linkLabel: "의료 페이지"
         },
         {
           industry: "전문직(士業)",
           theme: "계약서 정밀 검토, 신청・등기, 기일 관리, 보조금 신청",
           link: "/industries/shigyo",
-          linkLabel: "전문직 관련 분이라면 이쪽 →"
+          linkLabel: "전문직 페이지"
         },
         {
           industry: "건설",
           theme: "노무 관리, 설계 변경, 안전 확인, 노하우 계승",
           link: "/industries/construction",
-          linkLabel: "건설 관련 분이라면 이쪽 →"
+          linkLabel: "건설 페이지"
         },
         {
           industry: "제조",
           theme: "육안 검사, 노하우 계승, 설비 보전, 재고 관리",
           link: "/industries/manufacturing",
-          linkLabel: "제조 관련 분이라면 이쪽 →"
+          linkLabel: "제조 페이지"
         },
         {
           industry: "교육",
           theme: "시험 업무, 학부모 연락, 조사 보고, ICT 명부 관리",
           link: "/industries/education",
-          linkLabel: "교육 관련 분이라면 이쪽 →"
+          linkLabel: "교육 페이지"
         }
       ]
     },
@@ -3418,7 +3418,7 @@ const translations = {
       cta: {
         title: "우선 30초 만에 참고 견적을 체험해 보지 않으시겠어요?",
         description: "Grift는 과거 개발 실적과 시장 시세를 바탕으로 참고가 되는 비용・납기・유사 사례를 제시합니다. 상담 전 정리에도 활용해 주세요.",
-        primary: "Grift로 AI 견적 체험하기 (30초・가입 불필요)",
+        primary: "Grift로 견적 체험 (30초)",
         secondary: "무료로 상담하기",
         note: "Grift의 결과는 상담 전 참고 견적입니다. 정식 금액・납기는 요건 확인 후에 확정됩니다."
       }
@@ -3481,7 +3481,7 @@ const translations = {
       cta: {
         title: "우선 30초 만에 참고 견적을 체험해 보지 않으시겠어요?",
         description: "Grift는 과거 개발 실적과 시장 시세를 바탕으로 참고가 되는 비용・납기・유사 사례를 제시합니다. 상담 전 정리에도 활용해 주세요.",
-        primary: "Grift로 30초, AI 견적 체험하기",
+        primary: "Grift로 견적 체험 (30초)",
         secondary: "무료로 상담하기",
         note: "Grift의 결과는 상담 전 참고 견적입니다. 정식 금액・납기는 요건 확인 후에 확정됩니다."
       }
@@ -3549,7 +3549,7 @@ const translations = {
       cta: {
         title: "우선 30초 만에 참고 견적을 체험해 보지 않으시겠어요?",
         description: "Grift는 과거 개발 실적과 시장 시세를 바탕으로 참고가 되는 비용・납기・유사 사례를 제시합니다. 상담 전 정리에도 활용해 주세요.",
-        primary: "Grift로 30초, AI 견적 체험하기",
+        primary: "Grift로 견적 체험 (30초)",
         secondary: "무료로 상담하기",
         note: "Grift의 결과는 상담 전 참고 견적입니다. 정식 금액・납기는 요건 확인 후에 확정됩니다."
       }
@@ -3612,7 +3612,7 @@ const translations = {
       cta: {
         title: "우선 30초 만에 참고 견적을 체험해 보지 않으시겠어요?",
         description: "Grift는 과거 개발 실적과 시장 시세를 바탕으로 참고가 되는 비용・납기・유사 사례를 제시합니다. 상담 전 정리에도 활용해 주세요.",
-        primary: "Grift로 30초, AI 견적 체험하기",
+        primary: "Grift로 견적 체험 (30초)",
         secondary: "무료로 상담하기",
         note: "Grift의 결과는 상담 전 참고 견적입니다. 정식 금액・납기는 요건 확인 후에 확정됩니다."
       }
@@ -3675,7 +3675,7 @@ const translations = {
       cta: {
         title: "우선 30초 만에 참고 견적을 체험해 보지 않으시겠어요?",
         description: "Grift는 과거 개발 실적과 시장 시세를 바탕으로 참고가 되는 비용・납기・유사 사례를 제시합니다. 상담 전 정리에도 활용해 주세요.",
-        primary: "Grift로 30초, AI 견적 체험하기",
+        primary: "Grift로 견적 체험 (30초)",
         secondary: "무료로 상담하기",
         note: "Grift의 결과는 상담 전 참고 견적입니다. 정식 금액・납기는 요건 확인 후에 확정됩니다."
       }
@@ -3761,8 +3761,8 @@ const translations = {
       description1: "문의 내용을 확인한 후, 3 영업일 이내에 담당자가 연락드리겠습니다. 잠시만 기다려 주세요.",
       description2: "위 기간 내에 답변이 없는 경우, 전송 문제의 가능성이 있습니다. 번거로우시겠지만 다시 연락해 주시기 바랍니다.",
       heading: {
-        title: "문의",
-        description: "질문이나 상담, 견적 요청 등 언제든지 문의해 주세요."
+        title: "막힌 부분을 알려 주세요.",
+        description: "정리된 요구사항이 없어도 괜찮습니다. 과제와 제약, 아이디어를 보내 주시면 3영업일 안에 답변드리겠습니다."
       },
       form: {
         title: "언제든지 문의하세요!",
@@ -4120,7 +4120,7 @@ const translations = {
       security: { title: "보안 | Cor.inc", description: "Cor. 주식회사의 정보 보안, ISMS 인증 취득을 위한 체제, 그리고 로컬 퍼스트와 기밀도 등급에 기반한 AI 개발 환경에 대하여." }
     },
     privacy: {
-      title: "개인정보 보호방침(개인정보처리방침)",
+      title: "개인정보처리방침",
       lastUpdate: "기준일: 2026년 6월 13일 (제0.1판·초안)",
       note: "일본어판이 정본입니다. 본 한국어 번역은 참고용입니다.",
       intro: "Cor. 주식회사(이하 「당사」라 합니다.)는 당사가 취급하는 개인정보의 중요성을 인식하고, 개인정보 보호에 관한 법률(이하 「개인정보보호법」이라 합니다.) 및 그 밖의 관계 법령, 가이드라인 및 ISO/IEC 27001:2022(JIS Q 27001:2023)에 기반한 정보보안 관리체계에 따라 고객·종업원·채용 지원자 및 그 밖의 여러분의 개인정보를 적정하게 취급합니다. 당사는 다음의 방침에 기반하여 개인정보를 보호합니다.",
@@ -4299,10 +4299,10 @@ const translations = {
     homeBlog: {"eyebrow":"Lecturas","title":"El «cómo» de la IA, en artículos.","description":"Adopción de IA, uso seguro de datos confidenciales, cómo plantear los presupuestos y más: perspectivas prácticas para el día a día.","cta":"Ver todos los artículos"},
     homeHero: {
       kicker: "Más allá de lo imaginado, lo construimos contigo.",
-      title: "Convertimos lo que «no avanza» <br />en algo que construimos juntos.",
+      title: "Convertimos lo estancado<br />en avances construidos juntos.",
       subtitle: "Cor. Inc. se apoya en IA para datos confidenciales, LLM locales y Grift,<br class='sm:hidden' />y te acompaña de principio a fin: desde ordenar el problema hasta el diseño, la implementación y la operación.<br />No solo recibimos encargos: cuando conviene, también proponemos «aún no construirlo».",
       support: "Una empresa de implementación de IA nacida en Fukuoka que te acompaña de principio a fin —desde ordenar el problema hasta el diseño, la implementación y la operación— apoyada en IA para datos confidenciales, LLM locales y Grift.",
-      primaryCta: "Prueba un presupuesto con IA (30 s · sin registro)",
+      primaryCta: "Presupuesto IA (30 s)",
       secondaryCta: "Consulta gratis",
       philosophyCta: "Lee la filosofía de «Kyousou»",
       trustBadges: ["Desarrollo asistido por IA 4–5× (medición interna)", "LLM local · tu información no sale al exterior", "Infraestructura Segura", "Desde Fukuoka · cobertura nacional"]
@@ -4349,7 +4349,7 @@ const translations = {
         { label: "Evaluación Inicial", value: "100k - 300k yenes", note: "Evaluación de IA para Datos Confidenciales" },
         { label: "Desarrollo de PoC", value: "Desde 3 meses / ¥3M", note: "PoC de LLM Local e Infraestructura de IA" }
       ],
-      cta: "Ver nuestros proyectos"
+      cta: "Consultar un PoC de plataforma IA"
     },
     securityTrust: {
       title: "Crear con libertad. Proteger con responsabilidad.",
@@ -4399,31 +4399,31 @@ const translations = {
           industry: "Medicina",
           theme: "Orden de los datos internos, atención al paciente, seguridad de la información, estrategia de uso de IA",
           link: "/industries/medical",
-          linkLabel: "Si eres del sector médico, por aquí →"
+          linkLabel: "Página de sanidad"
         },
         {
           industry: "Profesiones colegiadas",
           theme: "Revisión de contratos, trámites y registros, control de plazos, solicitud de subvenciones",
           link: "/industries/shigyo",
-          linkLabel: "Si eres profesional colegiado, por aquí →"
+          linkLabel: "Página profesional"
         },
         {
           industry: "Construcción",
           theme: "Gestión laboral, cambios de diseño, comprobaciones de seguridad, transmisión del know-how",
           link: "/industries/construction",
-          linkLabel: "Si eres del sector de la construcción, por aquí →"
+          linkLabel: "Página de construcción"
         },
         {
           industry: "Industria",
           theme: "Inspección visual, transmisión del know-how, mantenimiento de equipos, gestión de inventario",
           link: "/industries/manufacturing",
-          linkLabel: "Si eres del sector industrial, por aquí →"
+          linkLabel: "Página industrial"
         },
         {
           industry: "Educación",
           theme: "Tareas de evaluación, comunicación con familias, informes, gestión de listas en herramientas TIC",
           link: "/industries/education",
-          linkLabel: "Si eres del sector educativo, por aquí →"
+          linkLabel: "Página de educación"
         }
       ]
     },
@@ -4490,7 +4490,7 @@ const translations = {
       cta: {
         title: "Para empezar, ¿por qué no pruebas un presupuesto de referencia en 30 segundos?",
         description: "Grift te ofrece un coste, un plazo y casos similares de referencia a partir de proyectos de desarrollo anteriores y de las tarifas del mercado. Úsalo también para ordenar ideas antes de la consulta.",
-        primary: "Prueba un presupuesto con IA en Grift (30 s · sin registro)",
+        primary: "Probar Grift (30 s)",
         secondary: "Consulta gratis",
         note: "Los resultados de Grift son un presupuesto orientativo previo a la consulta. El importe y el plazo definitivos se fijan tras confirmar los requisitos."
       }
@@ -4553,7 +4553,7 @@ const translations = {
       cta: {
         title: "Para empezar, ¿por qué no pruebas un presupuesto de referencia en 30 segundos?",
         description: "Grift te ofrece un coste, un plazo y casos similares de referencia a partir de proyectos de desarrollo anteriores y de las tarifas del mercado. Úsalo también para ordenar ideas antes de la consulta.",
-        primary: "Prueba un presupuesto con IA en 30 s con Grift",
+        primary: "Probar Grift (30 s)",
         secondary: "Consulta gratis",
         note: "Los resultados de Grift son un presupuesto orientativo previo a la consulta. El importe y el plazo definitivos se fijan tras confirmar los requisitos."
       }
@@ -4621,7 +4621,7 @@ const translations = {
       cta: {
         title: "Para empezar, ¿por qué no pruebas un presupuesto de referencia en 30 segundos?",
         description: "Grift te ofrece un coste, un plazo y casos similares de referencia a partir de proyectos de desarrollo anteriores y de las tarifas del mercado. Úsalo también para ordenar ideas antes de la consulta.",
-        primary: "Prueba un presupuesto con IA en 30 s con Grift",
+        primary: "Probar Grift (30 s)",
         secondary: "Consulta gratis",
         note: "Los resultados de Grift son un presupuesto orientativo previo a la consulta. El importe y el plazo definitivos se fijan tras confirmar los requisitos."
       }
@@ -4684,7 +4684,7 @@ const translations = {
       cta: {
         title: "Para empezar, ¿por qué no pruebas un presupuesto de referencia en 30 segundos?",
         description: "Grift te ofrece un coste, un plazo y casos similares de referencia a partir de proyectos de desarrollo anteriores y de las tarifas del mercado. Úsalo también para ordenar ideas antes de la consulta.",
-        primary: "Prueba un presupuesto con IA en 30 s con Grift",
+        primary: "Probar Grift (30 s)",
         secondary: "Consulta gratis",
         note: "Los resultados de Grift son un presupuesto orientativo previo a la consulta. El importe y el plazo definitivos se fijan tras confirmar los requisitos."
       }
@@ -4747,7 +4747,7 @@ const translations = {
       cta: {
         title: "Para empezar, ¿por qué no pruebas un presupuesto de referencia en 30 segundos?",
         description: "Grift te ofrece un coste, un plazo y casos similares de referencia a partir de proyectos de desarrollo anteriores y de las tarifas del mercado. Úsalo también para ordenar ideas antes de la consulta.",
-        primary: "Prueba un presupuesto con IA en 30 s con Grift",
+        primary: "Probar Grift (30 s)",
         secondary: "Consulta gratis",
         note: "Los resultados de Grift son un presupuesto orientativo previo a la consulta. El importe y el plazo definitivos se fijan tras confirmar los requisitos."
       }
@@ -4833,8 +4833,8 @@ const translations = {
       description1: "Después de confirmar el contenido de la consulta, nos pondremos en contacto con usted dentro de 3 días hábiles. Por favor, espere un momento.",
       description2: "Si no recibe respuesta dentro del período anterior, es posible que haya un problema de envío. Le pedimos que se ponga en contacto con nosotros nuevamente.",
       heading: {
-        title: "Contacto",
-        description: "Para preguntas, consultas, solicitudes de presupuesto, etc., no dude en contactarnos."
+        title: "Cuéntanos dónde se atasca.",
+        description: "No necesitas requisitos cerrados. Comparte el problema, las restricciones o la idea; respondemos en 3 días hábiles."
       },
       form: {
         title: "¡Consulte con confianza!",


### PR DESCRIPTION
## ① なぜ

Closes #163

develop preview で、5言語・複数ページにわたり見出し、CTA、ブログカード、法務/詳細ページの改行と整列が崩れていました。特にモバイルでは助詞だけが残るような孤立改行や、中央揃え/左揃えの方針不在により、文章の意味単位が追いにくい状態でした。

CSS の `text-wrap` だけではブラウザ差や長い翻訳タイトルを吸収できないため、共通タイポグラフィ、文言、コンポーネント幅、ブログテンプレート、検証ハーネスをまとめて揃えています。

## ② どう実装したか

- `Layout.astro` / `BlogLayout.astro` に `.type-heading`, `.type-copy`, `.type-action`, `.type-keep`, `.nowrap` を共通化し、通常ページとブログページの改行制御を統一
- 本文・法務・詳細ページは原則 start/left align、短い hero / CTA のみ中央寄せを許容する方針へ整理
- home / contact / industry / about / works / legal / privacy / security / 404 / blog 系ページの見出し幅・整列・CTA表示を調整
- 5言語のCTA文言と一部長すぎる翻訳タイトルを短縮し、意味単位で折り返しやすく修正
- ブログカード、関連記事、前後記事ナビ、パンくず、目次、リンクカードの折返し/省略/固定高を調整
- Playwright で production build の全HTMLルートを巡回し、実レンダリング行を `Range.getBoundingClientRect()` で測る visual text 監査を追加
- Chromium hard gate の GitHub Actions を追加し、監査結果と代表スクリーンショットを artifact として保存

## ③ 特にレビューしてほしい点

- 中央寄せを残した hero / CTA と、本文・記事・法務ページを start align に寄せた方針がサイト全体のトーンに合っているか
- 長いブログタイトルや前後記事ナビの省略表示が、情報量と可読性のバランスとして妥当か
- `visual-text` の hard fail 条件が、今回の孤立改行・水平 overflow・viewport 逸脱の再発防止として過不足ないか

## ④ テスト・確認方法

- `git diff --check`
- `npm run build`
  - production build 成功
  - 既存の Astro / SVG compressor warning は残存するが exit code は 0
- `npm run verify:visual-text`
  - production build 後に Chromium で全HTMLルートを監査
  - Routes: 430
  - Viewports: `390x844`, `768x1024`, `1440x900`
  - Observations: 1290
  - Failures: 0
  - 代表スクリーンショット: 24枚

ローカル証跡:

- `test-results/visual-text/summary.md`
- `test-results/visual-text/audit.json`
- `test-results/visual-text/evidence/*.png`

CI では `visual-text-audit` artifact に同じ種別の証跡を保存します。Firebase preview URL が発行された後、`PLAYWRIGHT_BASE_URL=<preview-url> npm run test:visual-text` で再検証します。
