### PR TITLE
feat(M1-I1): yomimono の collection 対応基盤（news/cases 拡張準備）

### DIFF
--- a/workers/yomimono/src/__tests__/generate.test.ts
+++ b/workers/yomimono/src/__tests__/generate.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { buildNewsMarkdown, buildCasesMarkdown, buildMarkdown } from '../generate';
+import type { NormalizedArticle } from '../validate';
+
+describe('buildNewsMarkdown — news frontmatter 形式検証', () => {
+  const newsArticle: NormalizedArticle = {
+    slug: 'test-news-slug',
+    title: 'テストニュース',
+    description: 'テストニュース説明',
+    category: 'info',
+    tags: ['tag1', 'tag2'],
+    body: '## テスト本文\n\n内容',
+    collection: 'news',
+    publishedAt: '2026-07-08',
+    externalUrl: 'https://example.com/article',
+  };
+
+  it('news: externalUrl あり→frontmatter に externalUrl を含む', () => {
+    const markdown = buildNewsMarkdown(newsArticle, false);
+    expect(markdown).toContain('externalUrl: "https://example.com/article"');
+    expect(markdown).toContain('title: "テストニュース"');
+    expect(markdown).toContain('description: "テストニュース説明"');
+    expect(markdown).toContain('category: "info"');
+    expect(markdown).toContain('publishedAt: 2026-07-08');
+    expect(markdown).toContain('isDraft: false');
+    expect(markdown).toContain('lang: "ja"');
+  });
+
+  it('news: externalUrl なし→frontmatter に externalUrl を含まない', () => {
+    const articleWithoutUrl = { ...newsArticle, externalUrl: undefined };
+    const markdown = buildNewsMarkdown(articleWithoutUrl, false);
+    expect(markdown).not.toContain('externalUrl:');
+    expect(markdown).toContain('title: "テストニュース"');
+  });
+
+  it('news: isDraft パラメータを反映', () => {
+    const markdown = buildNewsMarkdown(newsArticle, true);
+    expect(markdown).toContain('isDraft: true');
+
+    const markdownDraft = buildNewsMarkdown(newsArticle, false);
+    expect(markdownDraft).toContain('isDraft: false');
+  });
+
+  it('news: frontmatter の形式が既存ファイルと整合する', () => {
+    const markdown = buildNewsMarkdown(newsArticle, false);
+    // frontmatter のフィールド順序を確認
+    const lines = markdown.split('\n');
+    const titleIndex = lines.findIndex((line) => line.includes('title:'));
+    const descriptionIndex = lines.findIndex((line) => line.includes('description:'));
+    const publishedAtIndex = lines.findIndex((line) => line.includes('publishedAt:'));
+    const authorIndex = lines.findIndex((line) => line.includes('author:'));
+    const categoryIndex = lines.findIndex((line) => line.includes('category:'));
+    const tagsIndex = lines.findIndex((line) => line.includes('tags:'));
+    const langIndex = lines.findIndex((line) => line.includes('lang:'));
+    const isDraftIndex = lines.findIndex((line) => line.includes('isDraft:'));
+    // 2回目の --- (frontmatter終了) を見つける
+    const endIndex = lines.lastIndexOf('---');
+
+    // 全てのフィールドが frontmatter 内に存在すること
+    expect(titleIndex).toBeGreaterThan(0);
+    expect(descriptionIndex).toBeGreaterThan(0);
+    expect(publishedAtIndex).toBeGreaterThan(0);
+    expect(authorIndex).toBeGreaterThan(0);
+    expect(categoryIndex).toBeGreaterThan(0);
+    expect(tagsIndex).toBeGreaterThan(0);
+    expect(langIndex).toBeGreaterThan(0);
+    expect(isDraftIndex).toBeGreaterThan(0);
+    expect(endIndex).toBeGreaterThan(0);
+
+    // body が frontmatter の後に存在すること
+    const bodyIndex = lines.findIndex((line) => line.includes('## テスト本文'));
+    expect(bodyIndex).toBeGreaterThan(endIndex);
+  });
+});
+
+describe('buildCasesMarkdown — cases frontmatter 形式検証', () => {
+  const casesArticle: NormalizedArticle = {
+    slug: 'test-cases-slug',
+    title: 'テストケース',
+    description: 'テストケース説明',
+    category: 'ai-contract',
+    tags: ['tag1', 'tag2'],
+    body: '## テスト本文\n\n内容',
+    collection: 'cases',
+    publishedAt: '2026-07-08',
+    summary: 'テストケース要約',
+    featured: true,
+  };
+
+  it('cases: frontmatter に summary を含む', () => {
+    const markdown = buildCasesMarkdown(casesArticle, false);
+    expect(markdown).toContain('summary: "テストケース要約"');
+    expect(markdown).toContain('title: "テストケース"');
+    expect(markdown).toContain('description: "テストケース説明"');
+    expect(markdown).toContain('category: "ai-contract"');
+    expect(markdown).toContain('publishedAt: 2026-07-08');
+  });
+
+  it('cases: featured を反映', () => {
+    const markdown = buildCasesMarkdown(casesArticle, false);
+    expect(markdown).toContain('featured: true');
+
+    const articleNotFeatured = { ...casesArticle, featured: false };
+    const markdownNotFeatured = buildCasesMarkdown(articleNotFeatured, false);
+    expect(markdownNotFeatured).toContain('featured: false');
+  });
+
+  it('cases: isDraft パラメータを反映（バグ修正）', () => {
+    const markdownDraft = buildCasesMarkdown(casesArticle, true);
+    expect(markdownDraft).toContain('isDraft: true');
+
+    const markdownPublished = buildCasesMarkdown(casesArticle, false);
+    expect(markdownPublished).toContain('isDraft: false');
+  });
+
+  it('cases: frontmatter の形式が既存ファイルと整合する', () => {
+    const markdown = buildCasesMarkdown(casesArticle, false);
+    const lines = markdown.split('\n');
+
+    // 既存の cases ファイルと整合するフィールド構成
+    expect(markdown).toContain('title: "テストケース"');
+    expect(markdown).toContain('description: "テストケース説明"');
+    expect(markdown).toContain('category: "ai-contract"');
+    expect(markdown).toContain('publishedAt: 2026-07-08');
+    expect(markdown).toContain('summary: "テストケース要約"');
+    expect(markdown).toContain('isDraft: false');
+    expect(markdown).toContain('featured: true');
+
+    // body が frontmatter の後に存在すること
+    const endIndex = lines.lastIndexOf('---');
+    const bodyIndex = lines.findIndex((line) => line.includes('## テスト本文'));
+    expect(bodyIndex).toBeGreaterThan(endIndex);
+  });
+
+  it('cases: isDraft ハードコードバグが修正されている（反証可能）', () => {
+    // もし isDraft がハードコードされていれば、このテストは失敗する
+    const markdownDraft = buildCasesMarkdown(casesArticle, true);
+    const markdownPublished = buildCasesMarkdown(casesArticle, false);
+
+    // isDraft=true と false で結果が異なることを確認
+    expect(markdownDraft).not.toEqual(markdownPublished);
+    expect(markdownDraft).toContain('isDraft: true');
+    expect(markdownPublished).toContain('isDraft: false');
+  });
+});
+
+describe('buildMarkdown — blog との整合性検証', () => {
+  const blogArticle: NormalizedArticle = {
+    slug: 'test-blog-slug',
+    title: 'テストブログ',
+    description: 'テストブログ説明',
+    category: 'ai',
+    tags: ['tag1', 'tag2'],
+    body: '## テスト本文\n\n内容',
+    collection: 'blog',
+  };
+
+  it('blog: isDraft パラメータを反映', () => {
+    const markdownDraft = buildMarkdown(blogArticle, true);
+    const markdownPublished = buildMarkdown(blogArticle, false);
+
+    expect(markdownDraft).toContain('isDraft: true');
+    expect(markdownPublished).toContain('isDraft: false');
+  });
+
+  it('blog: pubDate を使用（publishedAt ではなく）', () => {
+    const markdown = buildMarkdown(blogArticle, false);
+    expect(markdown).toContain('pubDate:');
+    expect(markdown).not.toContain('publishedAt:');
+  });
+});

--- a/workers/yomimono/src/__tests__/github.test.ts
+++ b/workers/yomimono/src/__tests__/github.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { contentDir } from '../github';
+import type { Env } from '../types';
+
+describe('contentDir — コレクション別コンテンツディレクトリパス', () => {
+  const mockEnv: Env = {
+    BLOG_DIR: 'src/content/blog',
+    NEWS_DIR: 'src/content/news',
+    CASES_DIR: 'src/content/cases',
+    GH_OWNER: 'test-owner',
+    GH_REPO: 'test-repo',
+    GH_APP_ID: '123',
+    GH_INSTALLATION_ID: '456',
+    GH_APP_PRIVATE_KEY: 'test-key',
+    PUBLISH_BRANCH: 'main',
+    STYLE_GUIDE_PATH: 'docs/blog-style-guide.md',
+    ANTHROPIC_API_KEY: 'test-key',
+    ACCESS_PASSWORD: 'x'.repeat(20),
+    SESSION_SECRET: 'test-secret',
+    BASE_PATH: '/',
+  };
+
+  it('blog: `${BLOG_DIR}/ja` を返す', () => {
+    const dir = contentDir(mockEnv, 'blog');
+    expect(dir).toBe('src/content/blog/ja');
+  });
+
+  it('news: NEWS_DIR を返す', () => {
+    const dir = contentDir(mockEnv, 'news');
+    expect(dir).toBe('src/content/news');
+  });
+
+  it('cases: CASES_DIR を返す', () => {
+    const dir = contentDir(mockEnv, 'cases');
+    expect(dir).toBe('src/content/cases');
+  });
+
+  it('既定値（省略時）: blog → `${BLOG_DIR}/ja`', () => {
+    const dir = contentDir(mockEnv);
+    expect(dir).toBe('src/content/blog/ja');
+  });
+
+  it('パス結合の形式を確認（スラッシュの重複なし）', () => {
+    const blogDir = contentDir(mockEnv, 'blog');
+    expect(blogDir).not.toContain('//');
+    // src/content/blog/ja (4 segments)
+    expect(blogDir).toMatch(/^[^/]+\/[^/]+\/[^/]+\/[^/]+$/);
+
+    const newsDir = contentDir(mockEnv, 'news');
+    expect(newsDir).not.toContain('//');
+    expect(newsDir).toMatch(/^[^/]+\/[^/]+\/[^/]+$/);
+
+    const casesDir = contentDir(mockEnv, 'cases');
+    expect(casesDir).not.toContain('//');
+    expect(casesDir).toMatch(/^[^/]+\/[^/]+\/[^/]+$/);
+  });
+});

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -3,9 +3,14 @@ import {
   assertSlug,
   normalizeArticle,
   normalizeCategory,
+  normalizeCollection,
   safeImageName,
   sanitizeText,
   SLUG_RE,
+  DATE_RE,
+  VALID_CATEGORIES,
+  NEWS_CATEGORIES,
+  CASES_CATEGORIES,
 } from '../validate';
 
 describe('assertSlug — パストラバーサル防止（CRITICAL修正の要）', () => {
@@ -43,6 +48,188 @@ describe('normalizeCategory', () => {
   it('未知カテゴリは ai にフォールバック', () => {
     expect(normalizeCategory('malicious')).toBe('ai');
     expect(normalizeCategory(undefined)).toBe('ai');
+  });
+});
+
+describe('normalizeCategory — collection 別の category enum 検証', () => {
+  it.each(NEWS_CATEGORIES)('news の正当カテゴリ(%s)はそのまま返す', (c) => {
+    expect(normalizeCategory(c, 'news')).toBe(c);
+  });
+  it.each(CASES_CATEGORIES)('cases の正当カテゴリ(%s)はそのまま返す', (c) => {
+    expect(normalizeCategory(c, 'cases')).toBe(c);
+  });
+  it('news: 未知カテゴリは info にフォールバック（blog の ai ではない＝反証可能）', () => {
+    expect(normalizeCategory('malicious', 'news')).toBe('info');
+    expect(normalizeCategory(undefined, 'news')).toBe('info');
+    // blog の正当値 ai は news では不正 → info へ
+    expect(normalizeCategory('ai', 'news')).toBe('info');
+  });
+  it('cases: 未知カテゴリは grift にフォールバック（blog の ai ではない＝反証可能）', () => {
+    expect(normalizeCategory('malicious', 'cases')).toBe('grift');
+    expect(normalizeCategory(undefined, 'cases')).toBe('grift');
+    expect(normalizeCategory('ai', 'cases')).toBe('grift');
+    expect(normalizeCategory('engineering', 'cases')).toBe('grift');
+  });
+  it('blog/cases/news の enum は互いに素（回帰防止）', () => {
+    const blog = new Set<string>(VALID_CATEGORIES);
+    const news = new Set<string>(NEWS_CATEGORIES);
+    const cases = new Set<string>(CASES_CATEGORIES);
+    for (const c of news) expect(blog.has(c)).toBe(false);
+    for (const c of cases) expect(blog.has(c)).toBe(false);
+    for (const c of cases) expect(news.has(c)).toBe(false);
+  });
+});
+
+describe('normalizeCollection — collection 値の安全な正規化', () => {
+  it.each(['news', 'cases', 'blog'] as const)('正当な collection(%s)はそのまま', (c) => {
+    expect(normalizeCollection(c)).toBe(c);
+  });
+  it.each([undefined, null, '', 'malicious', 'NEWS', 'blog;', {}, 1])(
+    '不正・未知の collection(%s)は blog にフォールバック',
+    (raw) => {
+      expect(normalizeCollection(raw)).toBe('blog');
+    },
+  );
+});
+
+describe('DATE_RE / publishedAt — 日付形式の検証', () => {
+  it.each(['2026-07-08', '2026-01-01', '1999-12-31'])('正当な YYYY-MM-DD(%s)を受理', (d) => {
+    expect(DATE_RE.test(d)).toBe(true);
+  });
+  it.each(['2026-7-8', '2026/07/08', '2026-07-08T00:00:00', 'not-a-date', ''])(
+    '不正な日付形式(%s)を拒否（DATE_RE は書式のみ・暦の妥当性は見ない）',
+    (d) => {
+      expect(DATE_RE.test(d)).toBe(false);
+    },
+  );
+  it('normalizeArticle: 不正な publishedAt は undefined に正規化（反証可能）', () => {
+    const r = normalizeArticle({
+      slug: 'valid-slug',
+      title: 'タイトル',
+      description: '説明',
+      body: '本文',
+      publishedAt: '2026/07/08',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.publishedAt).toBeUndefined();
+  });
+  it('normalizeArticle: 正当な publishedAt は保持', () => {
+    const r = normalizeArticle({
+      slug: 'valid-slug',
+      title: 'タイトル',
+      description: '説明',
+      body: '本文',
+      publishedAt: '2026-07-08',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.publishedAt).toBe('2026-07-08');
+  });
+});
+
+describe('normalizeArticle — news collection', () => {
+  const newsBase = {
+    slug: 'news-slug',
+    title: 'ニュースタイトル',
+    description: 'ニュース説明',
+    category: 'info',
+    tags: ['tag'],
+    body: '## 本文',
+    collection: 'news' as const,
+  };
+
+  it('news: externalUrl あり は body 不要で ok', () => {
+    const r = normalizeArticle(
+      { ...newsBase, body: undefined, externalUrl: 'https://example.com/article' },
+      'news',
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.article.collection).toBe('news');
+      expect(r.article.category).toBe('info');
+      expect(r.article.externalUrl).toBe('https://example.com/article');
+    }
+  });
+
+  it('news: externalUrl なし は body 必須（反証可能: body 不要化バグなら失敗）', () => {
+    const r = normalizeArticle({ ...newsBase, body: undefined }, 'news');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(400);
+      expect(r.error).toContain('body');
+    }
+  });
+
+  it('news: externalUrl なし + body あり は ok', () => {
+    const r = normalizeArticle({ ...newsBase }, 'news');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.body).toBe('## 本文');
+  });
+
+  it('news: カテゴリ info/media/update/event/award のみ受理・それ以外は info へ', () => {
+    const r = normalizeArticle({ ...newsBase, category: 'media' }, 'news');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.category).toBe('media');
+
+    const fallback = normalizeArticle({ ...newsBase, category: 'evil' }, 'news');
+    expect(fallback.ok).toBe(true);
+    if (fallback.ok) expect(fallback.article.category).toBe('info');
+  });
+
+  it('news: slug/title/description 欠落は 400', () => {
+    const r = normalizeArticle({ ...newsBase, slug: undefined }, 'news');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
+});
+
+describe('normalizeArticle — cases collection', () => {
+  const casesBase = {
+    slug: 'cases-slug',
+    title: 'ケースタイトル',
+    description: 'ケース説明',
+    category: 'grift',
+    tags: ['tag'],
+    body: '## 本文',
+    summary: 'ケース要約',
+    collection: 'cases' as const,
+  };
+
+  it('cases: summary あり は ok（反証可能: summary 必須を誤って削除すると失敗）', () => {
+    const r = normalizeArticle({ ...casesBase }, 'cases');
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.article.collection).toBe('cases');
+      expect(r.article.category).toBe('grift');
+      expect(r.article.summary).toBe('ケース要約');
+    }
+  });
+
+  it('cases: summary 欠落は 400（反証可能）', () => {
+    const r = normalizeArticle({ ...casesBase, summary: undefined }, 'cases');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(400);
+      expect(r.error).toContain('summary');
+    }
+  });
+
+  it('cases: カテゴリ grift/confidential-ai/local-llm/ai-contract/tech-culture のみ・それ以外は grift', () => {
+    const r = normalizeArticle({ ...casesBase, category: 'local-llm' }, 'cases');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.category).toBe('local-llm');
+
+    const fallback = normalizeArticle({ ...casesBase, category: 'ai' }, 'cases');
+    expect(fallback.ok).toBe(true);
+    if (fallback.ok) expect(fallback.article.category).toBe('grift');
+  });
+
+  it('cases: body 欠落は 400（news と違い externalUrl でも免除されない）', () => {
+    const r = normalizeArticle(
+      { ...casesBase, body: undefined, externalUrl: 'https://example.com' },
+      'cases',
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('body');
   });
 });
 

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -6,6 +6,8 @@ import {
   normalizeCollection,
   safeImageName,
   sanitizeText,
+  isHttpUrl,
+  isValidCalendarDate,
   SLUG_RE,
   DATE_RE,
   VALID_CATEGORIES,
@@ -126,6 +128,51 @@ describe('DATE_RE / publishedAt — 日付形式の検証', () => {
   });
 });
 
+describe('isValidCalendarDate — 暦日付の厳密検証（P3: DATE_RE 通過後のロールオーバー拒否）', () => {
+  it.each(['2026-07-08', '2026-01-01', '2024-02-29', '2000-02-29'])(
+    '正当な実在日付(%s)は true',
+    (d) => {
+      expect(isValidCalendarDate(d)).toBe(true);
+    },
+  );
+  // DATE_RE は書式のみ検証するため、2026-99-99 は書式は通るが Date で NaN になる。
+  it('2026-99-99 は DATE_RE を通るが Date で NaN → 拒否（反証可能: isValidCalendarDate 未導入なら受理してしまう）', () => {
+    expect(DATE_RE.test('2026-99-99')).toBe(true);
+    expect(isValidCalendarDate('2026-99-99')).toBe(false);
+  });
+  it.each(['2026-02-30', '2026-04-31', '2026-13-01', '2026-00-10', '2026-12-32', '2025-02-29'])(
+    'ロールオーバー日付(%s)は拒否（実在しない暦日）',
+    (d) => {
+      expect(isValidCalendarDate(d)).toBe(false);
+    },
+  );
+  it.each(['2026-7-8', '2026/07/08', 'not-a-date', ''])('書式不正(%s)は拒否', (d) => {
+    expect(isValidCalendarDate(d)).toBe(false);
+  });
+});
+
+describe('normalizeArticle — publishedAt 暦日付検証の反映（P3・反証可能）', () => {
+  const base = {
+    slug: 'valid-slug',
+    title: 'タイトル',
+    description: '説明',
+    body: '本文',
+  };
+  it.each(['2026-99-99', '2026-02-30', '2026-04-31', '2026-13-01'])(
+    '実在しない暦日付(%s)は undefined に正規化（反証可能: isValidCalendarDate未導入なら保持してしまう）',
+    (d) => {
+      const r = normalizeArticle({ ...base, publishedAt: d });
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.article.publishedAt).toBeUndefined();
+    },
+  );
+  it.each(['2026-07-08', '2024-02-29'])('実在日付(%s)は保持', (d) => {
+    const r = normalizeArticle({ ...base, publishedAt: d });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.publishedAt).toBe(d);
+  });
+});
+
 describe('normalizeArticle — news collection', () => {
   const newsBase = {
     slug: 'news-slug',
@@ -179,6 +226,97 @@ describe('normalizeArticle — news collection', () => {
     const r = normalizeArticle({ ...newsBase, slug: undefined }, 'news');
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.status).toBe(400);
+  });
+});
+
+describe('isHttpUrl — http(s) URL のみ受理', () => {
+  it.each([
+    'https://example.com',
+    'http://example.com/article',
+    'HTTPS://COR-JP.COM/',
+    'https://blog.cor-jp.com/posts/foo',
+  ])('正当な http(s) URL(%s)は true', (u) => {
+    expect(isHttpUrl(u)).toBe(true);
+  });
+  it.each([
+    'not-a-url',
+    '',
+    'javascript:alert(1)',
+    'data:text/html,<script>',
+    'ftp://example.com',
+    '//example.com',
+    'mailto:foo@example.com',
+  ])('不正URL(%s)は false', (u) => {
+    expect(isHttpUrl(u)).toBe(false);
+  });
+});
+
+describe('normalizeArticle — news externalUrl 検証（P2・反証可能）', () => {
+  const newsBase = {
+    slug: 'news-slug',
+    title: 'ニュースタイトル',
+    description: 'ニュース説明',
+    category: 'info',
+    tags: ['tag'],
+    body: '## 本文',
+  };
+
+  it.each(['', '   ', 'not-a-url', 'javascript:alert(1)', 'ftp://example.com'])(
+    '不正URL(%s)は externalUrl 無し扱い → body 必須（反証可能: 検証未導入なら body 無しで受理してしまう）',
+    (badUrl) => {
+      const r = normalizeArticle(
+        { ...newsBase, body: undefined, externalUrl: badUrl },
+        'news',
+      );
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.status).toBe(400);
+        expect(r.error).toContain('body');
+      }
+    },
+  );
+
+  it.each([
+    'https://example.com/article',
+    'http://example.com',
+    'https://cor-jp.com/news/foo',
+  ])('有効 http(s) URL(%s)は body 不要で受理', (goodUrl) => {
+    const r = normalizeArticle(
+      { ...newsBase, body: undefined, externalUrl: goodUrl },
+      'news',
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.externalUrl).toBe(goodUrl);
+  });
+
+  it('不正URL + body あり は受理（externalUrl は undefined に正規化）', () => {
+    const r = normalizeArticle(
+      { ...newsBase, externalUrl: 'not-a-url' },
+      'news',
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.externalUrl).toBeUndefined();
+  });
+
+  it('sanitize（```除去）後も有効 http(s) URL なら body 不要で受理・コードフェンスは除去', () => {
+    // sanitizeText は ``` を除去するので、``https://...`` のような入力が URL として生き残るか確認
+    const r = normalizeArticle(
+      { ...newsBase, body: undefined, externalUrl: '```https://example.com```' },
+      'news',
+    );
+    // sanitize 後は "https://example.com" になるため有効 URL として受理するはず
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.externalUrl).toBe('https://example.com');
+  });
+
+  it('sanitize → http(s) 検証の順序: sanitize で空になったら body 必須（反証可能）', () => {
+    // externalUrl がコードフェンスのみで構成される場合、sanitize 後に空になる → body 必須
+    const r = normalizeArticle(
+      { ...newsBase, body: undefined, externalUrl: '``````' },
+      'news',
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('body');
   });
 });
 

--- a/workers/yomimono/src/generate.ts
+++ b/workers/yomimono/src/generate.ts
@@ -1,7 +1,7 @@
 import { callClaude, parseLastJsonBlock } from './anthropic';
 import { scanForViolations } from './guardrails';
-import { assertSlug, normalizeCategory } from './validate';
-import type { Env, Article, Violation, TopicCandidate } from './types';
+import { assertSlug, normalizeCategory, type NormalizedArticle } from './validate';
+import type { Collection, Env, Article, Violation, TopicCandidate } from './types';
 
 // ④ 記事生成: 社長の文体メモリ（blog-style-guide.md）で1本書く。
 // 戻り値に guardrail 検査結果を含め、⑤レビューで人が確認できるようにする。
@@ -71,7 +71,7 @@ ${recentTitles.map((t) => `- ${t}`).join('\n')}
 }
 
 // JST基準の日付で frontmatter を組む（公開時はこの markdown をそのままコミット）。
-export function buildMarkdown(article: Article, isDraft = false): string {
+export function buildMarkdown(article: NormalizedArticle | Article, isDraft = false): string {
   const today = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const frontmatter = [
     '---',
@@ -89,4 +89,46 @@ export function buildMarkdown(article: Article, isDraft = false): string {
   // body 先頭が `---` だと frontmatter 区切りと紛らわしいので、先頭の区切り行のみ除去する。
   const body = article.body.replace(/^(?:\s*\n)*-{3,}[ \t]*(?:\n|$)/, '');
   return `${frontmatter}${body}\n`;
+}
+
+// news コレクション用の markdown を生成する。
+export function buildNewsMarkdown(article: NormalizedArticle, isDraft = false): string {
+  const publishedAt = article.publishedAt || new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const frontmatter = [
+    '---',
+    `title: ${JSON.stringify(article.title)}`,
+    `description: ${JSON.stringify(article.description)}`,
+    `publishedAt: ${publishedAt}`,
+    'author: "Terisuke"',
+    `category: "${article.category}"`,
+    `tags: ${JSON.stringify(article.tags)}`,
+    'lang: "ja"',
+    `isDraft: ${isDraft}`,
+  ];
+  if (article.externalUrl) {
+    frontmatter.push(`externalUrl: ${JSON.stringify(article.externalUrl)}`);
+  }
+  frontmatter.push('---', '');
+  const body = article.body.replace(/^(?:\s*\n)*-{3,}[ \t]*(?:\n|$)/, '');
+  return `${frontmatter.join('\n')}${body}\n`;
+}
+
+// cases コレクション用の markdown を生成する。
+export function buildCasesMarkdown(article: NormalizedArticle, isDraft = false): string {
+  const publishedAt = article.publishedAt || new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const frontmatter = [
+    '---',
+    `title: ${JSON.stringify(article.title)}`,
+    `description: ${JSON.stringify(article.description)}`,
+    `category: "${article.category}"`,
+    `tags: ${JSON.stringify(article.tags)}`,
+    `publishedAt: ${publishedAt}`,
+    `summary: ${JSON.stringify(article.summary || '')}`,
+    'isDraft: false',
+    `featured: ${article.featured || false}`,
+    '---',
+    '',
+  ];
+  const body = article.body.replace(/^(?:\s*\n)*-{3,}[ \t]*(?:\n|$)/, '');
+  return `${frontmatter.join('\n')}${body}\n`;
 }

--- a/workers/yomimono/src/generate.ts
+++ b/workers/yomimono/src/generate.ts
@@ -124,7 +124,7 @@ export function buildCasesMarkdown(article: NormalizedArticle, isDraft = false):
     `tags: ${JSON.stringify(article.tags)}`,
     `publishedAt: ${publishedAt}`,
     `summary: ${JSON.stringify(article.summary || '')}`,
-    'isDraft: false',
+    `isDraft: ${isDraft}`,
     `featured: ${article.featured || false}`,
     '---',
     '',

--- a/workers/yomimono/src/github.ts
+++ b/workers/yomimono/src/github.ts
@@ -1,7 +1,7 @@
 import { Octokit } from '@octokit/core';
 import { createAppAuth } from '@octokit/auth-app';
 import { assertSlug, safeImageName } from './validate';
-import type { Env } from './types';
+import type { Collection, Env } from './types';
 
 export function makeOctokit(env: Env): Octokit {
   return new Octokit({
@@ -28,6 +28,13 @@ function base64ToUtf8(b64: string): string {
   return new TextDecoder().decode(bytes);
 }
 
+// コレクションに応じたコンテンツディレクトリを返す。
+export function contentDir(env: Env, collection: Collection = 'blog'): string {
+  if (collection === 'news') return env.NEWS_DIR;
+  if (collection === 'cases') return env.CASES_DIR;
+  return `${env.BLOG_DIR}/ja`;
+}
+
 // リポジトリのファイル内容を取得（文体ガイド等）。
 export async function getFileContent(env: Env, octokit: Octokit, path: string): Promise<string> {
   const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
@@ -41,13 +48,18 @@ export async function getFileContent(env: Env, octokit: Octokit, path: string): 
   return base64ToUtf8(data.content);
 }
 
-// 既存記事のスラッグ一覧（重複テーマ回避用）。BLOG_DIR/ja のファイル名から .md を除いたもの。
-export async function listArticleSlugs(env: Env, octokit: Octokit): Promise<string[]> {
+// 既存記事のスラッグ一覧（重複テーマ回避用）。コレクションディレクトリのファイル名から .md を除いたもの。
+export async function listArticleSlugs(
+  env: Env,
+  octokit: Octokit,
+  collection: Collection = 'blog',
+): Promise<string[]> {
   try {
+    const dir = contentDir(env, collection);
     const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
       owner: env.GH_OWNER,
       repo: env.GH_REPO,
-      path: `${env.BLOG_DIR}/ja`,
+      path: dir,
       ref: env.PUBLISH_BRANCH,
     });
     const items = res.data as Array<{ name: string; type: string }>;
@@ -69,9 +81,11 @@ export async function commitArticle(
   slug: string,
   markdown: string,
   authorEmail: string,
+  collection: Collection = 'blog',
 ): Promise<{ committed: true; path: string; commitUrl: string }> {
   assertSlug(slug); // 多重防御: 呼び出し側でも検証済みだが、ここでもパストラバーサルを必ず弾く
-  const path = `${env.BLOG_DIR}/ja/${slug}.md`;
+  const dir = contentDir(env, collection);
+  const path = `${dir}/${slug}.md`;
 
   // 重複 slug チェック（既存なら拒否）
   try {
@@ -90,13 +104,14 @@ export async function commitArticle(
   // 公開コミットは public 履歴に残るため、メールアドレス全体は埋め込まない（収集対策）。
   // ローカル部のみ記録し、完全なメールはサーバー側ログにのみ残す。
   const author = authorEmail.split('@')[0];
-  console.log('yomimono publish:', { slug, authorEmail });
+  const prefix = collection === 'news' ? 'news' : collection === 'cases' ? 'case' : 'post';
+  console.log(`yomimono publish (${collection}):`, { slug, authorEmail });
   const res = await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
     owner: env.GH_OWNER,
     repo: env.GH_REPO,
     path,
     branch: env.PUBLISH_BRANCH,
-    message: `post(yomimono): ${slug}（公開: ${author}）`,
+    message: `${prefix}(yomimono): ${slug}（公開: ${author}）`,
     content: utf8ToBase64(markdown),
   });
   const data = res.data as { commit?: { html_url?: string } };

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -1,4 +1,4 @@
-import type { Env } from './types';
+import type { Collection, Env } from './types';
 import {
   verifySession,
   checkPassword,
@@ -6,7 +6,7 @@ import {
   clearSessionCookie,
 } from './session';
 import { collectTopics } from './collect';
-import { generateArticle, buildMarkdown } from './generate';
+import { generateArticle, buildMarkdown, buildNewsMarkdown, buildCasesMarkdown } from './generate';
 import { scanForViolations } from './guardrails';
 import { makeOctokit, getFileContent, commitArticle, commitImage, listArticleSlugs } from './github';
 import { sanitizeText, normalizeArticle, type ArticleInput } from './validate';
@@ -216,8 +216,9 @@ export default {
 
       // 既存記事スラッグ一覧（重複テーマ回避用）
       if (req.method === 'GET' && path === '/api/recent') {
+        const collection = (url.searchParams.get('collection') || 'blog') as Collection;
         const octokit = makeOctokit(env);
-        const slugs = await listArticleSlugs(env, octokit);
+        const slugs = await listArticleSlugs(env, octokit, collection);
         return json({ slugs });
       }
 
@@ -293,9 +294,19 @@ export default {
       if (req.method === 'POST' && path === '/api/validate') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
-        const norm = normalizeArticle(body.article as ArticleInput | undefined);
+        const collection = (body.collection || 'blog') as Collection;
+        const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
-        const violations = scanForViolations(buildMarkdown(norm.article));
+        const normalized = norm.article;
+        let markdown: string;
+        if (collection === 'news') {
+          markdown = buildNewsMarkdown(normalized);
+        } else if (collection === 'cases') {
+          markdown = buildCasesMarkdown(normalized);
+        } else {
+          markdown = buildMarkdown(normalized);
+        }
+        const violations = scanForViolations(markdown);
         return json({ violations });
       }
 
@@ -303,17 +314,25 @@ export default {
       if (req.method === 'POST' && path === '/api/publish') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
-        const norm = normalizeArticle(body.article as ArticleInput | undefined);
+        const collection = (body.collection || 'blog') as Collection;
+        const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
         const normalized = norm.article;
         // 公開直前にもう一度ガードレールを通す（最終防衛線）
-        const markdown = buildMarkdown(normalized);
+        let markdown: string;
+        if (collection === 'news') {
+          markdown = buildNewsMarkdown(normalized);
+        } else if (collection === 'cases') {
+          markdown = buildCasesMarkdown(normalized);
+        } else {
+          markdown = buildMarkdown(normalized);
+        }
         const violations = scanForViolations(markdown);
         if (violations.length > 0) {
           return json({ error: 'ガードレール違反のため公開を中止しました', violations }, 422);
         }
         const octokit = makeOctokit(env);
-        const result = await commitArticle(env, octokit, normalized.slug, markdown, EDITOR);
+        const result = await commitArticle(env, octokit, normalized.slug, markdown, EDITOR, collection);
         return json(result);
       }
 

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -9,7 +9,7 @@ import { collectTopics } from './collect';
 import { generateArticle, buildMarkdown, buildNewsMarkdown, buildCasesMarkdown } from './generate';
 import { scanForViolations } from './guardrails';
 import { makeOctokit, getFileContent, commitArticle, commitImage, listArticleSlugs } from './github';
-import { sanitizeText, normalizeArticle, type ArticleInput } from './validate';
+import { sanitizeText, normalizeArticle, normalizeCollection, type ArticleInput } from './validate';
 import { HUB_HTML } from './ui-hub';
 import { AI_HTML } from './ui-ai';
 import { MANUAL_HTML } from './ui-manual';
@@ -216,7 +216,7 @@ export default {
 
       // 既存記事スラッグ一覧（重複テーマ回避用）
       if (req.method === 'GET' && path === '/api/recent') {
-        const collection = (url.searchParams.get('collection') || 'blog') as Collection;
+        const collection = normalizeCollection(url.searchParams.get('collection'));
         const octokit = makeOctokit(env);
         const slugs = await listArticleSlugs(env, octokit, collection);
         return json({ slugs });
@@ -294,7 +294,7 @@ export default {
       if (req.method === 'POST' && path === '/api/validate') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
-        const collection = (body.collection || 'blog') as Collection;
+        const collection = normalizeCollection(body.collection);
         const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
         const normalized = norm.article;
@@ -314,7 +314,7 @@ export default {
       if (req.method === 'POST' && path === '/api/publish') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
-        const collection = (body.collection || 'blog') as Collection;
+        const collection = normalizeCollection(body.collection);
         const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
         const normalized = norm.article;

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -6,7 +6,8 @@ import {
   clearSessionCookie,
 } from './session';
 import { collectTopics } from './collect';
-import { generateArticle, buildMarkdown, buildNewsMarkdown, buildCasesMarkdown } from './generate';
+// buildNewsMarkdown は M3 で news を有効化する際に再import（基盤関数は generate.ts に維持）
+import { generateArticle, buildMarkdown, buildCasesMarkdown } from './generate';
 import { scanForViolations } from './guardrails';
 import { makeOctokit, getFileContent, commitArticle, commitImage, listArticleSlugs } from './github';
 import { sanitizeText, normalizeArticle, normalizeCollection, type ArticleInput } from './validate';
@@ -19,6 +20,9 @@ import { STYLE_GUIDE_FALLBACK } from './style-guide';
 // コミット attribution（Access廃止で個人メールが無いため固定名）。
 const EDITOR = 'yomimono';
 const MIN_PASSWORD_LEN = 16;
+// news コレクションは M3 まで公開準備中: エンドポイント層で一時拒否するメッセージ。
+// 基盤関数（normalizeArticle('news') / buildNewsMarkdown / contentDir / commitArticle）は維持・M3 で有効化。
+const NEWS_NOT_READY_MSG = 'news collection は現在準備中です（blog/cases のみ利用可能）';
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -217,6 +221,10 @@ export default {
       // 既存記事スラッグ一覧（重複テーマ回避用）
       if (req.method === 'GET' && path === '/api/recent') {
         const collection = normalizeCollection(url.searchParams.get('collection'));
+        // news は M3 まで公開準備中: エンドポイント層で空配列を返す（基盤関数は維持・M3 で有効化）
+        if (collection === 'news') {
+          return json({ slugs: [] });
+        }
         const octokit = makeOctokit(env);
         const slugs = await listArticleSlugs(env, octokit, collection);
         return json({ slugs });
@@ -295,13 +303,16 @@ export default {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const collection = normalizeCollection(body.collection);
+        // news は M3 まで一時拒否（基盤関数は維持・M3 で有効化）
+        if (collection === 'news') {
+          return json({ error: NEWS_NOT_READY_MSG }, 400);
+        }
         const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
         const normalized = norm.article;
+        // news は上で拒否済みなので blog/cases のみ（buildNewsMarkdown は M3 で有効化）
         let markdown: string;
-        if (collection === 'news') {
-          markdown = buildNewsMarkdown(normalized);
-        } else if (collection === 'cases') {
+        if (collection === 'cases') {
           markdown = buildCasesMarkdown(normalized);
         } else {
           markdown = buildMarkdown(normalized);
@@ -315,14 +326,17 @@ export default {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const collection = normalizeCollection(body.collection);
+        // news は M3 まで一時拒否（基盤関数は維持・M3 で有効化）
+        if (collection === 'news') {
+          return json({ error: NEWS_NOT_READY_MSG }, 400);
+        }
         const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
         const normalized = norm.article;
         // 公開直前にもう一度ガードレールを通す（最終防衛線）
+        // news は上で拒否済みなので blog/cases のみ（buildNewsMarkdown は M3 で有効化）
         let markdown: string;
-        if (collection === 'news') {
-          markdown = buildNewsMarkdown(normalized);
-        } else if (collection === 'cases') {
+        if (collection === 'cases') {
           markdown = buildCasesMarkdown(normalized);
         } else {
           markdown = buildMarkdown(normalized);

--- a/workers/yomimono/src/types.ts
+++ b/workers/yomimono/src/types.ts
@@ -1,3 +1,5 @@
+export type Collection = 'blog' | 'news' | 'cases';
+
 export interface Env {
   // secrets
   ANTHROPIC_API_KEY: string;
@@ -8,6 +10,8 @@ export interface Env {
   GH_APP_ID: string;
   GH_INSTALLATION_ID: string;
   BLOG_DIR: string;
+  NEWS_DIR: string;
+  CASES_DIR: string;
   PUBLISH_BRANCH: string;
   STYLE_GUIDE_PATH: string;
   BASE_PATH: string; // マウントプレフィックス（例 /blog-admin）。cor-jp.com/blog-admin* ルートで使用。空ならルート直下。

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -104,7 +104,7 @@ export function head(title: string): string {
   );
 }
 
-export function header(active: 'hub' | 'ai' | 'manual'): string {
+export function header(active: 'hub' | 'ai' | 'manual' | 'manual-news' | 'manual-cases'): string {
   const link = (href: string, label: string, key: string) =>
     '<a href="__BASE__' + href + '"' + (active === key ? ' class="on"' : '') + '>' + label + '</a>';
   return (

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -5,6 +5,11 @@ export const VALID_CATEGORIES = ['ai', 'engineering', 'founder', 'lab'] as const
 export const NEWS_CATEGORIES = ['info', 'media', 'update', 'event', 'award'] as const;
 export const CASES_CATEGORIES = ['grift', 'confidential-ai', 'local-llm', 'ai-contract', 'tech-culture'] as const;
 
+// コレクション別の厳密な category 型。normalizeCategory の戻り型と NormalizedArticle で使用。
+export type BlogCategory = (typeof VALID_CATEGORIES)[number];
+export type NewsCategory = (typeof NEWS_CATEGORIES)[number];
+export type CaseCategory = (typeof CASES_CATEGORIES)[number];
+
 // slug は公開パス `src/content/blog/ja/<slug>.md` に直結する。
 // `/`・`.`・`..` を弾き、記事ディレクトリ外への書き込み（パストラバーサル）を防ぐ。
 export function assertSlug(slug: string): void {
@@ -13,6 +18,11 @@ export function assertSlug(slug: string): void {
   }
 }
 
+// collection 引数で戻り型を厳密化（blog 規定で BlogCategory、news で NewsCategory、cases で CaseCategory）。
+// 呼び出し側はリテラルで collection を渡す必要がある（Collection 全体だとオーバーロード未解決で型エラー）。
+export function normalizeCategory(c: string | undefined, collection?: 'blog'): BlogCategory;
+export function normalizeCategory(c: string | undefined, collection: 'news'): NewsCategory;
+export function normalizeCategory(c: string | undefined, collection: 'cases'): CaseCategory;
 export function normalizeCategory(c: string | undefined, collection: Collection = 'blog'): string {
   const validCategories =
     collection === 'news'
@@ -76,19 +86,22 @@ export interface ArticleInput {
   publishedAt?: string;
   featured?: boolean;
 }
-export type NormalizedArticle = {
+// collection 判別可能なユニオン型。blog/news/cases 各々で category を厳密に型付けする（4b3c257 以前の blog 厳密性を回復）。
+type NormalizedArticleCommon = {
   slug: string;
   title: string;
   description: string;
-  category: string;
   tags: string[];
   body: string;
-  collection: Collection;
   externalUrl?: string;
   summary?: string;
   publishedAt?: string;
   featured?: boolean;
 };
+export type NormalizedArticle =
+  | (NormalizedArticleCommon & { collection: 'blog'; category: BlogCategory })
+  | (NormalizedArticleCommon & { collection: 'news'; category: NewsCategory })
+  | (NormalizedArticleCommon & { collection: 'cases'; category: CaseCategory });
 
 // publish / validate 共通: 受け取った article を検証・正規化（パストラバーサル防止含む）。
 export function normalizeArticle(
@@ -117,21 +130,28 @@ export function normalizeArticle(
     return { ok: false, error: e instanceof Error ? e.message : 'slug が不正です', status: 400 };
   }
 
-  const article: NormalizedArticle = {
+  const common = {
     slug: a.slug,
     title: sanitizeText(a.title, 200),
     description: sanitizeText(a.description, 500),
-    category: normalizeCategory(a.category, coll),
     tags: Array.isArray(a.tags)
       ? a.tags.slice(0, 10).map((t) => sanitizeText(t, 50)).filter(Boolean)
       : [],
     body: String(a.body ?? '').slice(0, 100_000),
-    collection: coll,
     externalUrl: a.externalUrl ? sanitizeText(a.externalUrl, 2000) : undefined,
     summary: a.summary ? sanitizeText(a.summary, 1000) : undefined,
     publishedAt: a.publishedAt ? sanitizeText(a.publishedAt, 10) : undefined,
     featured: a.featured === true,
   };
+  // coll をリテラル狭めし、各コレクションの厳密な category 型を持つユニオンメンバを構築する。
+  let article: NormalizedArticle;
+  if (coll === 'news') {
+    article = { ...common, collection: 'news', category: normalizeCategory(a.category, 'news') };
+  } else if (coll === 'cases') {
+    article = { ...common, collection: 'cases', category: normalizeCategory(a.category, 'cases') };
+  } else {
+    article = { ...common, collection: 'blog', category: normalizeCategory(a.category) };
+  }
   if (!article.title || !article.description) {
     return { ok: false, error: 'title / description が空です', status: 400 };
   }

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -4,6 +4,13 @@ export const SLUG_RE = /^[a-z0-9-]{3,80}$/;
 export const VALID_CATEGORIES = ['ai', 'engineering', 'founder', 'lab'] as const;
 export const NEWS_CATEGORIES = ['info', 'media', 'update', 'event', 'award'] as const;
 export const CASES_CATEGORIES = ['grift', 'confidential-ai', 'local-llm', 'ai-contract', 'tech-culture'] as const;
+export const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// コレクション値を安全に正規化（unknown または無効な値は 'blog' フォールバック）
+export function normalizeCollection(raw: unknown): Collection {
+  if (raw === 'news' || raw === 'cases') return raw;
+  return 'blog';
+}
 
 // コレクション別の厳密な category 型。normalizeCategory の戻り型と NormalizedArticle で使用。
 export type BlogCategory = (typeof VALID_CATEGORIES)[number];
@@ -80,7 +87,6 @@ export interface ArticleInput {
   category?: string;
   tags?: unknown;
   body?: string;
-  collection?: Collection;
   externalUrl?: string;
   summary?: string;
   publishedAt?: string;
@@ -110,18 +116,23 @@ export function normalizeArticle(
 ): { ok: true; article: NormalizedArticle } | { ok: false; error: string; status: number } {
   const coll = collection || 'blog';
 
-  // news で externalUrl がある場合は body 不要
-  const requiresBody = coll !== 'news' || !a?.externalUrl;
-  if (!a?.slug || !a?.title || !a?.description || (requiresBody && !a?.body)) {
-    const required = ['slug', 'title', 'description'];
-    if (requiresBody) required.push('body');
-    if (coll === 'cases') required.push('summary');
-    return { ok: false, error: `article.${required.join(' / ')} は必須です`, status: 400 };
+  // a が未定義・非オブジェクトなら先に弾く（以降の a.* アクセスを安全にする＝TS2532/18047 抑制）
+  if (!a || typeof a !== 'object') {
+    return { ok: false, error: 'article は必須です', status: 400 };
   }
 
-  // cases は summary 必須
-  if (coll === 'cases' && !a?.summary) {
-    return { ok: false, error: 'article.summary は cases で必須です', status: 400 };
+  // 必須フィールドを一元検証: 欠落名を収集してメッセージに使い、
+  // 同じ条件で直接 return することで TS が slug/title/description を string に狭める
+  // （配列経由の遅延 return ではプロパティの型が狭まらないため）。
+  const requiresBody = coll !== 'news' || !a.externalUrl;
+  const missing: string[] = [];
+  if (!a.slug) missing.push('slug');
+  if (!a.title) missing.push('title');
+  if (!a.description) missing.push('description');
+  if (requiresBody && !a.body) missing.push('body');
+  if (coll === 'cases' && !a.summary) missing.push('summary');
+  if (!a.slug || !a.title || !a.description || (requiresBody && !a.body) || (coll === 'cases' && !a.summary)) {
+    return { ok: false, error: `article.${missing.join(' / ')} は必須です`, status: 400 };
   }
 
   try {
@@ -140,7 +151,8 @@ export function normalizeArticle(
     body: String(a.body ?? '').slice(0, 100_000),
     externalUrl: a.externalUrl ? sanitizeText(a.externalUrl, 2000) : undefined,
     summary: a.summary ? sanitizeText(a.summary, 1000) : undefined,
-    publishedAt: a.publishedAt ? sanitizeText(a.publishedAt, 10) : undefined,
+    publishedAt:
+      a.publishedAt && DATE_RE.test(a.publishedAt) ? sanitizeText(a.publishedAt, 10) : undefined,
     featured: a.featured === true,
   };
   // coll をリテラル狭めし、各コレクションの厳密な category 型を持つユニオンメンバを構築する。

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -58,6 +58,23 @@ export function sanitizeText(s: unknown, maxLen: number): string {
     .slice(0, maxLen);
 }
 
+// http(s) URL のみ受理（javascript: / data: 等の危険なスキームを排除）。
+const HTTP_URL_RE = /^https?:\/\//i;
+export function isHttpUrl(s: string): boolean {
+  return HTTP_URL_RE.test(s);
+}
+
+// YYYY-MM-DD 形式かつ実在する暦日付か検証（2026-99-99・2026-02-30 等のロールオーバーを拒否）。
+export function isValidCalendarDate(s: string): boolean {
+  if (!DATE_RE.test(s)) return false;
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return false;
+  // Date はロールオーバーする（2026-02-30 → 2026-03-02）ので、
+  // 入力の Y/M/D がそのまま Date に反映されたか検証する。
+  const [yyyy, mm, dd] = s.split('-').map(Number);
+  return d.getFullYear() === yyyy && d.getMonth() + 1 === mm && d.getDate() === dd;
+}
+
 export const IMAGE_EXT = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif'] as const;
 
 // アップロード画像のファイル名を安全な basename に正規化（パストラバーサル/拡張子偽装を防ぐ）。
@@ -121,10 +138,15 @@ export function normalizeArticle(
     return { ok: false, error: 'article は必須です', status: 400 };
   }
 
+  // externalUrl: sanitize した上で http(s) URL のみ採用。不正（空白・"not-a-url" 等）は
+  // externalUrl 無しとして扱い、news でも body 必須とする（危険なスキームの URL で本文免除を防ぐ）。
+  const sanitizedExternalUrl = a.externalUrl ? sanitizeText(a.externalUrl, 2000) : '';
+  const validExternalUrl = isHttpUrl(sanitizedExternalUrl) ? sanitizedExternalUrl : undefined;
+
   // 必須フィールドを一元検証: 欠落名を収集してメッセージに使い、
   // 同じ条件で直接 return することで TS が slug/title/description を string に狭める
   // （配列経由の遅延 return ではプロパティの型が狭まらないため）。
-  const requiresBody = coll !== 'news' || !a.externalUrl;
+  const requiresBody = coll !== 'news' || !validExternalUrl;
   const missing: string[] = [];
   if (!a.slug) missing.push('slug');
   if (!a.title) missing.push('title');
@@ -149,10 +171,12 @@ export function normalizeArticle(
       ? a.tags.slice(0, 10).map((t) => sanitizeText(t, 50)).filter(Boolean)
       : [],
     body: String(a.body ?? '').slice(0, 100_000),
-    externalUrl: a.externalUrl ? sanitizeText(a.externalUrl, 2000) : undefined,
+    externalUrl: validExternalUrl,
     summary: a.summary ? sanitizeText(a.summary, 1000) : undefined,
     publishedAt:
-      a.publishedAt && DATE_RE.test(a.publishedAt) ? sanitizeText(a.publishedAt, 10) : undefined,
+      a.publishedAt && isValidCalendarDate(a.publishedAt)
+        ? sanitizeText(a.publishedAt, 10)
+        : undefined,
     featured: a.featured === true,
   };
   // coll をリテラル狭めし、各コレクションの厳密な category 型を持つユニオンメンバを構築する。

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -1,7 +1,9 @@
-import type { Article } from './types';
+import type { Article, Collection } from './types';
 
 export const SLUG_RE = /^[a-z0-9-]{3,80}$/;
 export const VALID_CATEGORIES = ['ai', 'engineering', 'founder', 'lab'] as const;
+export const NEWS_CATEGORIES = ['info', 'media', 'update', 'event', 'award'] as const;
+export const CASES_CATEGORIES = ['grift', 'confidential-ai', 'local-llm', 'ai-contract', 'tech-culture'] as const;
 
 // slug は公開パス `src/content/blog/ja/<slug>.md` に直結する。
 // `/`・`.`・`..` を弾き、記事ディレクトリ外への書き込み（パストラバーサル）を防ぐ。
@@ -11,10 +13,20 @@ export function assertSlug(slug: string): void {
   }
 }
 
-export function normalizeCategory(c: string | undefined): Article['category'] {
-  return (VALID_CATEGORIES as readonly string[]).includes(c ?? '')
-    ? (c as Article['category'])
-    : 'ai';
+export function normalizeCategory(c: string | undefined, collection: Collection = 'blog'): string {
+  const validCategories =
+    collection === 'news'
+      ? NEWS_CATEGORIES
+      : collection === 'cases'
+        ? CASES_CATEGORIES
+        : VALID_CATEGORIES;
+  return (validCategories as readonly string[]).includes(c ?? '')
+    ? (c ?? 'ai')
+    : collection === 'news'
+      ? 'info'
+      : collection === 'cases'
+        ? 'grift'
+        : 'ai';
 }
 
 // プロンプト注入対策: コードフェンス・制御文字を除去し、長さを制限する。
@@ -58,37 +70,67 @@ export interface ArticleInput {
   category?: string;
   tags?: unknown;
   body?: string;
+  collection?: Collection;
+  externalUrl?: string;
+  summary?: string;
+  publishedAt?: string;
+  featured?: boolean;
 }
 export type NormalizedArticle = {
   slug: string;
   title: string;
   description: string;
-  category: Article['category'];
+  category: string;
   tags: string[];
   body: string;
+  collection: Collection;
+  externalUrl?: string;
+  summary?: string;
+  publishedAt?: string;
+  featured?: boolean;
 };
 
 // publish / validate 共通: 受け取った article を検証・正規化（パストラバーサル防止含む）。
 export function normalizeArticle(
   a: ArticleInput | undefined,
+  collection: Collection = 'blog',
 ): { ok: true; article: NormalizedArticle } | { ok: false; error: string; status: number } {
-  if (!a?.slug || !a?.body || !a?.title || !a?.description) {
-    return { ok: false, error: 'article.slug / title / description / body は必須です', status: 400 };
+  const coll = collection || 'blog';
+
+  // news で externalUrl がある場合は body 不要
+  const requiresBody = coll !== 'news' || !a?.externalUrl;
+  if (!a?.slug || !a?.title || !a?.description || (requiresBody && !a?.body)) {
+    const required = ['slug', 'title', 'description'];
+    if (requiresBody) required.push('body');
+    if (coll === 'cases') required.push('summary');
+    return { ok: false, error: `article.${required.join(' / ')} は必須です`, status: 400 };
   }
+
+  // cases は summary 必須
+  if (coll === 'cases' && !a?.summary) {
+    return { ok: false, error: 'article.summary は cases で必須です', status: 400 };
+  }
+
   try {
     assertSlug(a.slug);
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : 'slug が不正です', status: 400 };
   }
+
   const article: NormalizedArticle = {
     slug: a.slug,
     title: sanitizeText(a.title, 200),
     description: sanitizeText(a.description, 500),
-    category: normalizeCategory(a.category),
+    category: normalizeCategory(a.category, coll),
     tags: Array.isArray(a.tags)
       ? a.tags.slice(0, 10).map((t) => sanitizeText(t, 50)).filter(Boolean)
       : [],
-    body: String(a.body).slice(0, 100_000), // markdown構造を保つため制御文字は除去せず長さのみ制限
+    body: String(a.body ?? '').slice(0, 100_000),
+    collection: coll,
+    externalUrl: a.externalUrl ? sanitizeText(a.externalUrl, 2000) : undefined,
+    summary: a.summary ? sanitizeText(a.summary, 1000) : undefined,
+    publishedAt: a.publishedAt ? sanitizeText(a.publishedAt, 10) : undefined,
+    featured: a.featured === true,
   };
   if (!article.title || !article.description) {
     return { ok: false, error: 'title / description が空です', status: 400 };

--- a/workers/yomimono/wrangler.toml
+++ b/workers/yomimono/wrangler.toml
@@ -16,6 +16,8 @@ GH_REPO = "corsweb2024"
 GH_APP_ID = "4138716"
 GH_INSTALLATION_ID = "142454743"
 BLOG_DIR = "src/content/blog"
+NEWS_DIR = "src/content/news"
+CASES_DIR = "src/content/cases"
 PUBLISH_BRANCH = "main"
 STYLE_GUIDE_PATH = "docs/blog-style-guide.md"
 # ↓ BASE_PATH は上の routes の pattern と必ず一致させること（/blog-admin ⇔ cor-jp.com/blog-admin*）


### PR DESCRIPTION
Refs #220

## 概要
M1-I1: yomimono Worker を blog/news/cases の3コレクション対応に拡張する基盤。Epic #220（ニュース機能 + cases CMS + UI改善 + OGP PNG化）の第1弾。

## 変更内容
- **Collection 型・基盤**: types.ts（Env に NEWS_DIR/CASES_DIR）・wrangler.toml・Collection 型
- **コミット先分岐**: github.ts に contentDir(env,col) 新設・commitArticle/listArticleSlugs を collection 対応（既定 'blog' で blog 不変）
- **正規化**: validate.ts で normalizeArticle(a,col) を3コレクション対応・category enum・NormalizedArticle を collection 判別ユニオン型・normalizeCategory オーバーロード
- **Markdown 生成**: generate.ts で buildMarkdown 分岐・buildNewsMarkdown/buildCasesMarkdown 新設
- **API**: index.ts で /api/{publish,validate,recent} が body.collection 伝播
- **UI**: ui-shared.ts header 型に manual-news/manual-cases 追加（将来用・HUB 3セクション化は M2/M3）

## セキュリティ/品質
- **externalUrl 検証**: isHttpUrl（http(s) URL のみ・sanitize 後検証）
- **publishedAt 暦日付検証**: isValidCalendarDate（roll-over 拒否・2026-02-30/2026-99-99 等）
- **collection の型安全化**: normalizeCollection（as 排除）
- **required チェック一元化**: missing 配列
- **isDraft バグ修正**: buildCasesMarkdown のハードコード排除

## news の取り扱い（重要）
news collection は **M3（I5/I6）で有効化**。本PRでは基盤関数（normalizeArticle('news')/buildNewsMarkdown/contentDir('news')）を実装しつつ、**index.ts エンドポイント層で collection='news' を一時拒否**（400・サイレント失敗防止）。M3 で config.ts に newsCollection 追加・UI 開放時に import 1行 + 早期拒否削除で有効化。

## 検証
- typecheck: 緑
- test: 172 passed（基盤70 + news/cases/検証追加102）
- build: 437 pages（Astro 側への影響なし）
- blog/cases 回帰なし（既定 'blog'・実行時も型も完全不変）
- code-reviewer: Approve（CRITICAL/HIGH ゼロ・反証可能テスト）
- Codex CLI: No actionable correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)