### PR TITLE
refactor: BlogLayoutのSEO/OGP/構造化データを3コンポーネントに分離 (#209)

### DIFF
--- a/src/components/blog/seo/BlogOgp.astro
+++ b/src/components/blog/seo/BlogOgp.astro
@@ -1,0 +1,32 @@
+---
+// ブログ記事の Open Graph / Twitter Card メタタグ。
+// BlogLayout から抽出（出力は抽出前と同一）。
+import type { Locale } from '../../../utils/i18n';
+
+interface Props {
+  title: string;
+  description: string;
+  ogImage: string;
+  currentLocale: Locale;
+}
+
+const { title, description, ogImage, currentLocale } = Astro.props;
+---
+
+<!-- Open Graph / Facebook -->
+<meta property="og:type" content="article" />
+<meta property="og:url" content={Astro.url} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={ogImage} />
+<meta property="og:locale" content={currentLocale === 'ja' ? 'ja_JP' : 'en_US'} />
+<meta property="og:site_name" content="Cor.inc Blog" />
+
+<!-- Twitter -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@cor_terisuke" />
+<meta name="twitter:creator" content="@cor_terisuke" />
+<meta name="twitter:url" content={Astro.url} />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={ogImage} />

--- a/src/components/blog/seo/BlogSeoMeta.astro
+++ b/src/components/blog/seo/BlogSeoMeta.astro
@@ -1,0 +1,54 @@
+---
+// ブログ記事の基本SEOメタタグ: description/keywords/canonical/RSS/article:*/hreflang。
+// BlogLayout から抽出（出力は抽出前と同一）。
+import type { Locale } from '../../../utils/i18n';
+
+interface Props {
+  description: string;
+  keywords: string;
+  author: string;
+  pubDate: Date;
+  updatedDate?: Date;
+  category: string;
+  tags: string[];
+  currentLocale: Locale;
+}
+
+const { description, keywords, author, pubDate, updatedDate, category, tags, currentLocale } =
+  Astro.props;
+---
+
+<meta name="description" content={description} />
+<meta name="keywords" content={keywords} />
+<meta name="author" content={author} />
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+<meta name="revisit-after" content="7 days" />
+<meta name="format-detection" content="telephone=no" />
+<link rel="sitemap" href="/sitemap-index.xml" />
+<link rel="canonical" href={new URL(Astro.url.pathname, Astro.site)} />
+
+<!-- RSS Feeds -->
+<link rel="alternate" type="application/rss+xml" title="Cor.inc 技術ブログ (日本語)" href="/rss.xml" />
+<link rel="alternate" type="application/rss+xml" title="Cor.inc Tech Blog (English)" href="/en/rss.xml" />
+
+<!-- Article specific meta tags -->
+<meta property="article:published_time" content={pubDate.toISOString()} />
+{updatedDate && <meta property="article:modified_time" content={updatedDate.toISOString()} />}
+<meta property="article:author" content={author} />
+<meta property="article:section" content={category} />
+{tags.map(tag => <meta property="article:tag" content={tag} />)}
+
+<!-- Hreflang tags for bilingual SEO -->
+{currentLocale === 'ja' ? (
+  <>
+    <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="ja" />
+    <link rel="alternate" href={new URL(`/en${Astro.url.pathname}`, Astro.site)} hreflang="en" />
+    <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="x-default" />
+  </>
+) : (
+  <>
+    <link rel="alternate" href={new URL(Astro.url.pathname.replace('/en', '') || '/', Astro.site)} hreflang="ja" />
+    <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="en" />
+    <link rel="alternate" href={new URL(Astro.url.pathname.replace('/en', '') || '/', Astro.site)} hreflang="x-default" />
+  </>
+)}

--- a/src/components/blog/seo/BlogStructuredData.astro
+++ b/src/components/blog/seo/BlogStructuredData.astro
@@ -1,0 +1,165 @@
+---
+// ブログ記事の構造化データ (JSON-LD): Article/BreadcrumbList/WebSite。
+// BlogLayout から抽出（出力は抽出前と同一）。
+import type { Locale } from '../../../utils/i18n';
+
+interface Props {
+  title: string;
+  description: string;
+  keywords: string;
+  author: string;
+  pubDate: Date;
+  updatedDate?: Date;
+  category: string;
+  tags: string[];
+  // CollectionEntry 由来では url/alt が optional 推論になるため緩めに受ける
+  image?: { url?: string; alt?: string };
+  estimatedReadingTime: number;
+  currentLocale: Locale;
+}
+
+const {
+  title,
+  description,
+  keywords,
+  author,
+  pubDate,
+  updatedDate,
+  category,
+  tags,
+  image,
+  estimatedReadingTime,
+  currentLocale,
+} = Astro.props;
+
+// Enhanced structured data for tech blog
+const articleJsonLd = {
+  "@context": "https://schema.org",
+  "@type": category === 'ai' || category === 'engineering' ? "TechArticle" : "BlogPosting",
+  "headline": title,
+  "description": description,
+  "keywords": keywords,
+  "inLanguage": currentLocale,
+  "author": {
+    "@type": "Person",
+    "@id": "https://cor-jp.com/about#terisuke",
+    "name": author,
+    "url": "https://cor-jp.com/about",
+    "sameAs": [
+      "https://twitter.com/cor_terisuke",
+      "https://github.com/Cor-Incorporated",
+      "https://www.linkedin.com/in/teradakousuke/"
+    ]
+  },
+  "datePublished": pubDate.toISOString(),
+  "dateModified": (updatedDate || pubDate).toISOString(),
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://cor-jp.com#organization",
+    "name": "Cor.inc",
+    "url": "https://cor-jp.com",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://cor-jp.com/logo.png",
+      "width": 400,
+      "height": 400
+    },
+    "sameAs": [
+      "https://twitter.com/cor_terisuke",
+      "https://github.com/Cor-Incorporated"
+    ]
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": new URL(Astro.url.pathname, Astro.site).toString()
+  },
+  "url": new URL(Astro.url.pathname, Astro.site).toString(),
+  "articleSection": category,
+  "articleBody": description, // This should ideally be the full content
+  "wordCount": estimatedReadingTime * 200, // Estimated based on reading time
+  "commentCount": 0,
+  "isAccessibleForFree": true,
+  "isFamilyFriendly": true,
+  "copyrightHolder": {
+    "@type": "Organization",
+    "@id": "https://cor-jp.com#organization"
+  },
+  "copyrightYear": new Date(pubDate).getFullYear(),
+  "genre": currentLocale === 'ja' ? "技術ブログ" : "Technology Blog",
+  "about": tags.map(tag => ({
+    "@type": "Thing",
+    "name": tag
+  })),
+  ...(image?.url && {
+    "image": {
+      "@type": "ImageObject",
+      "url": new URL(image.url, Astro.site).toString(),
+      "caption": image.alt,
+      "width": 1200,
+      "height": 630
+    }
+  }),
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": ["h1", "h2", "h3"]
+  }
+};
+
+const breadcrumbJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": currentLocale === 'ja' ? "ホーム" : "Home",
+      "item": `https://cor-jp.com${currentLocale === 'en' ? '/en' : ''}`
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": currentLocale === 'ja' ? "ブログ" : "Blog",
+      "item": `https://cor-jp.com${currentLocale === 'en' ? '/en' : ''}/blog`
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": title
+    }
+  ]
+};
+
+// Website schema with search action for better search engine integration
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "@id": "https://cor-jp.com#website",
+  "name": "Cor.inc",
+  "alternateName": currentLocale === 'ja' ? "コー株式会社" : "Cor Inc",
+  "url": "https://cor-jp.com",
+  "description": currentLocale === 'ja'
+    ? "AI技術でコミュニケーションの未来を創造する技術ブログ"
+    : "Creating the future of communication with AI technology - Tech Blog",
+  "publisher": {
+    "@type": "Organization",
+    "@id": "https://cor-jp.com#organization"
+  },
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": `https://cor-jp.com${currentLocale === 'en' ? '/en' : ''}/blog?search={search_term_string}`
+    },
+    "query-input": "required name=search_term_string"
+  },
+  "inLanguage": [currentLocale],
+  "copyrightHolder": {
+    "@type": "Organization",
+    "@id": "https://cor-jp.com#organization"
+  }
+};
+---
+
+<script type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />
+<script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
+<script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd)} />

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -5,7 +5,10 @@ import Header from '../components/layout/Header.astro';
 import WebVitals from '../components/performance/WebVitals.astro';
 import Analytics from '../components/analytics/Analytics.astro';
 import { getCurrentLocale } from '../utils/i18n';
-import { BLOG_CATEGORIES } from '../config/categories';
+import { generateKeywords, estimateReadingTime } from '../utils/blog-seo';
+import BlogSeoMeta from '../components/blog/seo/BlogSeoMeta.astro';
+import BlogOgp from '../components/blog/seo/BlogOgp.astro';
+import BlogStructuredData from '../components/blog/seo/BlogStructuredData.astro';
 import type { CollectionEntry } from 'astro:content';
 
 type BlogPostData = {
@@ -41,182 +44,9 @@ const { title, description, pubDate, updatedDate, author, category, tags, image,
 // Use auto-generated OGP image if no custom ogImage is set
 const finalOgImage = ogImage || new URL(`/og/${post.slug}.svg`, Astro.site).toString();
 
+const estimatedReadingTime = estimateReadingTime(description);
+const keywords = generateKeywords(tags, category, currentLocale);
 
-// Estimate reading time from description for now
-const estimatedReadingTime = Math.max(1, Math.ceil(description.split(/\s+/).length / 50));
-
-// Generate keywords from title, description, category, and tags
-const generateKeywords = () => {
-  const baseKeywords = tags.slice(); // Copy tags array
-  
-  // Find category configuration
-  const categoryConfig = BLOG_CATEGORIES.find(cat => cat.id === category);
-  
-  // Add category-based keywords dynamically
-  if (categoryConfig) {
-    const categoryKeywords = {
-      'ai': ['AI', '人工知能', 'Artificial Intelligence', 'Machine Learning', 'Deep Learning'],
-      'engineering': ['エンジニアリング', 'Engineering', 'Software Development', '開発', 'プログラミング'],
-      'founder': ['起業', 'Startup', 'Entrepreneur', 'Business', 'スタートアップ'],
-      'lab': ['技術', 'Technology', 'Innovation', '革新', 'Research']
-    };
-    
-    const keywords = categoryKeywords[category as keyof typeof categoryKeywords];
-    if (keywords) {
-      baseKeywords.push(...keywords);
-    }
-  }
-  
-  // Add general tech keywords for all posts
-  baseKeywords.push(...(
-    currentLocale === 'ja' 
-      ? ['技術ブログ', 'テックブログ', 'エンジニア', '開発者', 'プログラマー', 'IT', 'Cor.inc']
-      : ['tech blog', 'technology', 'developer', 'programming', 'software', 'engineering', 'Cor.inc']
-  ));
-  
-  return baseKeywords.flat().slice(0, 15).join(', '); // Limit to 15 keywords
-};
-
-const keywords = generateKeywords();
-
-const formattedPubDate = new Date(pubDate).toLocaleDateString(currentLocale === 'ja' ? 'ja-JP' : 'en-US', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-});
-
-const formattedUpdatedDate = updatedDate ? new Date(updatedDate).toLocaleDateString(currentLocale === 'ja' ? 'ja-JP' : 'en-US', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-}) : null;
-
-// Enhanced structured data for tech blog
-const articleJsonLd = {
-  "@context": "https://schema.org",
-  "@type": category === 'ai' || category === 'engineering' ? "TechArticle" : "BlogPosting",
-  "headline": title,
-  "description": description,
-  "keywords": keywords,
-  "inLanguage": currentLocale,
-  "author": {
-    "@type": "Person",
-    "@id": "https://cor-jp.com/about#terisuke",
-    "name": author,
-    "url": "https://cor-jp.com/about",
-    "sameAs": [
-      "https://twitter.com/cor_terisuke",
-      "https://github.com/Cor-Incorporated",
-      "https://www.linkedin.com/in/teradakousuke/"
-    ]
-  },
-  "datePublished": pubDate.toISOString(),
-  "dateModified": (updatedDate || pubDate).toISOString(),
-  "publisher": {
-    "@type": "Organization",
-    "@id": "https://cor-jp.com#organization",
-    "name": "Cor.inc",
-    "url": "https://cor-jp.com",
-    "logo": {
-      "@type": "ImageObject",
-      "url": "https://cor-jp.com/logo.png",
-      "width": 400,
-      "height": 400
-    },
-    "sameAs": [
-      "https://twitter.com/cor_terisuke",
-      "https://github.com/Cor-Incorporated"
-    ]
-  },
-  "mainEntityOfPage": {
-    "@type": "WebPage",
-    "@id": new URL(Astro.url.pathname, Astro.site).toString()
-  },
-  "url": new URL(Astro.url.pathname, Astro.site).toString(),
-  "articleSection": category,
-  "articleBody": description, // This should ideally be the full content
-  "wordCount": estimatedReadingTime * 200, // Estimated based on reading time
-  "commentCount": 0,
-  "isAccessibleForFree": true,
-  "isFamilyFriendly": true,
-  "copyrightHolder": {
-    "@type": "Organization",
-    "@id": "https://cor-jp.com#organization"
-  },
-  "copyrightYear": new Date(pubDate).getFullYear(),
-  "genre": currentLocale === 'ja' ? "技術ブログ" : "Technology Blog",
-  "about": tags.map(tag => ({
-    "@type": "Thing",
-    "name": tag
-  })),
-  ...(image && {
-    "image": {
-      "@type": "ImageObject",
-      "url": new URL(image.url, Astro.site).toString(),
-      "caption": image.alt,
-      "width": 1200,
-      "height": 630
-    }
-  }),
-  "speakable": {
-    "@type": "SpeakableSpecification",
-    "cssSelector": ["h1", "h2", "h3"]
-  }
-};
-
-const breadcrumbJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {
-      "@type": "ListItem",
-      "position": 1,
-      "name": currentLocale === 'ja' ? "ホーム" : "Home",
-      "item": `https://cor-jp.com${currentLocale === 'en' ? '/en' : ''}`
-    },
-    {
-      "@type": "ListItem",
-      "position": 2,
-      "name": currentLocale === 'ja' ? "ブログ" : "Blog",
-      "item": `https://cor-jp.com${currentLocale === 'en' ? '/en' : ''}/blog`
-    },
-    {
-      "@type": "ListItem",
-      "position": 3,
-      "name": title
-    }
-  ]
-};
-
-// Website schema with search action for better search engine integration
-const websiteJsonLd = {
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  "@id": "https://cor-jp.com#website",
-  "name": "Cor.inc",
-  "alternateName": currentLocale === 'ja' ? "コー株式会社" : "Cor Inc",
-  "url": "https://cor-jp.com",
-  "description": currentLocale === 'ja' 
-    ? "AI技術でコミュニケーションの未来を創造する技術ブログ"
-    : "Creating the future of communication with AI technology - Tech Blog",
-  "publisher": {
-    "@type": "Organization",
-    "@id": "https://cor-jp.com#organization"
-  },
-  "potentialAction": {
-    "@type": "SearchAction",
-    "target": {
-      "@type": "EntryPoint",
-      "urlTemplate": `https://cor-jp.com${currentLocale === 'en' ? '/en' : ''}/blog?search={search_term_string}`
-    },
-    "query-input": "required name=search_term_string"
-  },
-  "inLanguage": [currentLocale],
-  "copyrightHolder": {
-    "@type": "Organization",
-    "@id": "https://cor-jp.com#organization"
-  }
-};
 ---
 
 <!doctype html>
@@ -234,63 +64,38 @@ const websiteJsonLd = {
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="generator" content={Astro.generator} />
-    <meta name="description" content={description} />
-    <meta name="keywords" content={keywords} />
-    <meta name="author" content={author} />
-    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
-    <meta name="revisit-after" content="7 days" />
-    <meta name="format-detection" content="telephone=no" />
-    <link rel="sitemap" href="/sitemap-index.xml" />
-    <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site)} />
-    
-    <!-- RSS Feeds -->
-    <link rel="alternate" type="application/rss+xml" title="Cor.inc 技術ブログ (日本語)" href="/rss.xml" />
-    <link rel="alternate" type="application/rss+xml" title="Cor.inc Tech Blog (English)" href="/en/rss.xml" />
-    
-    <!-- Article specific meta tags -->
-    <meta property="article:published_time" content={pubDate.toISOString()} />
-    {updatedDate && <meta property="article:modified_time" content={updatedDate.toISOString()} />}
-    <meta property="article:author" content={author} />
-    <meta property="article:section" content={category} />
-    {tags.map(tag => <meta property="article:tag" content={tag} />)}
-    
-    <!-- Hreflang tags for bilingual SEO -->
-    {currentLocale === 'ja' ? (
-      <>
-        <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="ja" />
-        <link rel="alternate" href={new URL(`/en${Astro.url.pathname}`, Astro.site)} hreflang="en" />
-        <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="x-default" />
-      </>
-    ) : (
-      <>
-        <link rel="alternate" href={new URL(Astro.url.pathname.replace('/en', '') || '/', Astro.site)} hreflang="ja" />
-        <link rel="alternate" href={new URL(Astro.url.pathname, Astro.site)} hreflang="en" />
-        <link rel="alternate" href={new URL(Astro.url.pathname.replace('/en', '') || '/', Astro.site)} hreflang="x-default" />
-      </>
-    )}
-    
-    <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="article" />
-    <meta property="og:url" content={Astro.url} />
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:image" content={finalOgImage} />
-    <meta property="og:locale" content={currentLocale === 'ja' ? 'ja_JP' : 'en_US'} />
-    <meta property="og:site_name" content="Cor.inc Blog" />
-    
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@cor_terisuke" />
-    <meta name="twitter:creator" content="@cor_terisuke" />
-    <meta name="twitter:url" content={Astro.url} />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content={finalOgImage} />
+    <BlogSeoMeta
+      description={description}
+      keywords={keywords}
+      author={author}
+      pubDate={pubDate}
+      updatedDate={updatedDate}
+      category={category}
+      tags={tags}
+      currentLocale={currentLocale}
+    />
+
+    <BlogOgp
+      title={title}
+      description={description}
+      ogImage={finalOgImage}
+      currentLocale={currentLocale}
+    />
     
     <!-- Structured Data -->
-    <script type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />
-    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
-    <script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd)} />
+    <BlogStructuredData
+      title={title}
+      description={description}
+      keywords={keywords}
+      author={author}
+      pubDate={pubDate}
+      updatedDate={updatedDate}
+      category={category}
+      tags={tags}
+      image={image}
+      estimatedReadingTime={estimatedReadingTime}
+      currentLocale={currentLocale}
+    />
     
     <!-- KaTeX CSS for math rendering -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0tAv4ct0nTaAbDJwPJzDEaqSD1odI+WdtXRGWt2kTvGFasHpSy3SV" crossorigin="anonymous">

--- a/src/utils/blog-seo.ts
+++ b/src/utils/blog-seo.ts
@@ -1,0 +1,40 @@
+import type { Locale } from './i18n';
+import { BLOG_CATEGORIES } from '../config/categories';
+
+// カテゴリ別のSEOキーワード。BlogLayout から抽出（挙動維持）。
+const CATEGORY_KEYWORDS: Record<string, string[]> = {
+  ai: ['AI', '人工知能', 'Artificial Intelligence', 'Machine Learning', 'Deep Learning'],
+  engineering: ['エンジニアリング', 'Engineering', 'Software Development', '開発', 'プログラミング'],
+  founder: ['起業', 'Startup', 'Entrepreneur', 'Business', 'スタートアップ'],
+  lab: ['技術', 'Technology', 'Innovation', '革新', 'Research'],
+};
+
+// タグ + カテゴリ由来 + 共通キーワードから meta keywords 文字列を生成する（最大15語）。
+export function generateKeywords(
+  tags: string[],
+  category: string,
+  currentLocale: Locale
+): string {
+  const baseKeywords = tags.slice();
+
+  const categoryConfig = BLOG_CATEGORIES.find(cat => cat.id === category);
+  if (categoryConfig) {
+    const keywords = CATEGORY_KEYWORDS[category];
+    if (keywords) {
+      baseKeywords.push(...keywords);
+    }
+  }
+
+  baseKeywords.push(
+    ...(currentLocale === 'ja'
+      ? ['技術ブログ', 'テックブログ', 'エンジニア', '開発者', 'プログラマー', 'IT', 'Cor.inc']
+      : ['tech blog', 'technology', 'developer', 'programming', 'software', 'engineering', 'Cor.inc'])
+  );
+
+  return baseKeywords.flat().slice(0, 15).join(', ');
+}
+
+// description の語数からの簡易読了時間（分）。BlogLayout から抽出（挙動維持）。
+export function estimateReadingTime(description: string): number {
+  return Math.max(1, Math.ceil(description.split(/\s+/).length / 50));
+}


### PR DESCRIPTION
## 概要
Refs #209 (受入基準2)。src/layouts/BlogLayout.astro (672行) のSEO関連を3コンポーネントに分離し、477行に削減。

## 変更内容
- `BlogSeoMeta.astro` — description/keywords/canonical/RSS/article:*/hreflang (54行)
- `BlogOgp.astro` — Open Graph + Twitter Card (32行)
- `BlogStructuredData.astro` — JSON-LD 3種 (Article/BreadcrumbList/WebSite) (165行)
- `src/utils/blog-seo.ts` — keywords生成・読了時間推定を純粋関数として抽出 (40行、ユニットテスト可能に)
- テンプレート未使用だった formattedPubDate/formattedUpdatedDate を削除 (各ページ側にローカル定義があり影響なし、grep確認済み)
- `...(image && {...})` → `...(image?.url && {...})`: url欠落時の new URL(undefined) 例外を防ぐ堅牢化 (既存コンテンツでは出力不変)

## 検証
- `npm run build` (astro check含む): 0 errors、437ページ生成
- **HTML出力同一性**: developビルドとの全437ページdiff (アセットハッシュ正規化) で実質同一 (差分2件はコードブロックのShikiハイライト色のみ=ビルド間非決定性)

## レビュー
- code-reviewer: Approve (CRITICAL/HIGH/MEDIUMゼロ)
- Codex CLI (経路A): 指摘なし (「分離により新たに発生した破壊的問題は見つかりませんでした」)

🤖 Generated with [Claude Code](https://claude.com/claude-code)