### PR TITLE
fix: FAQアコーディオンのaria-controls/idを安定生成し欠落を解消

### DIFF
--- a/src/components/products/Faq.astro
+++ b/src/components/products/Faq.astro
@@ -4,11 +4,10 @@ import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
 
-// ja のみ linkHref/linkLabel を持つ設問がある。id は aria-controls 用（現状未使用ロケールあり）。
+// ja のみ linkHref/linkLabel を持つ設問がある。
 type FaqQuestion = {
   question: string;
   answer: string;
-  id?: string;
   linkHref?: string;
   linkLabel?: string;
 };
@@ -38,7 +37,7 @@ const questions: FaqQuestion[] = t.faq.questions;
                   <button
                     type="button"
                     class="group block w-full py-6 text-left transition focus-visible:outline-none"
-                    aria-controls={question.id}
+                    aria-controls={`faq-question-${index}`}
                     x-on:click="open = !open"
                     aria-expanded="false"
                     x-bind:aria-expanded="open.toString()"
@@ -62,7 +61,7 @@ const questions: FaqQuestion[] = t.faq.questions;
                 </dt>
                 <dd 
                   class="pb-6 pr-6 overflow-hidden transition-all duration-300"
-                  id={question.id}
+                  id={`faq-question-${index}`}
                   x-show="open"
                   x-transition:enter="transition ease-out duration-300"
                   x-transition:enter-start="opacity-0 transform scale-95"


### PR DESCRIPTION
## 概要
closes #215

`src/components/products/Faq.astro` が参照する `question.id` は、`src/i18n/locales/{ja,en,zh,ko,es}.json` の `faq.questions[]` のいずれにも存在せず常に `undefined` だった。Astroの仕様上、属性値が `undefined` の場合は属性自体が出力を省略されるため、実ビルド (`dist/index.html` 等) で確認した結果、FAQアコーディオンのボタン7個全てに `aria-controls` 属性が無く、対応する `dd` 要素にも `id` 属性が無い状態になっていた。スクリーンリーダー等の支援技術がトグルボタンと展開パネルの対応関係を取れないアクセシビリティ回帰。

## 修正内容
- `questions.map((question, index) => (...))` の `index` から `faq-question-${index}` を生成し、`aria-controls` と `dd` の `id` に使用するよう変更
- どのロケールJSONにも存在しなかった未使用の `id?: string` 型フィールドを `FaqQuestion` 型定義から削除

## 検証
- `npm run build` 実行、ビルド成功 (437ページ)
- `dist/index.html` (ja) / `dist/en/index.html` / `dist/zh/index.html` / `dist/ko/index.html` / `dist/es/index.html` の全てで、FAQボタン7個分の `aria-controls=faq-question-N` と対応する `dd` の `id=faq-question-N` が1:1で一致することを確認
- code-reviewer エージェントによるレビュー: Approve（CRITICAL/HIGH なし）
- Codex CLI (`codex exec review --base develop`): リグレッションなしと判定

## Test plan
- [x] `npm run build` が成功する
- [x] 5言語全てのビルド済みHTMLで `aria-controls` と `id` が対応していることを確認
- [x] code-reviewer レビュー
- [x] Codex CLI セカンドオピニオン
- [ ] （任意）実ブラウザでFAQアコーディオンの開閉動作とスクリーンリーダーでの読み上げを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)