### PR TITLE
fix: JSON-LDの</script>インジェクション対策にsafeJsonLdを適用

### DIFF
--- a/src/components/blog/seo/BlogStructuredData.astro
+++ b/src/components/blog/seo/BlogStructuredData.astro
@@ -2,6 +2,7 @@
 // ブログ記事の構造化データ (JSON-LD): Article/BreadcrumbList/WebSite。
 // BlogLayout から抽出（出力は抽出前と同一）。
 import type { Locale } from '../../../utils/i18n';
+import { safeJsonLd } from '../../../utils/blog-seo';
 
 interface Props {
   title: string;
@@ -160,6 +161,6 @@ const websiteJsonLd = {
 };
 ---
 
-<script type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />
-<script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
-<script type="application/ld+json" set:html={JSON.stringify(websiteJsonLd)} />
+<script type="application/ld+json" set:html={safeJsonLd(articleJsonLd)} />
+<script type="application/ld+json" set:html={safeJsonLd(breadcrumbJsonLd)} />
+<script type="application/ld+json" set:html={safeJsonLd(websiteJsonLd)} />

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -2,6 +2,7 @@
 import { type CollectionEntry, getCollection } from 'astro:content'
 import Layout from '../../layouts/Layout.astro'
 import NextStep from '../../components/common/NextStep.astro'
+import { safeJsonLd } from '../../utils/blog-seo'
 
 // /works/<slug> の実績記事テンプレート。/works（index）とはルートが衝突しない。
 // 本番ビルドでは下書き（isDraft）を除外。dev では下書きも表示して執筆中プレビューを可能にする。
@@ -233,5 +234,5 @@ const articleJsonLd = {
     )}
   </article>
 
-  <script type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} is:inline />
+  <script type="application/ld+json" set:html={safeJsonLd(articleJsonLd)} is:inline />
 </Layout>

--- a/src/utils/__tests__/json-ld.test.ts
+++ b/src/utils/__tests__/json-ld.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { safeJsonLd } from '../blog-seo';
+
+describe('safeJsonLd', () => {
+  it('escapes </script> so a <script type="application/ld+json"> block cannot be closed early', () => {
+    const malicious = {
+      headline: 'hello</script><script>alert(document.cookie)</script>world',
+    };
+
+    const serialized = safeJsonLd(malicious);
+
+    // 反証可能性: このアサーションは JSON.stringify をそのまま使うと必ず失敗する
+    // (`</script>` がそのまま出力に残るため)。safeJsonLd が < をエスケープして
+    // 初めて成立する。
+    expect(serialized).not.toContain('</script>');
+    expect(serialized).not.toContain('<script>');
+  });
+
+  it('produces valid JSON that round-trips back to the original value', () => {
+    const malicious = {
+      title: 'hello</script><script>alert(1)</script>world',
+      tags: ['<b>tag</b>', 'normal-tag'],
+    };
+
+    const serialized = safeJsonLd(malicious);
+    const parsed = JSON.parse(serialized);
+
+    expect(parsed).toEqual(malicious);
+  });
+
+  it('leaves ordinary content untouched other than the JSON.stringify formatting', () => {
+    const data = { headline: 'ふつうのタイトル', count: 3, ok: true };
+
+    expect(safeJsonLd(data)).toBe(JSON.stringify(data));
+  });
+
+  it('demonstrates the vulnerability that motivated this fix: raw JSON.stringify is unsafe', () => {
+    const malicious = { headline: 'hello</script><script>alert(1)</script>world' };
+
+    // これは safeJsonLd ではなく素の JSON.stringify の挙動を示す対照実験。
+    // </script> が生の文字列としてそのまま残ることを確認し、safeJsonLd が
+    // 対処している問題が実在することを裏付ける。
+    expect(JSON.stringify(malicious)).toContain('</script>');
+  });
+});

--- a/src/utils/blog-seo.ts
+++ b/src/utils/blog-seo.ts
@@ -38,3 +38,11 @@ export function generateKeywords(
 export function estimateReadingTime(description: string): number {
   return Math.max(1, Math.ceil(description.split(/\s+/).length / 50));
 }
+
+// JSON-LD を <script type="application/ld+json"> に set:html で埋め込む際の安全なシリアライズ。
+// frontmatter (title/description/tags/author 等) に "</script><script>..." のような文字列が
+// 含まれていても、</script> によるタグの早期終了を防ぐ。< は JSON文字列として正当な
+// エスケープなので、JSON-LD を読むパーサー側では通常通り "<" として解釈される。
+export function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}


### PR DESCRIPTION
Closes #216

## 概要
JSON-LD を `<script type="application/ld+json">` に `set:html` で埋め込む際の格納型XSS（`</script>` インジェクション）対策。

## 問題（#216）
frontmatter（title/description/tags/author 等）に `</script><script>alert(1)</script>` のような文字列が含まれる場合、`JSON.stringify` の出力をそのまま `set:html` で埋め込むと、`</script>` により JSON-LD ブロックが早期終了し、続く `<script>` が実行される格納型XSS。記事本文・メタデータが寄稿者・翻訳・AI生成に由来する場合に現実的な脅威。

## 修正
`utils/blog-seo.ts` に `safeJsonLd(data)` を新設（`JSON.stringify` 後に `<` を `<` にエスケープ。JSON としては正当なのでパーサ側で `<` に復元）。`BlogStructuredData.astro` と `works/[...slug].astro` の JSON-LD 出力に適用。

## テスト
`src/utils/__tests__/json-ld.test.ts` に反証可能ユニットテスト（4件）追加。`safeJsonLd` なしでは `</script>` が出力に残りテスト失敗する設計。全52テスト緑。

## 影響範囲
- `src/utils/blog-seo.ts`（+8・`safeJsonLd` 新設）
- `src/components/blog/seo/BlogStructuredData.astro`（+3/-3・適用）
- `src/pages/works/[...slug].astro`（+1/-1・適用）
- `src/utils/__tests__/json-ld.test.ts`（+45・新設）

## レビュー
- code-reviewer: **Approve**（CRITICAL/HIGH ゼロ・適用漏れなし）
- Codex CLI: **No actionable regressions**（ビルド成功 437ページ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)