### PR TITLE
fix(works): 実績記事パンくずの「/」とタイトルの段違いを修正

### DIFF
--- a/.ai-ci-review-stamp
+++ b/.ai-ci-review-stamp
@@ -1,2 +1,2 @@
-HEAD:2b1a201f
-ci-quality-review:PASSED:2026-07-02T17:39:18Z
+HEAD:9d00781f
+ci-quality-review:PASSED:2026-07-03T10:30:42Z

--- a/.ai-review-stamp
+++ b/.ai-review-stamp
@@ -1,4 +1,4 @@
-HEAD:2b1a201f4f4c1536d2e5cc100aae643d9c69a7ab
-code-reviewer:PASSED:2026-07-02T17:39:18Z
-codex-reviewer:PASSED:2026-07-02T17:39:18Z
-thorough-checklist:PASSED:2026-07-02T17:39:18Z
+HEAD:9d00781fa663aecede7e7b626e8236a60b8eb6f8
+code-reviewer:PASSED:2026-07-03T10:30:42Z
+codex-reviewer:PASSED:2026-07-03T10:30:42Z
+thorough-checklist:PASSED:2026-07-03T10:30:42Z

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -155,7 +155,7 @@ const articleJsonLd = {
         <li class="before:mx-2 before:content-['/']">
           <a href="/works" class="hover:text-primary-950 dark:hover:text-primary-100">実績</a>
         </li>
-        <li class="hidden min-w-0 before:mx-2 before:content-['/'] sm:block">
+        <li class="hidden min-w-0 items-center before:mx-2 before:content-['/'] sm:flex">
           <span class="block max-w-md truncate text-primary-950 dark:text-primary-100">{data.title}</span>
         </li>
       </ol>


### PR DESCRIPTION
## 概要（ユーザー報告の表示バグ）
実績記事ページのパンくず3項目目で、`/`区切りとタイトルの行がずれて表示されていた。

## 原因と修正
タイトルの `span` が `block` のため、`li` の `before:content-['/']` 擬似要素が **span の上の行に押し出され**段違いに。`li` を `sm:flex items-center` に変更（擬似要素がflexアイテムとして同一行に整列）。1クラスの変更。

## 検証
- プレビュー実測: li 高さ20px（1行）・span と同一行・デスクトップ1440で「ホーム / 実績 / タイトル」が1行整列（スクショ確認）
- モバイル: タイトル項目は従来通り非表示（設計どおり）
- visual text audit（記事2ルート）0 failures / build 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)