### PR TITLE
fix: ブログ/実績記事のJSON-LDに</script>インジェクション対策を追加

### DIFF
--- a/src/components/blog/seo/BlogStructuredData.astro
+++ b/src/components/blog/seo/BlogStructuredData.astro
@@ -2,7 +2,7 @@
 // ブログ記事の構造化データ (JSON-LD): Article/BreadcrumbList/WebSite。
 // BlogLayout から抽出（出力は抽出前と同一）。
 import type { Locale } from '../../../utils/i18n';
-import { safeJsonLd } from '../../../utils/blog-seo';
+import { safeJsonLd } from '../../../utils/json-ld';
 
 interface Props {
   title: string;

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -2,7 +2,7 @@
 import { type CollectionEntry, getCollection } from 'astro:content'
 import Layout from '../../layouts/Layout.astro'
 import NextStep from '../../components/common/NextStep.astro'
-import { safeJsonLd } from '../../utils/blog-seo'
+import { safeJsonLd } from '../../utils/json-ld'
 
 // /works/<slug> の実績記事テンプレート。/works（index）とはルートが衝突しない。
 // 本番ビルドでは下書き（isDraft）を除外。dev では下書きも表示して執筆中プレビューを可能にする。

--- a/src/utils/__tests__/json-ld.test.ts
+++ b/src/utils/__tests__/json-ld.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { safeJsonLd } from '../blog-seo';
+import { safeJsonLd } from '../json-ld';
 
 describe('safeJsonLd', () => {
   it('escapes </script> so a <script type="application/ld+json"> block cannot be closed early', () => {

--- a/src/utils/blog-seo.ts
+++ b/src/utils/blog-seo.ts
@@ -38,11 +38,3 @@ export function generateKeywords(
 export function estimateReadingTime(description: string): number {
   return Math.max(1, Math.ceil(description.split(/\s+/).length / 50));
 }
-
-// JSON-LD を <script type="application/ld+json"> に set:html で埋め込む際の安全なシリアライズ。
-// frontmatter (title/description/tags/author 等) に "</script><script>..." のような文字列が
-// 含まれていても、</script> によるタグの早期終了を防ぐ。< は JSON文字列として正当な
-// エスケープなので、JSON-LD を読むパーサー側では通常通り "<" として解釈される。
-export function safeJsonLd(data: unknown): string {
-  return JSON.stringify(data).replace(/</g, '\\u003c');
-}

--- a/src/utils/json-ld.ts
+++ b/src/utils/json-ld.ts
@@ -1,0 +1,7 @@
+// JSON-LD を <script type="application/ld+json"> に set:html で埋め込む際の安全なシリアライズ。
+// frontmatter (title/description/tags/author 等) に "</script><script>..." のような文字列が
+// 含まれていても、</script> によるタグの早期終了を防ぐ。< は JSON文字列として正当な
+// エスケープなので、JSON-LD を読むパーサー側では通常通り "<" として解釈される。
+export function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}


### PR DESCRIPTION
## Summary
- `set:html={JSON.stringify(...)}` でJSON-LDを `<script type="application/ld+json">` に埋め込んでいる箇所は、frontmatter (title/description/tags/author) に `</script><script>...` が含まれると格納型XSSになり得た
- 共通ヘルパー `safeJsonLd()` を `src/utils/json-ld.ts` に追加し、`JSON.stringify()` の結果から `<` を `<` にエスケープして `</script>` による早期終了を防止
- `BlogStructuredData.astro` (article/breadcrumb/website の3箇所) と `works/[...slug].astro` (article) を `safeJsonLd()` に置換
- 既存の `og/[...slug].svg.ts` 系で使われている HTMLエンティティエスケープ方式ではなく `<` 方式を採用: JSONの構造・値の意味を壊さずに済むため
- code-reviewer指摘を受け、`safeJsonLd` はblog専用の `blog-seo.ts` ではなく中立モジュール `src/utils/json-ld.ts` に配置（works側からも利用するため）
- 反証可能性テスト (`src/utils/__tests__/json-ld.test.ts`) を追加: `</script>` 混入ペイロードでの安全性、JSONラウンドトリップの正当性、通常入力への非破壊性、対照実験として素の `JSON.stringify` が脆弱であることを検証

Closes #216

## Test plan
- [x] `npm run build` → 437ページ生成成功
- [x] `npx astro check` → 0 errors
- [x] `npx vitest run src/utils/__tests__/json-ld.test.ts` → 4 tests passed
- [x] ビルド済み dist 配下の実HTML (blog記事1件・works記事1件) から JSON-LD ブロックを抽出し、Pythonの `json.loads` で正常にパースできることを確認
- [x] `Layout.astro` 内の他2箇所のJSON-LD (Organization/FAQPage) は静的ハードコードでfrontmatterを埋め込んでいないため対象外と確認済み
- [x] code-reviewer (初回REQUEST CHANGES → テスト追加・モジュール分離で解消) / Codex CLI (承認、規約リスクなし) の2段階レビュー完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)