### PR TITLE
feat(M1-I2): 読みものCMS投稿UIを改善

### DIFF
--- a/workers/yomimono/src/__tests__/generate.test.ts
+++ b/workers/yomimono/src/__tests__/generate.test.ts
@@ -13,6 +13,7 @@ describe('buildNewsMarkdown — news frontmatter 形式検証', () => {
     collection: 'news',
     publishedAt: '2026-07-08',
     externalUrl: 'https://example.com/article',
+    isDraft: false,
   };
 
   it('news: externalUrl あり→frontmatter に externalUrl を含む', () => {
@@ -85,6 +86,7 @@ describe('buildCasesMarkdown — cases frontmatter 形式検証', () => {
     publishedAt: '2026-07-08',
     summary: 'テストケース要約',
     featured: true,
+    isDraft: false,
   };
 
   it('cases: frontmatter に summary を含む', () => {
@@ -153,6 +155,7 @@ describe('buildMarkdown — blog との整合性検証', () => {
     tags: ['tag1', 'tag2'],
     body: '## テスト本文\n\n内容',
     collection: 'blog',
+    isDraft: false,
   };
 
   it('blog: isDraft パラメータを反映', () => {

--- a/workers/yomimono/src/__tests__/ui-shared.test.ts
+++ b/workers/yomimono/src/__tests__/ui-shared.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { draftBarHtml, toolbarButtonsHtml } from '../ui-shared';
+
+describe('draftBarHtml — prefix サニタイズ（M1-I2 MEDIUM・反証可能）', () => {
+  it('正当な prefix（例: "m"）は id に展開される', () => {
+    const html = draftBarHtml('m');
+    expect(html).toContain('id="m_draftBar"');
+    expect(html).toContain('id="m_restore"');
+    expect(html).toContain('id="m_discard"');
+    expect(html).toContain('hidden');
+  });
+
+  it.each([
+    ['malicious" onclick="alert(1)', '二重引用符で属性を抜ける攻撃'],
+    ['a b', '空白込み'],
+    ['a<b>', '山括弧'],
+    ['../up', 'パストラバーサル文字'],
+    ['', '空文字'],
+    ['1abc', '数字開始（HTML id 規則違反）'],
+    ['a b c', '複数空白'],
+  ])('不正な prefix(%s / %s)は throw する（反証可能: 検証未導入なら素通り）', (prefix) => {
+    expect(() => draftBarHtml(prefix)).toThrow();
+  });
+
+  it.each(['m', 'manual', 'news_page', 'a-b-c', '_x', 'kind1'])(
+    '正当な prefix(%s)は throw しない',
+    (prefix) => {
+      expect(() => draftBarHtml(prefix)).not.toThrow();
+    },
+  );
+});
+
+describe('toolbarButtonsHtml — kind 識別子の検証（M1-I2 MEDIUM・反証可能）', () => {
+  it('既定のボタン群を生成する（8種）', () => {
+    const html = toolbarButtonsHtml();
+    const kinds = ['bold', 'h2', 'h3', 'link', 'ul', 'ol', 'quote', 'hr'];
+    for (const k of kinds) {
+      expect(html).toContain('data-md="' + k + '"');
+    }
+  });
+
+  it('title 属性値はエスケープされる（" を含まない素の日本語ツールチップ）', () => {
+    const html = toolbarButtonsHtml();
+    // 全ボタンの title が壊れた属性境界を生まないこと（title="..." の中に " が無い）
+    const matches = html.match(/title="[^"]*"/g) || [];
+    expect(matches.length).toBeGreaterThan(0);
+  });
+
+  it('生成HTMLに不正な属性境界（" onclick 等）が含まれない', () => {
+    const html = toolbarButtonsHtml();
+    expect(html).not.toMatch(/"[^"]*onclick/i);
+    expect(html).not.toMatch(/"[^"]*<script/i);
+  });
+});

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -472,3 +472,37 @@ describe('sanitizeText — プロンプト注入対策', () => {
     expect(sanitizeText('x'.repeat(500), 200)).toHaveLength(200);
   });
 });
+
+describe('normalizeArticle — isDraft パススルー（非エンジニア向けUI改善・反証可能）', () => {
+  const base = {
+    slug: 'draft-test',
+    title: '下書きテスト',
+    description: '説明',
+    body: '本文',
+  };
+  it('isDraft 省略時は false（従来の公開挙動は不変）', () => {
+    const r = normalizeArticle(base);
+    if (!r.ok) throw new Error('正規化失敗');
+    expect(r.article.isDraft).toBe(false);
+  });
+  it('isDraft: true を通す（「下書きとして保存」で反映される）', () => {
+    const r = normalizeArticle({ ...base, isDraft: true });
+    if (!r.ok) throw new Error('正規化失敗');
+    expect(r.article.isDraft).toBe(true);
+  });
+  it('isDraft に非真値は false に正規化（文字列 "true"・1 等を拒否）', () => {
+    for (const v of ['true', 1, 'yes', {}, []]) {
+      const r = normalizeArticle({ ...base, isDraft: v as unknown as boolean });
+      if (!r.ok) throw new Error('正規化失敗');
+      expect(r.article.isDraft).toBe(false);
+    }
+  });
+  it('cases でも isDraft を通す', () => {
+    const r = normalizeArticle(
+      { ...base, summary: 'リード', isDraft: true },
+      'cases',
+    );
+    if (!r.ok) throw new Error('正規化失敗');
+    expect(r.article.isDraft).toBe(true);
+  });
+});

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -313,9 +313,9 @@ export default {
         // news は上で拒否済みなので blog/cases のみ（buildNewsMarkdown は M3 で有効化）
         let markdown: string;
         if (collection === 'cases') {
-          markdown = buildCasesMarkdown(normalized);
+          markdown = buildCasesMarkdown(normalized, normalized.isDraft);
         } else {
-          markdown = buildMarkdown(normalized);
+          markdown = buildMarkdown(normalized, normalized.isDraft);
         }
         const violations = scanForViolations(markdown);
         return json({ violations });
@@ -337,9 +337,9 @@ export default {
         // news は上で拒否済みなので blog/cases のみ（buildNewsMarkdown は M3 で有効化）
         let markdown: string;
         if (collection === 'cases') {
-          markdown = buildCasesMarkdown(normalized);
+          markdown = buildCasesMarkdown(normalized, normalized.isDraft);
         } else {
-          markdown = buildMarkdown(normalized);
+          markdown = buildMarkdown(normalized, normalized.isDraft);
         }
         const violations = scanForViolations(markdown);
         if (violations.length > 0) {

--- a/workers/yomimono/src/ui-manual.ts
+++ b/workers/yomimono/src/ui-manual.ts
@@ -1,9 +1,16 @@
-import { head, header, tail } from './ui-shared';
+import { head, header, tail, toolbarButtonsHtml, draftBarHtml, UI_KIT_JS } from './ui-shared';
 
-// 手動作成ページ。Markdown を書き、画像はドラッグ&ドロップ/貼り付け/ボタンでアップロード。
-// 右側にライブプレビュー。公開は /api/validate → /api/publish（AI生成と同じ）。
+// 手動作成ページ（非エンジニア向けUI改善適用）。
+// - slug は タイトルから自動生成（上級者は <details> で編集可・非エンジニアは触れない）
+// - ツールバーで太字/見出し/リンク等の Markdown 記号を挿入（insertMarkdown）
+// - LocalStorage 自動下書き（デバウンス保存・復元バー）+「下書きをブラウザに保存」（localStorage のみ）
+//   ※ サーバー下書き（isDraft:true コミット）は M1-I3 の updateArticle 実装まで非提供。
+//     現状の commitArticle は同 slug 重複を拒否するため、下書き保存→公開が同 slug で不可なため。
+//     validate.ts/index.ts の isDraft 伝播・テストは M1-I3 で使用するため維持（UIからの送信のみ削除）。
+// - 画像はドラッグ&ドロップ/貼り付け/ボタンでアップロード（既存維持）。公開フロー・ガードレール不変。
 const BODY = `<main class="wide">
-  <p class="lead">テキストと画像で記事を作成します。画像は本文へドラッグ&ドロップ・貼り付け・「画像を追加」で挿入できます。書いたら「公開する」で cor-jp.com に公開（main マージ不要）。</p>
+  ` + draftBarHtml('m') + `
+  <p class="lead">タイトルと本文を書き、「公開する」で cor-jp.com に公開します。画像は本文へドラッグ&amp;ドロップ・貼り付け・「画像を追加」でも挿入できます。</p>
   <div class="step">
     <div class="row" style="gap:14px">
       <div class="field" style="flex:1;min-width:220px;margin:0"><label>タイトル</label><input id="m_title" placeholder="記事のタイトル"></div>
@@ -12,24 +19,25 @@ const BODY = `<main class="wide">
       </div>
     </div>
     <div class="row" style="gap:14px;margin-top:10px">
-      <div class="field" style="flex:1;min-width:220px;margin:0"><label>説明（カード・OGP用の1〜2文）</label><input id="m_desc" placeholder="一覧やSNSで表示される短い説明"></div>
+      <div class="field" style="flex:1;min-width:220px;margin:0"><label>記事のまとめ（一覧に表示される短文）</label><input id="m_desc" placeholder="記事の要約。一覧やSNSで表示されます"></div>
       <div class="field" style="width:240px;margin:0"><label>タグ（カンマ区切り）</label><input id="m_tags" placeholder="AI, 業務効率"></div>
     </div>
-    <div class="field" style="margin-top:10px"><label>slug（URL・英小文字/数字/ハイフン）</label><input id="m_slug" placeholder="my-first-post"></div>
+    <details class="advanced"><summary>URLを編集する（上級者向け）</summary>
+      <div class="field" style="margin-top:8px"><label>URLの末尾（英小文字/数字/ハイフン・空欄でタイトルから自動生成）</label><input id="m_slug" placeholder="自動生成されます"></div>
+    </details>
   </div>
 
   <div class="split">
     <div class="step editor">
-      <div class="toolbar">
-        <strong style="font-size:13px;color:var(--navy)">本文（Markdown）</strong>
+      <div class="toolbar" id="m_toolbar">
+        <strong style="font-size:13px;color:var(--navy)">本文</strong>
+        ` + toolbarButtonsHtml() + `
         <button class="ghost" id="m_imgBtn" type="button">画像を追加</button>
         <span class="meta" id="m_imgMsg"></span>
         <input type="file" id="m_file" accept="image/*" multiple hidden>
       </div>
-      <textarea id="m_body" class="drop" maxlength="100000" placeholder="## 見出し
-
-本文をここに。**太字**、[リンク](https://example.com)、- 箇条書き なども使えます。
-画像はここにドラッグ&ドロップ、または貼り付けできます。"></textarea>
+      <textarea id="m_body" class="drop" maxlength="100000" placeholder="見出しや本文を書きましょう。ツールバーのボタンで太字・見出し・リンクなどを挿入できます。
+画像はここにドラッグ&amp;ドロップ、または貼り付けでも挿入できます。"></textarea>
     </div>
     <div class="step">
       <div class="toolbar"><strong style="font-size:13px;color:var(--navy)">プレビュー</strong></div>
@@ -40,23 +48,43 @@ const BODY = `<main class="wide">
   <div class="step">
     <div class="row">
       <button class="pub" id="m_pub">公開する</button>
-      <button class="ghost" id="m_check" type="button">ガードレール再チェック</button>
+      <button class="ghost" id="m_draft" type="button">下書きをブラウザに保存</button>
+      <button class="ghost" id="m_check" type="button">公開前チェック</button>
       <span class="meta" id="m_msg"></span>
     </div>
     <div id="m_result"></div>
+    <details class="help"><summary>技術的なメモ（かっこのある方向け）</summary>
+      <div class="help-body">
+        <ul>
+          <li>公開は GitHub の main ブランチへコミットされ、数分で静的サイトに反映されます（main マージ不要）。</li>
+          <li>本文は Markdown 形式で保存されます。ツールバーが記号を自動挿入します。</li>
+          <li>「下書きをブラウザに保存」はこの端末のブラウザ（localStorage）にのみ保存されます。サーバーには送信されません。</li>
+          <li>入力中の内容は自動的にこのブラウザに保存されます（デバイスごと・公開時に消去）。</li>
+        </ul>
+      </div>
+    </details>
   </div>
 </main>`;
 
 const JS = `
-  // slug 既定値（post-YYYYMMDD-HHMM）。ユーザーは編集可。
-  (function(){ var d=new Date(), p=function(n){return (n<10?'0':'')+n;};
-    $('m_slug').value='post-'+d.getFullYear()+p(d.getMonth()+1)+p(d.getDate())+'-'+p(d.getHours())+p(d.getMinutes()); })();
-
-  // アップロード直後の画像はまだ本番にデプロイされていないため、
-  // プレビューでは data URL を使って即表示する（本文の markdown は /images/... のまま）。
+  // === 状態 ===
+  var slugEdited = false;
+  var DRAFT_KEY = 'draft:blog:new';
+  var pendingDraft = null;
   var imgCache = {};
+  var IMG_CACHE_MAX = 20; // プレビュー用 data URL のキャッシュ上限（古いものから破棄）
+  var _pvTimer = null;
+  var _draftTimer = null; // 下書き自動保存タイマー（公開成功時にキャンセルして競合防止）
 
-  // --- 最小 Markdown レンダラ（esc + safeUrl で安全に） ---
+  // imgCache に data URL を登録。上限超過時は最古のエントリから削除（挿入順 = 古い順）。
+  function setImgCache(url, dataUrl){
+    if(!url || imgCache.hasOwnProperty(url)) { imgCache[url]=dataUrl; return; }
+    var keys = Object.keys(imgCache);
+    while(keys.length >= IMG_CACHE_MAX && keys.length > 0){ delete imgCache[keys.shift()]; }
+    imgCache[url]=dataUrl;
+  }
+
+  // === 最小 Markdown レンダラ（esc + safeUrl で安全に） ===
   function inline(t){
     t = esc(t);
     t = t.replace(/!\\[([^\\]]*)\\]\\(([^)\\s]+)\\)/g, function(m,alt,url){ var src = imgCache[url] ? imgCache[url] : esc(safeUrl(url)); return '<img src="'+src+'" alt="'+alt+'">'; });
@@ -68,37 +96,42 @@ const JS = `
   }
   function mdToHtml(md){
     var lines = String(md||'').split(/\\r?\\n/);
-    var out = [], list = null, inCode = false, codeBuf = [];
+    var out = [], list = null, bq = false, inCode = false, codeBuf = [];
     function closeList(){ if(list){ out.push('</'+list+'>'); list=null; } }
+    function closeBq(){ if(bq){ out.push('</blockquote>'); bq=false; } }
     for (var i=0;i<lines.length;i++){
       var ln = lines[i];
       if (/^\`\`\`/.test(ln)){
         if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); inCode=false; codeBuf=[]; }
-        else { closeList(); inCode=true; }
+        else { closeList(); closeBq(); inCode=true; }
         continue;
       }
       if (inCode){ codeBuf.push(esc(ln)); continue; }
       var mh = ln.match(/^(#{1,3})\\s+(.*)$/);
       var mu = ln.match(/^\\s*[-*]\\s+(.*)$/);
       var mo = ln.match(/^\\s*\\d+\\.\\s+(.*)$/);
-      if (mh){ closeList(); var lvl=mh[1].length; out.push('<h'+lvl+'>'+inline(mh[2])+'</h'+lvl+'>'); }
-      else if (mu){ if(list!=='ul'){ closeList(); list='ul'; out.push('<ul>'); } out.push('<li>'+inline(mu[1])+'</li>'); }
-      else if (mo){ if(list!=='ol'){ closeList(); list='ol'; out.push('<ol>'); } out.push('<li>'+inline(mo[1])+'</li>'); }
-      else if (/^\\s*$/.test(ln)){ closeList(); }
-      else { closeList(); out.push('<p>'+inline(ln)+'</p>'); }
+      var mq = ln.match(/^>\\s?(.*)$/);
+      var mhr = /^\\s*(?:-{3,}|\\*{3,}|_{3,})\\s*$/.test(ln);
+      if (mhr){ closeList(); closeBq(); out.push('<hr>'); }
+      else if (mh){ closeList(); closeBq(); var lvl=mh[1].length; out.push('<h'+lvl+'>'+inline(mh[2])+'</h'+lvl+'>'); }
+      else if (mu){ closeBq(); if(list!=='ul'){ closeList(); list='ul'; out.push('<ul>'); } out.push('<li>'+inline(mu[1])+'</li>'); }
+      else if (mo){ closeBq(); if(list!=='ol'){ closeList(); list='ol'; out.push('<ol>'); } out.push('<li>'+inline(mo[1])+'</li>'); }
+      else if (mq){ closeList(); if(!bq){ out.push('<blockquote>'); bq=true; } out.push('<p>'+inline(mq[1])+'</p>'); }
+      else if (/^\\s*$/.test(ln)){ closeList(); closeBq(); }
+      else { closeList(); closeBq(); out.push('<p>'+inline(ln)+'</p>'); }
     }
-    if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); } // 未閉じフェンスも描画
-    closeList();
+    if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); }
+    closeList(); closeBq();
     return out.join('');
   }
   function updatePreview(){
     var html = mdToHtml($('m_body').value);
     $('m_prev').innerHTML = html || '<p class="meta">ここに表示されます。</p>';
   }
-  var _pvTimer = null;
-  $('m_body').addEventListener('input', function(){ if(_pvTimer) clearTimeout(_pvTimer); _pvTimer=setTimeout(updatePreview, 120); });
+  function schedulePreview(){ if(_pvTimer) clearTimeout(_pvTimer); _pvTimer=setTimeout(updatePreview, 120); }
 
-  // --- 画像アップロード ---
+  // === 画像アップロード（既存維持: D&D / ペースト / ボタン） ===
+  // アップロード直後の画像はまだ本番にデプロイされていないため、プレビューは data URL で即表示する（本文 markdown は /images/... のまま）。
   function insertAtCursor(text){
     var ta=$('m_body'), s=ta.selectionStart, e=ta.selectionEnd;
     ta.value = ta.value.slice(0,s) + text + ta.value.slice(e);
@@ -114,34 +147,88 @@ const JS = `
       var dataUrl=String(reader.result||'');
       var base64=dataUrl.split(',')[1]||'';
       api('/api/upload-image', { filename:file.name||'image.png', dataBase64:base64 }).then(function(j){
-        imgCache[j.url]=dataUrl; // プレビュー即表示用
+        setImgCache(j.url, dataUrl);
         insertAtCursor('\\n![' + (file.name||'画像') + '](' + j.url + ')\\n');
         $('m_imgMsg').textContent='挿入しました: '+j.url;
       }).catch(function(e){ $('m_imgMsg').innerHTML='<span style="color:#dc2626">画像アップロード失敗: '+esc(e.message)+'</span>'; });
     };
     reader.readAsDataURL(file);
   }
+
+  // === 入力データ収集 ===
+  function gatherAll(){
+    return { title:$('m_title').value, desc:$('m_desc').value, cat:$('m_cat').value, tags:$('m_tags').value, slug:$('m_slug').value, body:$('m_body').value };
+  }
+  function applyDraft(d){
+    if(!d) return;
+    $('m_title').value = d.title || '';
+    $('m_desc').value = d.desc || '';
+    $('m_cat').value = d.cat || 'ai';
+    $('m_tags').value = d.tags || '';
+    $('m_slug').value = d.slug || '';
+    $('m_body').value = d.body || '';
+    slugEdited = !!($('m_slug').value.trim());
+    updatePreview();
+  }
+  function gather(){
+    var tags = $('m_tags').value.split(',').map(function(s){ return s.trim(); }).filter(Boolean);
+    // slug は空欄ならタイトルから自動生成（slug 隠蔽・非エンジニアは意識しない）
+    var slug = $('m_slug').value.trim() || titleToSlug($('m_title').value);
+    return { slug: slug, title: $('m_title').value.trim(), description: $('m_desc').value.trim(), category: $('m_cat').value, tags: tags, body: $('m_body').value };
+  }
+  function validateLocal(a){
+    if(!a.title) return 'タイトルを入力してください';
+    if(!a.description) return '記事のまとめを入力してください';
+    if(!a.body.trim()) return '本文を入力してください';
+    if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'URLの末尾は英小文字・数字・ハイフン（3〜80字）で指定してください';
+    return '';
+  }
+
+  // === 下書き（LocalStorage 自動保存・復元） ===
+  // 公開成功時に未処理の保留保存をキャンセルし、公開済み記事が下書きとして復元されるのを防ぐため
+  // debounceFn ではなくキャンセル可能なタイマーで実装する。
+  function scheduleDraftSave(){
+    if(_draftTimer) clearTimeout(_draftTimer);
+    _draftTimer = setTimeout(function(){ _draftTimer=null; saveDraft(DRAFT_KEY, gatherAll()); }, 800);
+  }
+  function cancelDraftSave(){ if(_draftTimer){ clearTimeout(_draftTimer); _draftTimer=null; } }
+  function resetForm(){
+    $('m_title').value=''; $('m_desc').value=''; $('m_cat').value='ai';
+    $('m_tags').value=''; $('m_slug').value=''; $('m_body').value='';
+    slugEdited = false; imgCache = {};
+    updatePreview();
+  }
+
+  // === 初期化 ===
+  wireToolbar($('m_toolbar'), $('m_body'));
+  (function(){
+    var d = loadDraft(DRAFT_KEY);
+    if(d && (d.title || d.body)){ pendingDraft = d; $('m_draftBar').hidden = false; }
+  })();
+
+  // === イベント束ね ===
+  $('m_title').addEventListener('input', function(){
+    if(!slugEdited){ $('m_slug').value = titleToSlug($('m_title').value); }
+    scheduleDraftSave();
+  });
+  $('m_slug').addEventListener('input', function(){ slugEdited = !!($('m_slug').value.trim()); scheduleDraftSave(); });
+  $('m_desc').addEventListener('input', scheduleDraftSave);
+  $('m_tags').addEventListener('input', scheduleDraftSave);
+  $('m_cat').addEventListener('change', scheduleDraftSave);
+  $('m_body').addEventListener('input', function(){ schedulePreview(); scheduleDraftSave(); });
+
+  $('m_restore').addEventListener('click', function(){ applyDraft(pendingDraft); $('m_draftBar').hidden = true; });
+  $('m_discard').addEventListener('click', function(){ clearDraft(DRAFT_KEY); pendingDraft = null; $('m_draftBar').hidden = true; });
+
   $('m_imgBtn').addEventListener('click', function(){ $('m_file').click(); });
   $('m_file').addEventListener('change', function(){ for(var i=0;i<this.files.length;i++) uploadFile(this.files[i]); this.value=''; });
-
   var ta=$('m_body');
   ta.addEventListener('dragover', function(e){ e.preventDefault(); ta.classList.add('over'); });
   ta.addEventListener('dragleave', function(){ ta.classList.remove('over'); });
   ta.addEventListener('drop', function(e){ e.preventDefault(); ta.classList.remove('over'); var f=e.dataTransfer&&e.dataTransfer.files; if(f) for(var i=0;i<f.length;i++) uploadFile(f[i]); });
   ta.addEventListener('paste', function(e){ var it=e.clipboardData&&e.clipboardData.items; if(!it) return; for(var i=0;i<it.length;i++){ if(it[i].type&&it[i].type.indexOf('image')===0){ var f=it[i].getAsFile(); if(f){ e.preventDefault(); uploadFile(f); } } } });
 
-  // --- 公開 / 再チェック ---
-  function gather(){
-    var tags = $('m_tags').value.split(',').map(function(s){ return s.trim(); }).filter(Boolean);
-    return { slug:$('m_slug').value.trim(), title:$('m_title').value.trim(), description:$('m_desc').value.trim(), category:$('m_cat').value, tags:tags, body:$('m_body').value };
-  }
-  function validateLocal(a){
-    if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'slug は英小文字・数字・ハイフン 3〜80字で入力してください';
-    if(!a.title) return 'タイトルを入力してください';
-    if(!a.description) return '説明を入力してください';
-    if(!a.body.trim()) return '本文を入力してください';
-    return '';
-  }
+  // === 公開前チェック ===
   $('m_check').addEventListener('click', function(){
     var a=gather(); var err=validateLocal(a);
     if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
@@ -153,17 +240,37 @@ const JS = `
       btn.disabled=false;
     }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; });
   });
+
+  // === 公開する（article のみ送信・isDraft は既定 false） ===
   $('m_pub').addEventListener('click', function(){
     var a=gather(); var err=validateLocal(a);
     if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
     var btn=this; btn.disabled=true; btn.innerHTML='<span class="spin"></span>公開中…'; $('m_msg').textContent='';
     api('/api/publish', { article:a }).then(function(j){
       var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
-      $('m_result').innerHTML='<div class="done">✓ 公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
+      $('m_result').innerHTML='<div class="done">✓ 公開しました（数分でサイトに反映されます） '+link+'</div>';
       $('m_msg').textContent='';
-      btn.disabled=false; btn.innerHTML='公開する'; // 成功後もボタンを復帰（別記事を続けて書けるように）
+      // 公開済み記事の下書きが残らないよう、保留中の自動保存をキャンセルしてから消去＋フォームリセット。
+      // リセット後の入力で新規記事として自動保存が再開する（.value 設定では input 事件は発火しない）。
+      cancelDraftSave();
+      clearDraft(DRAFT_KEY);
+      pendingDraft = null;
+      $('m_draftBar').hidden = true;
+      resetForm();
+      btn.disabled=false; btn.innerHTML='公開する';
     }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.innerHTML='公開する'; });
+  });
+
+  // === 下書きをブラウザに保存（localStorage のみ・サーバーへは送信しない） ===
+  // サーバー下書き（isDraft:true コミット）は commitArticle が同 slug 重複を拒否するため、
+  // 下書き保存→公開が同 slug でできず、M1-I3 の updateArticle 実装まで非提供。
+  $('m_draft').addEventListener('click', function(){
+    var btn=this; btn.disabled=true;
+    saveDraft(DRAFT_KEY, gatherAll());
+    $('m_result').innerHTML='<div class="done">✓ このブラウザに下書きを保存しました（次回訪問時に復元できます・サーバーには送信されません）</div>';
+    $('m_msg').textContent='';
+    btn.disabled=false;
   });
 `;
 
-export const MANUAL_HTML = head('手動作成 — 読みもの 作成スタジオ') + header('manual') + BODY + tail(JS);
+export const MANUAL_HTML = head('手動作成 — 読みもの 作成スタジオ') + header('manual') + BODY + tail(UI_KIT_JS + JS);

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -73,7 +73,25 @@ export const CSS = `
   .preview pre code { background:none; color:inherit; padding:0; }
   .preview ul,.preview ol { padding-left:22px; }
   .preview a { color:var(--accent); }
+  .preview blockquote { margin:10px 0; padding:6px 14px; border-left:3px solid var(--line); color:var(--muted); }
+  .preview blockquote p { margin:4px 0; }
+  .preview hr { border:none; border-top:1px solid var(--line); margin:16px 0; }
   .toolbar { display:flex; gap:8px; align-items:center; margin-bottom:8px; flex-wrap:wrap; }
+  /* 非エンジニア向けUI改善キット */
+  .tb-btn { background:#eef2f7; color:var(--ink); padding:6px 11px; font-size:13px; font-weight:600; border-radius:8px; }
+  .tb-btn:hover { background:#e0e7f1; }
+  .tb-btn b { font-weight:700; }
+  .advanced > summary, .help > summary { cursor:pointer; font-size:12px; color:var(--muted); user-select:none; }
+  .advanced { margin-top:12px; }
+  .help { margin-top:14px; }
+  .help-body { font-size:12px; color:var(--muted); margin-top:8px; line-height:1.7; }
+  .help-body ul { margin:6px 0; padding-left:18px; }
+  .help-body code { background:#f1f5f9; padding:1px 5px; border-radius:4px; font-size:12px; }
+  .draft-bar { background:#fffbeb; border:1px solid #fde68a; color:#92400e; border-radius:8px; padding:10px 12px; margin-bottom:12px; display:flex; gap:8px; align-items:center; font-size:13px; flex-wrap:wrap; }
+  .draft-bar button { padding:5px 10px; font-size:12px; }
+  /* .draft-bar の display:flex は [hidden]{display:none} より後に定義されるため
+     specificity で hidden が負ける。属性セレクタを併用して hidden を優先する。 */
+  .draft-bar[hidden] { display:none; }
 `;
 
 // 共通JS（各ページIIFEの先頭で展開）。BASE はサーバが __BASE__ を注入。
@@ -90,6 +108,22 @@ function apiLong(p,b){return fetch(BASE+p,{method:'POST',headers:{'content-type'
 
 function escHtml(s: string): string {
   return s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[c] as string);
+}
+
+// 属性値用エスケープ（escHtml に加え " を &quot; に）。ツールバーの title 属性等に使用。
+function escAttr(s: string): string {
+  return String(s == null ? '' : s).replace(/[&<>"]/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c] as string,
+  );
+}
+
+// HTML id / data-* 識別子として安全な字面か検証（注入・壊れた属性値を防ぐ）。
+// prefix/kind 等、DOM id や data-md 属性に展開される値のみに適用（表示テキストは対象外）。
+const ID_RE = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+function assertId(value: string, name: string): void {
+  if (!ID_RE.test(value)) {
+    throw new Error('ui-shared: 無効な ' + name + ' 識別子です: "' + value + '"');
+  }
 }
 
 export function head(title: string): string {
@@ -121,3 +155,119 @@ export function header(active: 'hub' | 'ai' | 'manual' | 'manual-news' | 'manual
 export function tail(pageJs: string): string {
   return '<script>(function(){' + COMMON_JS + pageJs + '})();</script></body></html>';
 }
+
+// === 非エンジニア向けUI改善キット（ui-manual / ui-manual-news / ui-manual-cases 共通） ===
+// ツールバーのボタン群。data-md 属性で insertMarkdown の kind を指定する。
+// 画像ボタンは各ページで独自ロジック（アップロード）を持つためここには含めない。
+export function toolbarButtonsHtml(): string {
+  const btn = (kind: string, label: string, title: string): string => {
+    // kind は data-md 属性に展開され JS の dispatch で比較される識別子。ID_RE で厳密検証。
+    assertId(kind, 'kind');
+    // title は表示用ツールチップ（日本語）なので HTML 属性としてエスケープ。
+    return (
+      '<button type="button" class="tb-btn" data-md="' +
+      kind +
+      '" title="' +
+      escAttr(title) +
+      '">' +
+      label +
+      '</button>'
+    );
+  };
+  return (
+    btn('bold', '<b>B</b>', '太字') +
+    btn('h2', '大見出し', '大見出し（節見出し）') +
+    btn('h3', '小見出し', '小見出し') +
+    btn('link', 'リンク', 'リンク') +
+    btn('ul', '箇条書き', '箇条書きリスト') +
+    btn('ol', '番号リスト', '番号リスト') +
+    btn('quote', '引用', '引用') +
+    btn('hr', '区切り線', '区切り線')
+  );
+}
+
+// 下書き復元バー（prefix はページの id 接頭辞。例: 'm'）。
+export function draftBarHtml(prefix: string): string {
+  // prefix はDOM id に展開されるため ID_RE で検証（不正文字で id が壊れるのを防ぐ）。
+  assertId(prefix, 'prefix');
+  return (
+    '<div id="' + prefix + '_draftBar" class="draft-bar" hidden>' +
+    '<span>入力中の下書きがあります</span>' +
+    '<button type="button" class="ghost" id="' + prefix + '_restore">復元する</button>' +
+    '<button type="button" class="ghost" id="' + prefix + '_discard">破棄</button>' +
+    '</div>'
+  );
+}
+
+// 共通UI改善JS（各ページの pageJs 先頭に連結して tail() で包む。COMMON_JS の esc/safeUrl/$/api を利用）。
+// 注: テンプレートリテラル内に ${ とバックティックを入れないこと。バックスラッシュは2重化。
+export const UI_KIT_JS = `
+  // --- titleToSlug: タイトルから URL slug を自動生成 ---
+  // カナ→ローマ字（簡易）→ ASCII のみ抽出 → ハイフン結合 → 空ならタイムスタンプ fallback。
+  // 非エンジニアは slug 概念に触れず、タイトル入力で URL が決まる。
+  var SLUG_H='あいうえおぁぃぅぇぉかきくけこさしすせそたちつてとっなにぬねのはひふへほまみむめもやゃゆゅよょらりるれろわをんがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ';
+  var SLUG_K='アイウエオァィゥェォカキクケコサシスセソタチツテトッナニヌネノハヒフヘホマミムメモヤャユュヨョラリルレロワヲンガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ';
+  var SLUG_R=['a','i','u','e','o','a','i','u','e','o','ka','ki','ku','ke','ko','sa','shi','su','se','so','ta','chi','tsu','te','to','tsu','na','ni','nu','ne','no','ha','hi','fu','he','ho','ma','mi','mu','me','mo','ya','ya','yu','yu','yo','yo','ra','ri','ru','re','ro','wa','wo','n','ga','gi','gu','ge','go','za','ji','zu','ze','zo','da','ji','zu','de','do','ba','bi','bu','be','bo','pa','pi','pu','pe','po'];
+  function titleToSlug(title){
+    var map={};
+    for(var i=0;i<SLUG_H.length;i++){ map[SLUG_H.charAt(i)]=SLUG_R[i]; map[SLUG_K.charAt(i)]=SLUG_R[i]; }
+    var s=String(title==null?'':title).trim().toLowerCase();
+    s=s.replace(/[あ-んァ-ヶ]/g,function(ch){ return map[ch]||''; });
+    s=s.replace(/[^a-z0-9\\s-]/g,'');
+    s=s.replace(/[\\s-]+/g,'-').replace(/^-+|-+$/g,'');
+    // SLUG_RE は {3,80} なので 3文字未満の slug（例: 「AI導入」→「ai」）は受理されない。
+    // 空or短すぎる場合はタイムスタンプでパディングし、3文字以上を保証する。
+    if(s.length<3){
+      var d=new Date(),p=function(n){return (n<10?'0':'')+n;};
+      var ts=d.getFullYear()+p(d.getMonth()+1)+p(d.getDate())+'-'+p(d.getHours())+p(d.getMinutes())+p(d.getSeconds());
+      s = s ? s+'-'+ts : 'post-'+ts;
+    }
+    if(s.length>80){ s=s.slice(0,80).replace(/-[a-z0-9]*$/,'')||s.slice(0,80); }
+    return s;
+  }
+  // --- insertMarkdown: textarea の選択範囲に Markdown 記号を挿入 ---
+  // インライン(kind=bold/link)は選択範囲を記号で囲む。ブロック(kind=h2/h3/ul/ol/quote)は行頭に prefix。
+  // kind=hr はカーソル位置に区切り線を挿入。挿入後に input イベントを発火（プレビュー・下書き保存が連動）。
+  function insertMarkdown(ta,kind){
+    var s=ta.selectionStart,e=ta.selectionEnd,val=ta.value;
+    var before=val.slice(0,s),sel=val.slice(s,e),after=val.slice(e);
+    var prefix='',suffix='',block=false;
+    if(kind==='bold'){prefix='**';suffix='**';}
+    else if(kind==='h2'){block=true;prefix='## ';}
+    else if(kind==='h3'){block=true;prefix='### ';}
+    else if(kind==='link'){prefix='[';suffix='](https://example.com)';}
+    else if(kind==='ul'){block=true;prefix='- ';}
+    else if(kind==='ol'){block=true;prefix='1. ';}
+    else if(kind==='quote'){block=true;prefix='> ';}
+    else if(kind==='hr'){
+      ta.value=before+'\\n---\\n'+after;
+      ta.selectionStart=ta.selectionEnd=before.length+5;
+      ta.focus(); ta.dispatchEvent(new Event('input')); return;
+    } else { return; }
+    if(block){
+      var lineStart=before.lastIndexOf('\\n')+1;
+      var seg=val.slice(lineStart,e);
+      var newSeg=seg.split('\\n').map(function(l){return prefix+l;}).join('\\n');
+      ta.value=val.slice(0,lineStart)+newSeg+after;
+      ta.selectionStart=lineStart; ta.selectionEnd=lineStart+newSeg.length;
+    } else {
+      ta.value=before+prefix+sel+suffix+after;
+      if(sel){ ta.selectionStart=s+prefix.length; ta.selectionEnd=s+prefix.length+sel.length; }
+      else { ta.selectionStart=ta.selectionEnd=s+prefix.length; }
+    }
+    ta.focus();
+    ta.dispatchEvent(new Event('input'));
+  }
+  // --- wireToolbar: container 内の [data-md] ボタンにクリックハンドラを束ねる ---
+  function wireToolbar(container,ta){
+    if(!container||!ta) return;
+    var btns=container.querySelectorAll('[data-md]');
+    for(var i=0;i<btns.length;i++){
+      (function(btn){ btn.addEventListener('click',function(ev){ ev.preventDefault(); insertMarkdown(ta,btn.getAttribute('data-md')); }); })(btns[i]);
+    }
+  }
+  // --- LocalStorage 下書き（プライベートモード・容量超過は静かに無視） ---
+  function saveDraft(key,data){ try{ localStorage.setItem(key,JSON.stringify(data)); }catch(_){} }
+  function loadDraft(key){ try{ var v=localStorage.getItem(key); return v?JSON.parse(v):null; }catch(_){ return null; } }
+  function clearDraft(key){ try{ localStorage.removeItem(key); }catch(_){} }
+`;

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -108,6 +108,7 @@ export interface ArticleInput {
   summary?: string;
   publishedAt?: string;
   featured?: boolean;
+  isDraft?: boolean;
 }
 // collection 判別可能なユニオン型。blog/news/cases 各々で category を厳密に型付けする（4b3c257 以前の blog 厳密性を回復）。
 type NormalizedArticleCommon = {
@@ -120,6 +121,9 @@ type NormalizedArticleCommon = {
   summary?: string;
   publishedAt?: string;
   featured?: boolean;
+  // isDraft: 「下書きとして保存」用。true なら frontmatter に isDraft: true を書き、
+  // サイト一覧（!data.isDraft フィルタ）で非表示。既定 false で従来の公開挙動は不変。
+  isDraft: boolean;
 };
 export type NormalizedArticle =
   | (NormalizedArticleCommon & { collection: 'blog'; category: BlogCategory })
@@ -178,6 +182,7 @@ export function normalizeArticle(
         ? sanitizeText(a.publishedAt, 10)
         : undefined,
     featured: a.featured === true,
+    isDraft: a.isDraft === true,
   };
   // coll をリテラル狭めし、各コレクションの厳密な category 型を持つユニオンメンバを構築する。
   let article: NormalizedArticle;


### PR DESCRIPTION
## ① なぜ

Issue #220 の M1-I2 として、既存の読みものCMS投稿画面を非エンジニアでも扱いやすい入力体験へ寄せるためです。slug の手入力、Markdown 記法、下書き喪失、技術的な validation 文言が投稿の障壁になっていました。

Refs #220

## ② どう実装したか

- タイトルから slug を自動生成し、URL編集を上級者向け操作へ移動
- Markdown を知らなくても本文を整えられるツールバーとプレビュー導線を追加
- ブラウザ下書き保存・復元・破棄の導線を追加
- validation の表示を投稿者向けの文言へ整理
- UI helper と validation の回帰テストを追加

## ③ 特にレビューしてほしい点

- slug 自動生成と手動編集の境界が、既存記事URLを壊さないか
- 下書き保存/復元/破棄が公開操作と混線しないか
- validation 文言が非エンジニア向けとして十分に具体的か

## 含めないもの

- OGP PNG化
- News / cases CMS
- 既存記事編集 M1-I3
- 公開ブログUI刷新
- SEO/security audit

## ④ テスト・確認方法

- `npm --prefix workers/yomimono run typecheck`
- `npm --prefix workers/yomimono test -- --run`（6 files / 193 tests）
- `git diff --check origin/develop...HEAD`
- GitHub Checks
  - `claude-review`: pass
  - `Chromium visual text audit`: pass

## 実ブラウザ証跡

ローカル Worker に dummy `.dev.vars` を一時投入して確認し、確認後に削除済みです。本番秘密情報は使用していません。

- login UI: `/tmp/corsweb-220-evidence/m1-i2-local-login.png`
- admin hub: `/tmp/corsweb-220-evidence/m1-i2-local-admin-hub.png`
- manual empty: `/tmp/corsweb-220-evidence/m1-i2-local-manual-empty.png`
- slug auto-generation: `/tmp/corsweb-220-evidence/m1-i2-local-manual-filled-slug.png`
  - `AI導入チェックリスト 2026` -> `aichietsukurisuto-2026`
- toolbar insertion: `/tmp/corsweb-220-evidence/m1-i2-local-manual-toolbar.png`
- draft saved: `/tmp/corsweb-220-evidence/m1-i2-local-manual-draft-saved.png`
- draft restore banner: `/tmp/corsweb-220-evidence/m1-i2-local-manual-draft-restore-banner.png`
- draft restored: `/tmp/corsweb-220-evidence/m1-i2-local-manual-draft-restored.png`
- precheck: `/tmp/corsweb-220-evidence/m1-i2-local-manual-precheck.png`
  - `/blog-admin/api/validate` returned 200 locally
  - UI showed `✓ 違反なし。公開できます`

## 未取得の証跡

Cloudflare Worker の live route 反映後の `https://cor-jp.com/blog-admin/login`, `/blog-admin/`, `/blog-admin/manual` は未取得です。develop 統合後に Worker deploy 経路を確認して取得します。
