### PR TITLE
feat(blog): 読み物向けブログUIを刷新

### DIFF
--- a/e2e/blog.spec.ts
+++ b/e2e/blog.spec.ts
@@ -3,17 +3,17 @@ import { test, expect } from '@playwright/test';
 test.describe('Blog functionality', () => {
   test('should load homepage', async ({ page }) => {
     await page.goto('/');
-    await expect(page).toHaveTitle(/Cor\.inc/);
+    await expect(page).toHaveTitle(/Cor\./);
   });
 
   test('should navigate to Japanese blog', async ({ page }) => {
     await page.goto('/blog/');
-    await expect(page.locator('h1')).toContainText('技術ブログ');
+    await expect(page.getByRole('heading', { name: 'ブログ', exact: true })).toBeVisible();
   });
 
   test('should navigate to English blog', async ({ page }) => {
     await page.goto('/en/blog/');
-    await expect(page.locator('h1')).toContainText('Tech Blog');
+    await expect(page.getByRole('heading', { name: 'Blog', exact: true })).toBeVisible();
   });
 
   test('should display blog posts on Japanese blog page', async ({ page }) => {
@@ -28,16 +28,14 @@ test.describe('Blog functionality', () => {
     await expect(blogPosts.first()).toBeVisible();
   });
 
-  test('should allow language switching', async ({ page }) => {
-    await page.goto('/');
-    
-    // Switch to English
-    await page.click('[data-testid="language-toggle"]');
-    await expect(page).toHaveURL('/en/');
-    
-    // Switch back to Japanese
-    await page.click('[data-testid="language-toggle"]');
-    await expect(page).toHaveURL('/');
+  test('should display category and tag article lists', async ({ page }) => {
+    await page.goto('/blog/category/ai/');
+    await expect(page.getByRole('heading', { name: 'AI', exact: true })).toBeVisible();
+    await expect(page.locator('[data-testid="blog-post"]').first()).toBeVisible();
+
+    await page.goto('/blog/tags/Astro/');
+    await expect(page.getByRole('heading', { name: '#Astro', exact: true })).toBeVisible();
+    await expect(page.locator('[data-testid="blog-post"]').first()).toBeVisible();
   });
 
   test('should display OGP image for blog posts', async ({ page }) => {
@@ -47,6 +45,6 @@ test.describe('Blog functionality', () => {
     
     // Check if OGP meta tags exist
     const ogImage = page.locator('meta[property="og:image"]');
-    await expect(ogImage).toHaveAttribute('content', /\/og\/.*\.svg/);
+    await expect(ogImage).toHaveAttribute('content', /\/og\/.*\.(svg|png)$/);
   });
 });

--- a/src/components/blog/BlogArchiveHeader.astro
+++ b/src/components/blog/BlogArchiveHeader.astro
@@ -1,0 +1,62 @@
+---
+interface Props {
+  eyebrow: string;
+  title: string;
+  description: string;
+  countLabel?: string;
+  rssHref?: string;
+  rssLabel?: string;
+  backHref?: string;
+  backLabel?: string;
+}
+
+const {
+  eyebrow,
+  title,
+  description,
+  countLabel,
+  rssHref,
+  rssLabel,
+  backHref,
+  backLabel,
+} = Astro.props;
+---
+
+<header class="mx-auto max-w-3xl py-12 text-center sm:py-16">
+  {backHref && backLabel && (
+    <div class="mb-5">
+      <a
+        href={backHref}
+        class="inline-flex items-center text-sm font-medium text-stone-500 transition-colors duration-150 hover:text-stone-800 dark:text-stone-400 dark:hover:text-stone-100"
+      >
+        <span aria-hidden="true" class="mr-1">←</span>
+        {backLabel}
+      </a>
+    </div>
+  )}
+
+  <p class="mb-3 text-sm font-semibold text-blue-700 dark:text-blue-300">
+    {eyebrow}
+  </p>
+  <h1 class="text-balance text-3xl font-semibold leading-tight text-stone-950 dark:text-stone-50 sm:text-5xl">
+    {title}
+  </h1>
+  <p class="mx-auto mt-5 max-w-2xl text-pretty text-base leading-8 text-stone-600 dark:text-stone-300 sm:text-lg">
+    {description}
+  </p>
+
+  {(countLabel || rssHref) && (
+    <div class="mt-6 flex flex-wrap items-center justify-center gap-3 text-sm text-stone-500 dark:text-stone-400">
+      {countLabel && <span class="tabular-nums">{countLabel}</span>}
+      {countLabel && rssHref && <span aria-hidden="true">/</span>}
+      {rssHref && rssLabel && (
+        <a
+          href={rssHref}
+          class="font-medium text-stone-600 transition-colors duration-150 hover:text-blue-700 dark:text-stone-300 dark:hover:text-blue-300"
+        >
+          {rssLabel}
+        </a>
+      )}
+    </div>
+  )}
+</header>

--- a/src/components/blog/BlogCategoryNav.astro
+++ b/src/components/blog/BlogCategoryNav.astro
@@ -1,0 +1,51 @@
+---
+import { BLOG_CATEGORIES, getCategoryLabel } from '../../config/categories';
+import { getCurrentLocale, getLocalizedUrl } from '../../utils/i18n';
+
+interface Props {
+  currentCategory?: string;
+}
+
+const { currentCategory } = Astro.props;
+const currentLocale = getCurrentLocale(Astro.url);
+
+const labels = {
+  ja: { all: 'すべて', nav: 'カテゴリ' },
+  en: { all: 'All', nav: 'Categories' },
+  zh: { all: '全部', nav: '分类' },
+  ko: { all: '전체', nav: '카테고리' },
+  es: { all: 'Todo', nav: 'Categorías' },
+};
+
+const currentLabels = labels[currentLocale] ?? labels.en;
+const allHref = getLocalizedUrl('/blog', currentLocale);
+---
+
+<nav class="mb-8 border-y border-stone-200 py-4 dark:border-stone-800" aria-label={currentLabels.nav}>
+  <div class="mx-auto flex max-w-5xl gap-2 overflow-x-auto px-4 sm:flex-wrap sm:justify-center sm:px-0">
+    <a
+      href={allHref}
+      class={`shrink-0 rounded-full border px-4 py-2 text-sm font-medium transition-colors duration-150 ${
+        !currentCategory
+          ? 'border-stone-950 bg-stone-950 text-white dark:border-stone-100 dark:bg-stone-100 dark:text-stone-950'
+          : 'border-stone-200 bg-white text-stone-700 hover:border-stone-400 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-200 dark:hover:border-stone-500'
+      }`}
+      aria-current={!currentCategory ? 'page' : undefined}
+    >
+      {currentLabels.all}
+    </a>
+    {BLOG_CATEGORIES.map((category) => (
+      <a
+        href={getLocalizedUrl(`/blog/category/${category.id}`, currentLocale)}
+        class={`shrink-0 rounded-full border px-4 py-2 text-sm font-medium transition-colors duration-150 ${
+          category.id === currentCategory
+            ? 'border-stone-950 bg-stone-950 text-white dark:border-stone-100 dark:bg-stone-100 dark:text-stone-950'
+            : 'border-stone-200 bg-white text-stone-700 hover:border-stone-400 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-200 dark:hover:border-stone-500'
+        }`}
+        aria-current={category.id === currentCategory ? 'page' : undefined}
+      >
+        {getCategoryLabel(category.id, currentLocale)}
+      </a>
+    ))}
+  </div>
+</nav>

--- a/src/components/blog/CategoryBadge.astro
+++ b/src/components/blog/CategoryBadge.astro
@@ -1,4 +1,5 @@
 ---
+import { getCategoryLabel } from '../../config/categories';
 import { getCurrentLocale } from '../../utils/i18n';
 
 interface Props {
@@ -12,44 +13,11 @@ const categoryColors = {
   'ai': 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
   'engineering': 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200',
   'founder': 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
-  'lab': 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
-};
-
-const categoryLabels = {
-  ja: {
-    'ai': 'AI',
-    'engineering': 'エンジニアリング',
-    'founder': '創業',
-    'lab': 'ラボ',
-  },
-  en: {
-    'ai': 'AI',
-    'engineering': 'Engineering',
-    'founder': 'Founder',
-    'lab': 'Lab',
-  },
-  zh: {
-    'ai': '人工智能',
-    'engineering': '工程',
-    'founder': '創業',
-    'lab': '實驗室',
-  },
-  ko: {
-    'ai': 'AI',
-    'engineering': '엔지니어링',
-    'founder': '창업',
-    'lab': '연구소',
-  },
-  es: {
-    'ai': 'IA',
-    'engineering': 'Ingeniería',
-    'founder': 'Fundador',
-    'lab': 'Laboratorio',
-  },
+  'lab': 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
 };
 
 const colorClass = categoryColors[category as keyof typeof categoryColors] || 'bg-stone-100 text-stone-800 dark:bg-stone-700 dark:text-stone-200';
-const label = categoryLabels[currentLocale as keyof typeof categoryLabels]?.[category as keyof typeof categoryLabels['ja']] || category;
+const label = getCategoryLabel(category, currentLocale);
 ---
 
 <span class={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${colorClass}`}>

--- a/src/components/blog/PostCard.astro
+++ b/src/components/blog/PostCard.astro
@@ -18,13 +18,30 @@ interface Props {
       featured?: boolean;
     };
   };
+  variant?: 'card' | 'feed' | 'compact';
 }
 
-const { post } = Astro.props;
-const { title, description, pubDate, category, tags, image } = post.data;
+const { post, variant = 'card' } = Astro.props;
+const { title, description, pubDate, author, category, tags, image } = post.data;
 const currentLocale = getCurrentLocale(Astro.url);
 
-const formattedDate = new Date(pubDate).toLocaleDateString(currentLocale === 'ja' ? 'ja-JP' : 'en-US', {
+const localeMap = {
+  ja: 'ja-JP',
+  en: 'en-US',
+  zh: 'zh-CN',
+  ko: 'ko-KR',
+  es: 'es-ES',
+};
+
+const labels = {
+  ja: { read: '記事を読む', by: '著者' },
+  en: { read: 'Read article', by: 'By' },
+  zh: { read: '阅读文章', by: '作者' },
+  ko: { read: '글 읽기', by: '작성자' },
+  es: { read: 'Leer artículo', by: 'Por' },
+};
+
+const formattedDate = new Date(pubDate).toLocaleDateString(localeMap[currentLocale], {
   year: 'numeric',
   month: 'long',
   day: 'numeric',
@@ -33,60 +50,116 @@ const formattedDate = new Date(pubDate).toLocaleDateString(currentLocale === 'ja
 // Remove leading language code (e.g., 'ja/', 'en/', 'fr/') dynamically
 const cleanSlug = post.slug.replace(/^[a-z]{2}\/|^[a-z]{2}-[A-Z]{2}\//, '');
 const postUrl = currentLocale === 'ja' ? `/blog/${cleanSlug}` : `/${currentLocale}/blog/${cleanSlug}`;
+const currentLabels = labels[currentLocale] ?? labels.en;
+
+const articleClass = variant === 'feed'
+  ? 'group relative overflow-hidden rounded-lg border border-stone-200 bg-white shadow-sm transition-shadow duration-150 hover:shadow-md dark:border-stone-800 dark:bg-stone-900'
+  : variant === 'compact'
+    ? 'group relative flex h-full flex-col overflow-hidden rounded-lg border border-stone-200 bg-white shadow-sm transition-shadow duration-150 hover:shadow-md dark:border-stone-800 dark:bg-stone-900'
+    : 'group relative flex h-full min-h-80 flex-col overflow-hidden rounded-lg border border-stone-200 bg-white shadow-sm transition-shadow duration-150 hover:shadow-md dark:border-stone-800 dark:bg-stone-900';
 ---
 
-<article class="group relative flex h-full min-h-80 flex-col overflow-hidden rounded-2xl bg-white shadow-sm transition-all duration-300 hover:shadow-lg dark:bg-stone-800">
-  <a href={postUrl} class="absolute inset-0 z-10" aria-label={title}>
-    <span class="sr-only">{
-      currentLocale === 'ja' ? '記事を読む' :
-      currentLocale === 'zh' ? '阅读文章' :
-      currentLocale === 'ko' ? '글 읽기' :
-      currentLocale === 'es' ? 'Leer artículo' :
-      'Read article'
-    }</span>
+<article data-testid="blog-post" class={articleClass}>
+  <a href={postUrl} class="absolute inset-0 z-10" aria-label={`${currentLabels.read}: ${title}`}>
+    <span class="sr-only">{currentLabels.read}</span>
   </a>
-  
-  {image && (
-    <div class="aspect-[16/9] overflow-hidden rounded-t-2xl">
-      <img
-        src={image.url}
-        alt={image.alt}
-        loading="lazy"
-        decoding="async"
-        class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
-      />
-    </div>
-  )}
-  
-  <div class="flex flex-1 flex-col p-6">
-    <div class="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
-      <CategoryBadge category={category} />
-      <time datetime={new Date(pubDate).toISOString()} class="shrink-0 text-stone-500 dark:text-stone-400">
-        {formattedDate}
-      </time>
-    </div>
-    
-    <h3 class="mb-2 line-clamp-2 text-balance text-lg font-semibold leading-snug text-stone-900 transition-colors group-hover:text-blue-600 dark:text-stone-100 dark:group-hover:text-blue-400">
-      {title}
-    </h3>
-    
-    <p class="mb-4 line-clamp-3 flex-1 text-pretty text-sm leading-6 text-stone-600 dark:text-stone-300">
-      {description}
-    </p>
-    
-    {tags.length > 0 && (
-      <div class="mt-auto flex flex-wrap items-center gap-1.5 pt-2">
-        {tags.slice(0, 2).map(tag => (
-          <span class="max-w-full rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 dark:bg-stone-700 dark:text-stone-300">
-            #{tag}
+
+  {variant === 'feed' ? (
+    <div class="grid gap-4 p-4 sm:grid-cols-[10rem_minmax(0,1fr)] sm:p-5">
+      {image ? (
+        <div class="aspect-[16/10] overflow-hidden rounded-md bg-stone-100 dark:bg-stone-800 sm:aspect-square">
+          <img
+            src={image.url}
+            alt={image.alt}
+            loading="lazy"
+            decoding="async"
+            class="h-full w-full object-cover transition-transform duration-150 group-hover:scale-[1.02]"
+          />
+        </div>
+      ) : (
+        <div class="hidden aspect-square rounded-md border border-stone-200 bg-stone-50 dark:border-stone-800 dark:bg-stone-950 sm:block" aria-hidden="true"></div>
+      )}
+
+      <div class="flex min-w-0 flex-col gap-3">
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+          <CategoryBadge category={category} />
+          <time datetime={new Date(pubDate).toISOString()} class="shrink-0 tabular-nums text-stone-500 dark:text-stone-400">
+            {formattedDate}
+          </time>
+          <span class="min-w-0 truncate text-stone-500 dark:text-stone-400">
+            {currentLabels.by} {author}
           </span>
-        ))}
-        {tags.length > 2 && (
-          <span class="text-xs text-stone-500 dark:text-stone-400">
-            +{tags.length - 2}
-          </span>
+        </div>
+
+        <h2 class="line-clamp-2 text-balance text-xl font-semibold leading-snug text-stone-950 transition-colors duration-150 group-hover:text-blue-700 dark:text-stone-50 dark:group-hover:text-blue-300">
+          {title}
+        </h2>
+
+        <p class="line-clamp-2 text-pretty text-sm leading-6 text-stone-600 dark:text-stone-300 sm:text-base sm:leading-7">
+          {description}
+        </p>
+
+        {tags.length > 0 && (
+          <div class="relative z-20 mt-auto flex flex-wrap items-center gap-2">
+            {tags.slice(0, 3).map(tag => (
+              <span class="max-w-full truncate rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-600 dark:bg-stone-800 dark:text-stone-300">
+                #{tag}
+              </span>
+            ))}
+            {tags.length > 3 && (
+              <span class="text-xs tabular-nums text-stone-500 dark:text-stone-400">
+                +{tags.length - 3}
+              </span>
+            )}
+          </div>
         )}
       </div>
-    )}
-  </div>
+    </div>
+  ) : (
+    <>
+      {image && (
+        <div class="aspect-[16/9] overflow-hidden">
+          <img
+            src={image.url}
+            alt={image.alt}
+            loading="lazy"
+            decoding="async"
+            class="h-full w-full object-cover transition-transform duration-150 group-hover:scale-[1.02]"
+          />
+        </div>
+      )}
+
+      <div class={`flex flex-1 flex-col ${variant === 'compact' ? 'p-4' : 'p-5'}`}>
+        <div class="mb-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+          <CategoryBadge category={category} />
+          <time datetime={new Date(pubDate).toISOString()} class="shrink-0 tabular-nums text-stone-500 dark:text-stone-400">
+            {formattedDate}
+          </time>
+        </div>
+
+        <h3 class={`${variant === 'compact' ? 'text-base' : 'text-lg'} mb-2 line-clamp-2 text-balance font-semibold leading-snug text-stone-950 transition-colors duration-150 group-hover:text-blue-700 dark:text-stone-50 dark:group-hover:text-blue-300`}>
+          {title}
+        </h3>
+
+        <p class="mb-4 line-clamp-3 flex-1 text-pretty text-sm leading-6 text-stone-600 dark:text-stone-300">
+          {description}
+        </p>
+
+        {tags.length > 0 && (
+          <div class="mt-auto flex flex-wrap items-center gap-1.5 pt-2">
+            {tags.slice(0, 2).map(tag => (
+              <span class="max-w-full truncate rounded-full bg-stone-100 px-2 py-1 text-xs font-medium text-stone-600 dark:bg-stone-800 dark:text-stone-300">
+                #{tag}
+              </span>
+            ))}
+            {tags.length > 2 && (
+              <span class="text-xs tabular-nums text-stone-500 dark:text-stone-400">
+                +{tags.length - 2}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  )}
 </article>

--- a/src/components/blog/TagList.astro
+++ b/src/components/blog/TagList.astro
@@ -1,5 +1,5 @@
 ---
-import { getCurrentLocale } from '../../utils/i18n';
+import { getCurrentLocale, getLocalizedUrl } from '../../utils/i18n';
 
 interface Props {
   tags: string[];
@@ -16,8 +16,8 @@ const currentLocale = getCurrentLocale(Astro.url);
   <div class="flex flex-wrap gap-2">
     {displayTags.map(tag => (
       <a
-        href={currentLocale === 'ja' ? `/blog/tags/${tag}` : `/en/blog/tags/${tag}`}
-        class="inline-flex items-center rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700 transition-colors hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600"
+        href={getLocalizedUrl(`/blog/tags/${tag}`, currentLocale)}
+        class="inline-flex max-w-full items-center rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700 transition-colors duration-150 hover:bg-stone-200 dark:bg-stone-800 dark:text-stone-200 dark:hover:bg-stone-700"
       >
         #{tag}
       </a>

--- a/src/components/blog/TipButton.astro
+++ b/src/components/blog/TipButton.astro
@@ -21,10 +21,10 @@ const tipButtonText = currentLocale === 'ja' ? '投げ銭する' : 'Send Tip';
 ---
 
 {isTipEnabled && stripePaymentLink && (
-<div class={`rounded-2xl border border-stone-200 bg-gradient-to-br from-blue-50 to-indigo-50 p-6 dark:border-stone-700 dark:from-stone-800 dark:to-stone-900 ${className}`}>
+<div class={`rounded-lg border border-stone-200 bg-white p-6 shadow-sm dark:border-stone-800 dark:bg-stone-900 ${className}`}>
   <div class="flex items-start gap-4">
     <div class="flex-shrink-0">
-      <div class="flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900">
+      <div class="flex size-12 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900">
         <svg class="h-6 w-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
         </svg>
@@ -68,4 +68,3 @@ const tipButtonText = currentLocale === 'ja' ? '投げ銭する' : 'Send Tip';
   </div>
 </div>
 )}
-

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -37,7 +37,7 @@ interface Props {
   prevPost?: BlogPost;
 }
 
-const { post, relatedPosts, nextPost, prevPost } = Astro.props;
+const { post } = Astro.props;
 const currentLocale = getCurrentLocale(Astro.url);
 const { title, description, pubDate, updatedDate, author, category, tags, image, ogImage } = post.data;
 
@@ -181,6 +181,10 @@ const keywords = generateKeywords(tags, category, currentLocale);
       [x-cloak] { display: none !important; }
       
       /* Blog specific styles */
+      .prose {
+        max-width: none;
+      }
+
       .prose :where(h1, h2, h3) {
         word-break: auto-phrase;
         overflow-wrap: anywhere;
@@ -193,10 +197,41 @@ const keywords = generateKeywords(tags, category, currentLocale);
         overflow-wrap: break-word;
         line-break: strict;
         text-wrap: pretty;
+        line-height: 1.9;
       }
 
       .prose :where(a) {
         overflow-wrap: anywhere;
+      }
+
+      .prose :where(h2) {
+        border-top: 1px solid #e7e5e4;
+        margin-top: 3rem;
+        padding-top: 2rem;
+      }
+
+      .dark .prose :where(h2) {
+        border-top-color: #44403c;
+      }
+
+      .prose :where(blockquote) {
+        border-left-color: #2563eb;
+        background-color: #fafaf9;
+        border-radius: 0.5rem;
+        padding: 1rem 1.25rem;
+      }
+
+      .dark .prose :where(blockquote) {
+        background-color: #1c1917;
+      }
+
+      .prose :where(img) {
+        border-radius: 0.5rem;
+        border: 1px solid #e7e5e4;
+      }
+
+      .dark .prose :where(img) {
+        border-color: #44403c;
       }
 
       .prose pre {
@@ -258,9 +293,9 @@ const keywords = generateKeywords(tags, category, currentLocale);
       /* Link Card Styles */
       .remark-link-card-plus__container {
         margin: 1.5rem 0;
-        border-radius: 0.75rem;
+        border-radius: 0.5rem;
         overflow: hidden;
-        transition: all 0.3s ease;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
         background-color: #fafaf9;
         border: 1px solid #e7e5e4;
       }
@@ -308,7 +343,7 @@ const keywords = generateKeywords(tags, category, currentLocale);
         width: 100%;
         height: 100%;
         object-fit: cover;
-        transition: transform 0.3s ease;
+        transition: transform 0.15s ease;
       }
       
       .remark-link-card-plus__card:hover .remark-link-card-plus__image {

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -2,9 +2,10 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../components/blog/PostCard.astro';
 import Layout from '../../layouts/Layout.astro';
-import { getCurrentLocale } from '../../utils/i18n';
 
 interface Props {
   page: Page<CollectionEntry<'blog'>>;
@@ -26,76 +27,34 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 };
 
 const { page } = Astro.props;
-const currentLocale = getCurrentLocale(Astro.url);
-const pageTitle = currentLocale === 'ja' ? '技術ブログ | Cor.inc' : 'Tech Blog | Cor.inc';
-const pageDescription = currentLocale === 'ja' 
-  ? 'AI・機械学習、エンジニアリング、スタートアップ創業、技術革新に関する最新の技術ブログ。開発者・エンジニア向けの実践的な知識と洞察をお届けします。'
-  : 'Latest tech blog covering AI/Machine Learning, software engineering, startup journey, and innovation. Practical insights and knowledge for developers and engineers.';
-
-// Categories for filtering
-const categories = [
-  { id: 'all', label: currentLocale === 'ja' ? 'すべて' : 'All' },
-  { id: 'ai', label: currentLocale === 'ja' ? 'AI' : 'AI' },
-  { id: 'engineering', label: currentLocale === 'ja' ? 'エンジニアリング' : 'Engineering' },
-  { id: 'founder', label: currentLocale === 'ja' ? '創業' : 'Founder' },
-  { id: 'lab', label: currentLocale === 'ja' ? 'ラボ' : 'Lab' },
-];
+const pageTitle = 'ブログ | Cor.inc';
+const pageDescription = 'AI活用、開発、経営の現場で得た知見を、専門外の方にも読みやすい形でまとめています。';
+const countLabel = page.total > page.size
+  ? `${page.total}記事中 ${page.start + 1}-${page.end}記事を表示`
+  : `${page.total}記事`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        {currentLocale === 'ja' ? 'ブログ' : 'Blog'}
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- RSS Feed Link -->
-      <div class="mt-4">
-        <a 
-          href="/rss.xml" 
-          class="inline-flex items-center gap-2 text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-          title="RSSフィードを購読"
-        >
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-            <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
-            <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
-          </svg>
-          {currentLocale === 'ja' ? 'RSS購読' : 'RSS Feed'}
-        </a>
-      </div>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          {`${page.total}記事中 ${page.start + 1}-${page.end}記事を表示 (${page.currentPage}/${page.lastPage}ページ)`}
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Cor.inc Blog"
+      title="ブログ"
+      description={pageDescription}
+      countLabel={countLabel}
+      rssHref="/rss.xml"
+      rssLabel="RSS"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/blog' : `/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.length > 0 ? (
         page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))
       ) : (
-        <div class="col-span-full text-center py-12">
+        <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
           <p class="text-lg text-stone-600 dark:text-stone-300">
             ブログ記事を準備中です。しばらくお待ちください。
           </p>
@@ -115,11 +74,11 @@ const categories = [
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
-          {currentLocale === 'ja' ? '前へ' : 'Previous'}
+          前へ
         </a>
         
         <!-- Page Numbers -->
@@ -129,8 +88,8 @@ const categories = [
               href={pageNum === 1 ? '/blog' : `/blog/${pageNum}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 pageNum === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={pageNum === page.currentPage ? 'page' : undefined}
             >
@@ -145,11 +104,11 @@ const categories = [
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >
-          {currentLocale === 'ja' ? '次へ' : 'Next'}
+          次へ
         </a>
       </nav>
     )}

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -64,77 +64,8 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
 
 ---
 
-<style>
-  /* Hide the appended heading links to keep clean heading appearance */
-  .prose .heading-link {
-    opacity: 0;
-    transition: opacity 0.2s;
-    text-decoration: none;
-    margin-left: 0.5rem;
-    font-size: 0.875em;
-  }
-  
-  .prose h1:hover .heading-link,
-  .prose h2:hover .heading-link,
-  .prose h3:hover .heading-link,
-  .prose h4:hover .heading-link,
-  .prose h5:hover .heading-link,
-  .prose h6:hover .heading-link {
-    opacity: 0.7;
-  }
-  
-  .prose .heading-link:hover {
-    opacity: 1;
-  }
-
-  /* Ensure proper heading styles */
-  .prose h1 {
-    font-size: 2rem !important;
-    font-weight: 700 !important;
-    line-height: 1.25 !important;
-    color: rgb(28 25 23) !important;
-    margin-top: 2rem !important;
-    margin-bottom: 1.5rem !important;
-  }
-
-  .prose h2 {
-    font-size: 1.5rem !important;
-    font-weight: 700 !important;
-    line-height: 1.375 !important;
-    color: rgb(28 25 23) !important;
-    margin-top: 2rem !important;
-    margin-bottom: 1rem !important;
-  }
-
-  .prose h3 {
-    font-size: 1.25rem !important;
-    font-weight: 600 !important;
-    line-height: 1.5 !important;
-    color: rgb(28 25 23) !important;
-    margin-top: 1.5rem !important;
-    margin-bottom: 0.75rem !important;
-  }
-
-  .prose h4 {
-    font-size: 1.125rem !important;
-    font-weight: 600 !important;
-    line-height: 1.5 !important;
-    color: rgb(28 25 23) !important;
-    margin-top: 1rem !important;
-    margin-bottom: 0.5rem !important;
-  }
-
-  /* Dark mode heading colors */
-  .dark .prose h1,
-  .dark .prose h2,
-  .dark .prose h3,
-  .dark .prose h4 {
-    color: rgb(245 245 244) !important;
-  }
-</style>
-
 <BlogLayout post={post} relatedPosts={relatedPosts} nextPost={nextPost} prevPost={prevPost}>
-  <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+  <article class="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
       <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
@@ -194,7 +125,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
 
     <!-- Featured Image -->
     {post.data.image && (
-      <div class="mb-8 overflow-hidden rounded-2xl">
+      <div class="mb-8 overflow-hidden rounded-lg">
         <img
           src={post.data.image.url}
           alt={post.data.image.alt}
@@ -225,7 +156,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     <!-- Tags -->
     {post.data.tags.length > 0 && (
       <div class="mt-12 border-t border-stone-200 pt-8 dark:border-stone-700">
-        <h3 class="mb-4 text-sm font-medium uppercase tracking-wider text-stone-500 dark:text-stone-400">
+        <h3 class="mb-4 text-sm font-medium text-stone-500 dark:text-stone-400">
           {currentLocale === 'ja' ? 'タグ' : 'Tags'}
         </h3>
         <TagList tags={post.data.tags} />
@@ -271,7 +202,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
         </h2>
         <div class="grid gap-8 md:grid-cols-3">
           {relatedPosts.map(relatedPost => (
-            <PostCard post={relatedPost} />
+            <PostCard post={relatedPost} variant="compact" />
           ))}
         </div>
       </section>

--- a/src/pages/blog/category/[id]/[...page].astro
+++ b/src/pages/blog/category/[id]/[...page].astro
@@ -2,6 +2,8 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../components/blog/PostCard.astro';
 import { BLOG_CATEGORIES, getCategoryDescription, getCategoryLabel } from '../../../../config/categories';
 import Layout from '../../../../layouts/Layout.astro';
@@ -49,64 +51,28 @@ const pageTitle = `${categoryLabel} | Blog | Cor.inc`;
 const categoryDesc = getCategoryDescription(id, currentLocale === 'ja' ? 'ja' : 'en');
 const pageDescription = categoryDesc || (currentLocale === 'ja'
   ? `${categoryLabel} に属するブログ記事一覧` : `Blog posts in ${categoryLabel}`);
-
-// 「すべて」リンクのアクティブ判定
-const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
-
+const countLabel = page.total > page.size
+  ? `${page.total}記事中 ${page.start + 1}-${page.end}記事を表示`
+  : `${page.total}記事`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        {categoryLabel}
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          {currentLocale === 'ja' 
-            ? `${page.total}記事中 ${page.start + 1}-${page.end}記事を表示 (${page.currentPage}/${page.lastPage}ページ)`
-            : `Showing ${page.start + 1}-${page.end} of ${page.total} articles (Page ${page.currentPage} of ${page.lastPage})`
-          }
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Category"
+      title={categoryLabel}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/blog"
+      backLabel="ブログ一覧に戻る"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      <a
-        href={currentLocale === 'ja' ? '/blog' : '/en/blog'}
-        class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-          isAllActive
-            ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-            : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-        }`}
-      >
-        {currentLocale === 'ja' ? 'すべて' : 'All'}
-      </a>
-      {BLOG_CATEGORIES.map((category) => (
-        <a
-          href={currentLocale === 'ja' ? `/blog/category/${category.id}` : `/en/blog/category/${category.id}`}
-          class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-            category.id === id
-              ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-              : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-          }`}
-        >
-          {category.label[currentLocale === 'ja' ? 'ja' : 'en']}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav currentCategory={id} />
 
     <!-- 記事グリッド -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.map(post => (
-        <PostCard post={post} />
+        <PostCard post={post} variant="feed" />
       ))}
     </div>
 
@@ -116,7 +82,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
         {page.url.prev ? (
           <a
             href={`${base}blog/category/${id}${page.url.prev}`}
-            class={`rounded-lg px-3 py-2 text-sm font-medium bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600`}
+            class="rounded-lg bg-white px-3 py-2 text-sm font-medium text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800"
           >
             {currentLocale === 'ja' ? '前へ' : 'Previous'}
           </a>
@@ -134,8 +100,8 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
               href={`${base}blog/category/${id}${num === 1 ? '' : '/' + num}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 num === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={num === page.currentPage ? 'page' : undefined}
             >
@@ -147,7 +113,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
         {page.url.next ? (
           <a
             href={`${base}blog/category/${id}${page.url.next}`}
-            class={`rounded-lg px-3 py-2 text-sm font-medium bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600`}
+            class="rounded-lg bg-white px-3 py-2 text-sm font-medium text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800"
           >
             {currentLocale === 'ja' ? '次へ' : 'Next'}
           </a>

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -2,9 +2,10 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../components/blog/PostCard.astro';
 import Layout from '../../../../layouts/Layout.astro';
-import { getCurrentLocale } from '../../../../utils/i18n';
 
 interface Props {
   page: Page<CollectionEntry<'blog'>>;
@@ -36,73 +37,34 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 };
 
 const { page, tag } = Astro.props as Props;
-const currentLocale = getCurrentLocale(Astro.url);
 const pageTitle = `「${tag}」タグの記事 | Blog | Cor.inc`;
-const pageDescription = `「${tag}」タグが付いた記事の一覧。関連する技術記事やチュートリアルをご覧いただけます。`;
-
-// Categories for filtering
-const categories = [
-  { id: 'all', label: 'すべて' },
-  { id: 'ai', label: 'AI' },
-  { id: 'engineering', label: 'エンジニアリング' },
-  { id: 'founder', label: '創業' },
-  { id: 'lab', label: 'ラボ' },
-];
+const pageDescription = `「${tag}」に関する記事を、新しい順にまとめています。`;
+const countLabel = page.total > page.size
+  ? `${page.total}記事中 ${page.start + 1}-${page.end + 1}記事を表示`
+  : `${page.total}記事`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <div class="mb-4">
-        <a 
-          href="/blog" 
-          class="inline-flex items-center text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-        >
-          ← ブログ一覧に戻る
-        </a>
-      </div>
-      
-      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
-        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
-          <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-            #{tag}
-          </span>
-          タグの記事
-        </span>
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          {page.total}記事中 {page.start + 1}-{page.end + 1}記事を表示 (ページ {page.currentPage}/{page.lastPage})
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Tag"
+      title={`#${tag}`}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/blog"
+      backLabel="ブログ一覧に戻る"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/blog' : `/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.length > 0 ? (
         page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))
       ) : (
-        <div class="col-span-full text-center py-12">
+        <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
           <p class="text-lg text-stone-600 dark:text-stone-300">
             「{tag}」タグの記事が見つかりませんでした。
           </p>
@@ -122,7 +84,7 @@ const categories = [
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -136,8 +98,8 @@ const categories = [
               href={pageNum === 1 ? `/blog/tags/${tag}` : `/blog/tags/${tag}/${pageNum}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 pageNum === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={pageNum === page.currentPage ? 'page' : undefined}
             >
@@ -152,7 +114,7 @@ const categories = [
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/en/blog/[...page].astro
+++ b/src/pages/en/blog/[...page].astro
@@ -2,6 +2,8 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import Layout from '../../../layouts/Layout.astro';
 
@@ -25,73 +27,34 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 };
 
 const { page } = Astro.props;
-const pageTitle = 'Tech Blog | Cor.inc';
-const pageDescription = 'Latest tech blog covering AI/Machine Learning, software engineering, startup journey, and innovation. Practical insights and knowledge for developers and engineers.';
-
-// Categories for filtering
-const categories = [
-  { id: 'all', label: 'All' },
-  { id: 'ai', label: 'AI' },
-  { id: 'engineering', label: 'Engineering' },
-  { id: 'founder', label: 'Founder' },
-  { id: 'lab', label: 'Lab' },
-];
+const pageTitle = 'Blog | Cor.inc';
+const pageDescription = 'Clear notes from AI, product, and engineering work, written for readers who need the practical decision points first.';
+const countLabel = page.total > page.size
+  ? `Showing ${page.start + 1}-${page.end} of ${page.total} articles`
+  : `${page.total} articles`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        Blog
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- RSS Feed Link -->
-      <div class="mt-4">
-        <a 
-          href="/en/rss.xml" 
-          class="inline-flex items-center gap-2 text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-          title="Subscribe to RSS Feed"
-        >
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-            <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
-            <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
-          </svg>
-          RSS Feed
-        </a>
-      </div>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          Showing {page.start + 1}-{page.end} of {page.total} articles (Page {page.currentPage} of {page.lastPage})
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Cor.inc Blog"
+      title="Blog"
+      description={pageDescription}
+      countLabel={countLabel}
+      rssHref="/en/rss.xml"
+      rssLabel="RSS"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/en/blog' : `/en/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.length > 0 ? (
         page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))
       ) : (
-        <div class="col-span-full text-center py-12">
+        <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
           <p class="text-lg text-stone-600 dark:text-stone-300">
             Blog posts are coming soon. Please check back later.
           </p>
@@ -108,7 +71,7 @@ const categories = [
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -122,8 +85,8 @@ const categories = [
               href={pageNum === 1 ? '/en/blog' : `/en/blog/${pageNum}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 pageNum === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={pageNum === page.currentPage ? 'page' : undefined}
             >
@@ -138,7 +101,7 @@ const categories = [
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/en/blog/[...slug].astro
+++ b/src/pages/en/blog/[...slug].astro
@@ -4,9 +4,9 @@ import CategoryBadge from '../../../components/blog/CategoryBadge.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import ShareButtons from '../../../components/blog/ShareButtons.astro';
 import TableOfContents from '../../../components/blog/TableOfContents.astro';
+import TagList from '../../../components/blog/TagList.astro';
 import TipButton from '../../../components/blog/TipButton.astro';
 import BlogLayout from '../../../layouts/BlogLayout.astro';
-import { getCurrentLocale } from '../../../utils/i18n';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => {
@@ -23,7 +23,6 @@ interface Props { post: CollectionEntry<'blog'> }
 
 const { post } = Astro.props;
 const { Content, headings } = await post.render();
-const currentLocale = getCurrentLocale(Astro.url);
 
 // Get related posts and navigation posts
 const allPosts = await getCollection('blog', ({ data }) => {
@@ -48,12 +47,6 @@ const formattedPubDate = new Date(post.data.pubDate).toLocaleDateString('en-US',
   day: 'numeric',
 });
 
-const formattedUpdatedDate = post.data.updatedDate ? new Date(post.data.updatedDate).toLocaleDateString('en-US', {
-  year: 'numeric',
-  month: 'long',
-  day: 'numeric',
-}) : null;
-
 // Calculate reading time based on content length
 const readingTime = Math.max(1, Math.round(post.body.length / 1000));
 const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
@@ -61,7 +54,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <BlogLayout post={post} relatedPosts={relatedPosts} nextPost={nextPost} prevPost={prevPost}>
-  <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+  <article class="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
       <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
@@ -93,7 +86,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     </header>
 
     {post.data.image && (
-      <div class="mb-8 overflow-hidden rounded-2xl">
+      <div class="mb-8 overflow-hidden rounded-lg">
         <img src={post.data.image.url} alt={post.data.image.alt} class="h-auto w-full" loading="eager" decoding="async" />
       </div>
     )}
@@ -109,19 +102,10 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     <!-- Tags -->
     {post.data.tags.length > 0 && (
       <div class="mt-12 border-t border-stone-200 pt-8 dark:border-stone-700">
-        <h3 class="mb-4 text-sm font-medium uppercase tracking-wider text-stone-500 dark:text-stone-400">
+        <h3 class="mb-4 text-sm font-medium text-stone-500 dark:text-stone-400">
           Tags
         </h3>
-        <div class="flex flex-wrap gap-2">
-          {post.data.tags.map(tag => (
-            <a
-              href={`/en/blog/tags/${tag}`}
-              class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-300 dark:hover:bg-stone-600"
-            >
-              #{tag}
-            </a>
-          ))}
-        </div>
+        <TagList tags={post.data.tags} />
       </div>
     )}
 
@@ -164,7 +148,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
         </h2>
         <div class="grid gap-8 md:grid-cols-3">
           {relatedPosts.map(relatedPost => (
-            <PostCard post={relatedPost} />
+            <PostCard post={relatedPost} variant="compact" />
           ))}
         </div>
       </section>

--- a/src/pages/en/blog/category/[id]/[...page].astro
+++ b/src/pages/en/blog/category/[id]/[...page].astro
@@ -2,10 +2,12 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../../components/blog/PostCard.astro';
 import Layout from '../../../../../layouts/Layout.astro';
 import { getCurrentLocale } from '../../../../../utils/i18n';
-import { getCategoryLabel, getCategoryDescription, BLOG_CATEGORIES } from '../../../../../config/categories';
+import { getCategoryLabel, getCategoryDescription } from '../../../../../config/categories';
 
 interface Props {
   page: Page<CollectionEntry<'blog'>>;
@@ -48,63 +50,28 @@ const pageTitle = `${categoryLabel} | Blog | Cor.inc`;
 const categoryDesc = getCategoryDescription(id, currentLocale === 'ja' ? 'ja' : 'en');
 const pageDescription = categoryDesc || (currentLocale === 'ja'
   ? `${categoryLabel} に属するブログ記事一覧` : `Blog posts in ${categoryLabel}`);
-
-// 判定: カテゴリ未選択、または存在しないカテゴリの場合は「すべて」をアクティブにする
-const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
+const countLabel = page.total > page.size
+  ? `Showing ${page.start + 1}-${page.end + 1} of ${page.total} articles`
+  : `${page.total} articles`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        {categoryLabel}
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          {currentLocale === 'ja' 
-            ? `${page.total}記事中 ${page.start + 1}-${page.end + 1}記事を表示 (${page.currentPage}/${page.lastPage}ページ)`
-            : `Showing ${page.start + 1}-${page.end + 1} of ${page.total} articles (Page ${page.currentPage} of ${page.lastPage})`
-          }
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Category"
+      title={categoryLabel}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/en/blog"
+      backLabel="Back to Blog"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      <a
-        href={currentLocale === 'ja' ? '/blog' : '/en/blog'}
-        class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-          isAllActive
-            ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-            : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-        }`}
-      >
-        {currentLocale === 'ja' ? 'すべて' : 'All'}
-      </a>
-      {BLOG_CATEGORIES.map((category) => (
-        <a
-          href={currentLocale === 'ja' ? `/blog/category/${category.id}` : `/en/blog/category/${category.id}`}
-          class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-            category.id === id
-              ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-              : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-          }`}
-        >
-          {category.label[currentLocale === 'ja' ? 'ja' : 'en']}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav currentCategory={id} />
 
     <!-- 記事グリッド -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.map(post => (
-        <PostCard post={post} />
+        <PostCard post={post} variant="feed" />
       ))}
     </div>
 
@@ -116,7 +83,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500'
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -129,8 +96,8 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
               href={num === 1 ? `${currentLocale === 'ja' ? '' : '/en'}/blog/category/${id}` : `${currentLocale === 'ja' ? '' : '/en'}/blog/category/${id}/${num}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 num === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={num === page.currentPage ? 'page' : undefined}
             >
@@ -144,7 +111,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500'
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/en/blog/tags/[tag]/[...page].astro
+++ b/src/pages/en/blog/tags/[tag]/[...page].astro
@@ -2,8 +2,9 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../../components/blog/PostCard.astro';
-import { BLOG_CATEGORIES } from '../../../../../config/categories';
 import Layout from '../../../../../layouts/Layout.astro';
 
 interface Props {
@@ -37,75 +38,36 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { page, tag } = Astro.props as Props;
 const pageTitle = `"${tag}" Tag Articles | Blog | Cor.inc`;
-const pageDescription = `Articles tagged with "${tag}". Explore related technical articles and tutorials.`;
-
-// Categories for filtering (share with config)
-const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.en }));
+const pageDescription = `Articles tagged with "${tag}", sorted from newest to oldest.`;
+const countLabel = page.total > page.size
+  ? `Showing ${page.start + 1}-${page.end + 1} of ${page.total} articles`
+  : `${page.total} articles`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <div class="mb-4">
-        <a 
-          href="/en/blog" 
-          class="inline-flex items-center text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-        >
-          ← Back to Blog
-        </a>
-      </div>
-      
-      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
-        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
-          <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-            #{tag}
-          </span>
-          Tag Articles
-        </span>
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          Showing {page.start + 1}-{page.end + 1} of {page.total} articles (Page {page.currentPage} of {page.lastPage})
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Tag"
+      title={`#${tag}`}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/en/blog"
+      backLabel="Back to Blog"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/en/blog' : `/en/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.length > 0 ? (
         page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))
       ) : (
-        <div class="col-span-full text-center py-12 space-y-4">
+        <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
           <p class="text-lg text-stone-600 dark:text-stone-300">
             No articles were found for the tag "{tag}".
           </p>
-          <p class="text-sm text-stone-500 dark:text-stone-400">
-            You can:
-          </p>
-          <div class="flex flex-wrap justify-center gap-4">
-            <a href="/en/blog" class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">Browse All Articles</a>
-            <a href="/en/blog" class="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600">Popular Tags</a>
-          </div>
         </div>
       )}
     </div>
@@ -119,7 +81,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -133,8 +95,8 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
               href={pageNum === 1 ? `/en/blog/tags/${tag}` : `/en/blog/tags/${tag}/${pageNum}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 pageNum === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={pageNum === page.currentPage ? 'page' : undefined}
             >
@@ -149,7 +111,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/es/blog/[...page].astro
+++ b/src/pages/es/blog/[...page].astro
@@ -2,6 +2,8 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import Layout from '../../../layouts/Layout.astro';
 
@@ -25,74 +27,35 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 };
 
 const { page } = Astro.props;
-const pageTitle = 'Blog Técnico | Cor.inc';
-const pageDescription = 'Último blog técnico sobre IA/Machine Learning, ingeniería de software, viaje emprendedor e innovación. Conocimientos prácticos para desarrolladores e ingenieros.';
-
-// Categories for filtering
-const categories = [
-  { id: 'all', label: 'Todo' },
-  { id: 'ai', label: 'IA' },
-  { id: 'engineering', label: 'Ingeniería' },
-  { id: 'founder', label: 'Fundador' },
-  { id: 'lab', label: 'Laboratorio' },
-];
+const pageTitle = 'Blog | Cor.inc';
+const pageDescription = 'Notas claras sobre IA, producto e ingeniería, escritas para leer primero los puntos de decisión prácticos.';
+const countLabel = page.total > page.size
+  ? `Mostrando ${page.start + 1}-${page.end} de ${page.total} artículos`
+  : `${page.total} artículos`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        Blog
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Cor.inc Blog"
+      title="Blog"
+      description={pageDescription}
+      countLabel={countLabel}
+      rssHref="/es/rss.xml"
+      rssLabel="RSS"
+    />
 
-      <!-- RSS Feed Link -->
-      <div class="mt-4">
-        <a
-          href="/es/rss.xml"
-          class="inline-flex items-center gap-2 text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-          title="Suscribirse al RSS"
-        >
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-            <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
-            <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
-          </svg>
-          Feed RSS
-        </a>
-      </div>
-
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          Mostrando {page.start + 1}-{page.end} de {page.total} artículos (Página {page.currentPage} de {page.lastPage})
-        </p>
-      )}
-    </div>
-
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/es/blog' : `/es/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
     {page.data.length > 0 ? (
-      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+      <div class="mx-auto flex max-w-5xl flex-col gap-4">
         {page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))}
       </div>
     ) : (
-      <div class="text-center py-12">
+      <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
         <p class="text-lg text-stone-600 dark:text-stone-300">
           No hay artículos de blog todavía
         </p>
@@ -105,7 +68,7 @@ const categories = [
         {page.url.prev && (
           <a
             href={page.url.prev}
-            class="rounded-lg px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-100 dark:text-stone-300 dark:hover:bg-stone-800"
+            class="rounded-lg bg-white px-4 py-2 text-sm font-medium text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800"
           >
             ← Anterior
           </a>
@@ -118,7 +81,7 @@ const categories = [
         {page.url.next && (
           <a
             href={page.url.next}
-            class="rounded-lg px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-100 dark:text-stone-300 dark:hover:bg-stone-800"
+            class="rounded-lg bg-white px-4 py-2 text-sm font-medium text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800"
           >
             Siguiente →
           </a>

--- a/src/pages/es/blog/[...slug].astro
+++ b/src/pages/es/blog/[...slug].astro
@@ -4,9 +4,9 @@ import CategoryBadge from '../../../components/blog/CategoryBadge.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import ShareButtons from '../../../components/blog/ShareButtons.astro';
 import TableOfContents from '../../../components/blog/TableOfContents.astro';
+import TagList from '../../../components/blog/TagList.astro';
 import TipButton from '../../../components/blog/TipButton.astro';
 import BlogLayout from '../../../layouts/BlogLayout.astro';
-import { getCurrentLocale } from '../../../utils/i18n';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => {
@@ -23,7 +23,6 @@ interface Props { post: CollectionEntry<'blog'> }
 
 const { post } = Astro.props;
 const { Content, headings } = await post.render();
-const currentLocale = getCurrentLocale(Astro.url);
 
 // Get related posts and navigation posts
 const allPosts = await getCollection('blog', ({ data }) => {
@@ -61,7 +60,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <BlogLayout post={post} relatedPosts={relatedPosts} nextPost={nextPost} prevPost={prevPost}>
-  <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+  <article class="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
       <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
@@ -93,7 +92,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     </header>
 
     {post.data.image && (
-      <div class="mb-8 overflow-hidden rounded-2xl">
+      <div class="mb-8 overflow-hidden rounded-lg">
         <img src={post.data.image.url} alt={post.data.image.alt} class="h-auto w-full" loading="eager" decoding="async" />
       </div>
     )}
@@ -109,19 +108,10 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     <!-- Tags -->
     {post.data.tags.length > 0 && (
       <div class="mt-12 border-t border-stone-200 pt-8 dark:border-stone-700">
-        <h3 class="mb-4 text-sm font-medium uppercase tracking-wider text-stone-500 dark:text-stone-400">
+        <h3 class="mb-4 text-sm font-medium text-stone-500 dark:text-stone-400">
           Etiquetas
         </h3>
-        <div class="flex flex-wrap gap-2">
-          {post.data.tags.map(tag => (
-            <a
-              href={`/es/blog/tags/${tag}`}
-              class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-300 dark:hover:bg-stone-600"
-            >
-              #{tag}
-            </a>
-          ))}
-        </div>
+        <TagList tags={post.data.tags} />
       </div>
     )}
 
@@ -169,7 +159,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
         <h2 class="mb-6 text-2xl font-bold text-stone-900 dark:text-stone-100">Artículos Relacionados</h2>
         <div class="grid gap-8 md:grid-cols-3">
           {relatedPosts.map(relPost => (
-            <PostCard post={relPost} />
+            <PostCard post={relPost} variant="compact" />
           ))}
         </div>
       </div>

--- a/src/pages/es/blog/category/[id]/[...page].astro
+++ b/src/pages/es/blog/category/[id]/[...page].astro
@@ -2,10 +2,11 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../../components/blog/PostCard.astro';
 import Layout from '../../../../../layouts/Layout.astro';
-import { getCurrentLocale } from '../../../../../utils/i18n';
-import { getCategoryLabel, getCategoryDescription, BLOG_CATEGORIES } from '../../../../../config/categories';
+import { getCategoryLabel, getCategoryDescription } from '../../../../../config/categories';
 
 interface Props {
   page: Page<CollectionEntry<'blog'>>;
@@ -41,66 +42,33 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { page, categoryId } = Astro.props as Props;
 const id: string = (Astro.params.id as string | undefined) ?? categoryId ?? '';
-const currentLocale = getCurrentLocale(Astro.url);
 
 const categoryLabel = getCategoryLabel(id, 'es');
 const pageTitle = `${categoryLabel} | Blog | Cor.inc`;
 const categoryDesc = getCategoryDescription(id, 'es');
 const pageDescription = categoryDesc || `Artículos del blog en la categoría ${categoryLabel}`;
-
-// 判定: カテゴリ未選択、または存在しないカテゴリの場合は「すべて」をアクティブにする
-const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
+const countLabel = page.total > page.size
+  ? `Mostrando ${page.start + 1}-${page.end + 1} de ${page.total} artículos`
+  : `${page.total} artículos`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        {categoryLabel}
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          `Mostrando ${page.start + 1}-${page.end + 1} de ${page.total} artículos (Página ${page.currentPage} de ${page.lastPage})`
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Categoría"
+      title={categoryLabel}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/es/blog"
+      backLabel="Volver al Blog"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      <a
-        href='/es/blog'
-        class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-          isAllActive
-            ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-            : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-        }`}
-      >
-        Todo
-      </a>
-      {BLOG_CATEGORIES.map((category) => (
-        <a
-          href={`/es/blog/category/${category.id}`}
-          class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-            category.id === id
-              ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-              : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-          }`}
-        >
-          {category.label.es || category.label.en}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav currentCategory={id} />
 
     <!-- 記事グリッド -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.map(post => (
-        <PostCard post={post} />
+        <PostCard post={post} variant="feed" />
       ))}
     </div>
 
@@ -112,7 +80,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500'
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -125,8 +93,8 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
               href={num === 1 ? `/es/blog/category/${id}` : `/es/blog/category/${id}/${num}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 num === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={num === page.currentPage ? 'page' : undefined}
             >
@@ -140,7 +108,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500'
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/es/blog/tags/[tag]/[...page].astro
+++ b/src/pages/es/blog/tags/[tag]/[...page].astro
@@ -2,8 +2,9 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../../components/blog/PostCard.astro';
-import { BLOG_CATEGORIES } from '../../../../../config/categories';
 import Layout from '../../../../../layouts/Layout.astro';
 
 interface Props {
@@ -37,75 +38,36 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { page, tag } = Astro.props as Props;
 const pageTitle = `Artículos con etiqueta "${tag}" | Blog | Cor.inc`;
-const pageDescription = `Artículos etiquetados con "${tag}". Explore artículos técnicos y tutoriales relacionados.`;
-
-// Categories for filtering (share with config)
-const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.es || cat.label.en }));
+const pageDescription = `Artículos etiquetados con "${tag}", ordenados desde el más reciente.`;
+const countLabel = page.total > page.size
+  ? `Mostrando ${page.start + 1}-${page.end + 1} de ${page.total} artículos`
+  : `${page.total} artículos`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <div class="mb-4">
-        <a
-          href="/es/blog"
-          class="inline-flex items-center text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-        >
-          ← Volver al Blog
-        </a>
-      </div>
-      
-      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
-        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
-          <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-            #{tag}
-          </span>
-          Artículos con Etiqueta
-        </span>
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          Mostrando {page.start + 1}-{page.end + 1} de {page.total} artículos (Página {page.currentPage} de {page.lastPage})
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Etiqueta"
+      title={`#${tag}`}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/es/blog"
+      backLabel="Volver al Blog"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/es/blog' : `/es/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.length > 0 ? (
         page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))
       ) : (
-        <div class="col-span-full text-center py-12 space-y-4">
+        <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
           <p class="text-lg text-stone-600 dark:text-stone-300">
             No se encontraron artículos con la etiqueta "{tag}".
           </p>
-          <p class="text-sm text-stone-500 dark:text-stone-400">
-            Puedes:
-          </p>
-          <div class="flex flex-wrap justify-center gap-4">
-            <a href="/es/blog" class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">Ver Todos los Artículos</a>
-            <a href="/es/blog" class="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600">Etiquetas Populares</a>
-          </div>
         </div>
       )}
     </div>
@@ -119,7 +81,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -133,8 +95,8 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
               href={pageNum === 1 ? `/es/blog/tags/${tag}` : `/es/blog/tags/${tag}/${pageNum}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 pageNum === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={pageNum === page.currentPage ? 'page' : undefined}
             >
@@ -149,7 +111,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/ko/blog/[...page].astro
+++ b/src/pages/ko/blog/[...page].astro
@@ -2,6 +2,8 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import Layout from '../../../layouts/Layout.astro';
 
@@ -25,74 +27,35 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 };
 
 const { page } = Astro.props;
-const pageTitle = '기술 블로그 | Cor.inc';
-const pageDescription = 'AI/머신러닝, 소프트웨어 엔지니어링, 창업 여정 및 혁신을 다루는 최신 기술 블로그. 개발자와 엔지니어를 위한 실용적인 통찰과 지식.';
-
-// Categories for filtering
-const categories = [
-  { id: 'all', label: '전체' },
-  { id: 'ai', label: 'AI' },
-  { id: 'engineering', label: '엔지니어링' },
-  { id: 'founder', label: '창업자' },
-  { id: 'lab', label: '연구소' },
-];
+const pageTitle = '블로그 | Cor.inc';
+const pageDescription = 'AI, 제품, 엔지니어링 현장에서 얻은 배움을 의사결정에 필요한 내용부터 읽기 쉽게 정리합니다.';
+const countLabel = page.total > page.size
+  ? `총 ${page.total}개 중 ${page.start + 1}-${page.end}개 글 표시`
+  : `총 ${page.total}개 글`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        블로그
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Cor.inc Blog"
+      title="블로그"
+      description={pageDescription}
+      countLabel={countLabel}
+      rssHref="/ko/rss.xml"
+      rssLabel="RSS"
+    />
 
-      <!-- RSS Feed Link -->
-      <div class="mt-4">
-        <a
-          href="/ko/rss.xml"
-          class="inline-flex items-center gap-2 text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-          title="RSS 피드 구독"
-        >
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-            <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
-            <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
-          </svg>
-          RSS 피드
-        </a>
-      </div>
-
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          표시 중 {page.start + 1}-{page.end} / 총 {page.total}개 글 (페이지 {page.currentPage}/{page.lastPage})
-        </p>
-      )}
-    </div>
-
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/ko/blog' : `/ko/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
     {page.data.length > 0 ? (
-      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+      <div class="mx-auto flex max-w-5xl flex-col gap-4">
         {page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))}
       </div>
     ) : (
-      <div class="text-center py-12">
+      <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
         <p class="text-lg text-stone-600 dark:text-stone-300">
           아직 블로그 글이 없습니다
         </p>
@@ -105,7 +68,7 @@ const categories = [
         {page.url.prev && (
           <a
             href={page.url.prev}
-            class="rounded-lg px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-100 dark:text-stone-300 dark:hover:bg-stone-800"
+            class="rounded-lg bg-white px-4 py-2 text-sm font-medium text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800"
           >
             ← 이전
           </a>
@@ -118,7 +81,7 @@ const categories = [
         {page.url.next && (
           <a
             href={page.url.next}
-            class="rounded-lg px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-100 dark:text-stone-300 dark:hover:bg-stone-800"
+            class="rounded-lg bg-white px-4 py-2 text-sm font-medium text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800"
           >
             다음 →
           </a>

--- a/src/pages/ko/blog/[...slug].astro
+++ b/src/pages/ko/blog/[...slug].astro
@@ -4,9 +4,9 @@ import CategoryBadge from '../../../components/blog/CategoryBadge.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import ShareButtons from '../../../components/blog/ShareButtons.astro';
 import TableOfContents from '../../../components/blog/TableOfContents.astro';
+import TagList from '../../../components/blog/TagList.astro';
 import TipButton from '../../../components/blog/TipButton.astro';
 import BlogLayout from '../../../layouts/BlogLayout.astro';
-import { getCurrentLocale } from '../../../utils/i18n';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => {
@@ -23,7 +23,6 @@ interface Props { post: CollectionEntry<'blog'> }
 
 const { post } = Astro.props;
 const { Content, headings } = await post.render();
-const currentLocale = getCurrentLocale(Astro.url);
 
 // Get related posts and navigation posts
 const allPosts = await getCollection('blog', ({ data }) => {
@@ -61,7 +60,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <BlogLayout post={post} relatedPosts={relatedPosts} nextPost={nextPost} prevPost={prevPost}>
-  <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+  <article class="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
       <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
@@ -93,7 +92,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     </header>
 
     {post.data.image && (
-      <div class="mb-8 overflow-hidden rounded-2xl">
+      <div class="mb-8 overflow-hidden rounded-lg">
         <img src={post.data.image.url} alt={post.data.image.alt} class="h-auto w-full" loading="eager" decoding="async" />
       </div>
     )}
@@ -109,19 +108,10 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     <!-- Tags -->
     {post.data.tags.length > 0 && (
       <div class="mt-12 border-t border-stone-200 pt-8 dark:border-stone-700">
-        <h3 class="mb-4 text-sm font-medium uppercase tracking-wider text-stone-500 dark:text-stone-400">
+        <h3 class="mb-4 text-sm font-medium text-stone-500 dark:text-stone-400">
           태그
         </h3>
-        <div class="flex flex-wrap gap-2">
-          {post.data.tags.map(tag => (
-            <a
-              href={`/ko/blog/tags/${tag}`}
-              class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-300 dark:hover:bg-stone-600"
-            >
-              #{tag}
-            </a>
-          ))}
-        </div>
+        <TagList tags={post.data.tags} />
       </div>
     )}
 
@@ -169,7 +159,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
         <h2 class="mb-6 text-2xl font-bold text-stone-900 dark:text-stone-100">관련 글</h2>
         <div class="grid gap-8 md:grid-cols-3">
           {relatedPosts.map(relPost => (
-            <PostCard post={relPost} />
+            <PostCard post={relPost} variant="compact" />
           ))}
         </div>
       </div>

--- a/src/pages/ko/blog/category/[id]/[...page].astro
+++ b/src/pages/ko/blog/category/[id]/[...page].astro
@@ -2,10 +2,11 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../../components/blog/PostCard.astro';
 import Layout from '../../../../../layouts/Layout.astro';
-import { getCurrentLocale } from '../../../../../utils/i18n';
-import { getCategoryLabel, getCategoryDescription, BLOG_CATEGORIES } from '../../../../../config/categories';
+import { getCategoryLabel, getCategoryDescription } from '../../../../../config/categories';
 
 interface Props {
   page: Page<CollectionEntry<'blog'>>;
@@ -41,66 +42,33 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { page, categoryId } = Astro.props as Props;
 const id: string = (Astro.params.id as string | undefined) ?? categoryId ?? '';
-const currentLocale = getCurrentLocale(Astro.url);
 
 const categoryLabel = getCategoryLabel(id, 'ko');
 const pageTitle = `${categoryLabel} | 블로그 | Cor.inc`;
 const categoryDesc = getCategoryDescription(id, 'ko');
 const pageDescription = categoryDesc || `${categoryLabel} 카테고리의 블로그 글`;
-
-// 判定: カテゴリ未選択、または存在しないカテゴリの場合は「すべて」をアクティブにする
-const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
+const countLabel = page.total > page.size
+  ? `총 ${page.total}개 중 ${page.start + 1}-${page.end + 1}개 글 표시`
+  : `총 ${page.total}개 글`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        {categoryLabel}
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          `표시 중 ${page.start + 1}-${page.end + 1} / 총 ${page.total}개 글 (페이지 ${page.currentPage}/${page.lastPage})`
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="카테고리"
+      title={categoryLabel}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/ko/blog"
+      backLabel="블로그로 돌아가기"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      <a
-        href='/ko/blog'
-        class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-          isAllActive
-            ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-            : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-        }`}
-      >
-        전체
-      </a>
-      {BLOG_CATEGORIES.map((category) => (
-        <a
-          href={`/ko/blog/category/${category.id}`}
-          class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-            category.id === id
-              ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-              : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-          }`}
-        >
-          {category.label.ko || category.label.en}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav currentCategory={id} />
 
     <!-- 記事グリッド -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.map(post => (
-        <PostCard post={post} />
+        <PostCard post={post} variant="feed" />
       ))}
     </div>
 
@@ -112,7 +80,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500'
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -125,8 +93,8 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
               href={num === 1 ? `/ko/blog/category/${id}` : `/ko/blog/category/${id}/${num}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 num === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={num === page.currentPage ? 'page' : undefined}
             >
@@ -140,7 +108,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500'
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/ko/blog/tags/[tag]/[...page].astro
+++ b/src/pages/ko/blog/tags/[tag]/[...page].astro
@@ -2,8 +2,9 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../../components/blog/PostCard.astro';
-import { BLOG_CATEGORIES } from '../../../../../config/categories';
 import Layout from '../../../../../layouts/Layout.astro';
 
 interface Props {
@@ -37,75 +38,36 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { page, tag } = Astro.props as Props;
 const pageTitle = `"${tag}" 태그 글 | 블로그 | Cor.inc`;
-const pageDescription = `"${tag}" 태그가 붙은 글들입니다. 관련 기술 글과 튜토리얼을 탐색해보세요.`;
-
-// Categories for filtering (share with config)
-const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.ko || cat.label.en }));
+const pageDescription = `"${tag}" 태그가 붙은 글을 최신순으로 모았습니다.`;
+const countLabel = page.total > page.size
+  ? `총 ${page.total}개 중 ${page.start + 1}-${page.end + 1}개 글 표시`
+  : `총 ${page.total}개 글`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <div class="mb-4">
-        <a
-          href="/ko/blog"
-          class="inline-flex items-center text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-        >
-          ← 블로그로 돌아가기
-        </a>
-      </div>
-      
-      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
-        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
-          <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-            #{tag}
-          </span>
-          태그 글
-        </span>
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          표시 중 {page.start + 1}-{page.end + 1} / 총 {page.total}개 글 (페이지 {page.currentPage}/{page.lastPage})
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="태그"
+      title={`#${tag}`}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/ko/blog"
+      backLabel="블로그로 돌아가기"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/ko/blog' : `/ko/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.length > 0 ? (
         page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))
       ) : (
-        <div class="col-span-full text-center py-12 space-y-4">
+        <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
           <p class="text-lg text-stone-600 dark:text-stone-300">
             "{tag}" 태그의 글을 찾을 수 없습니다.
           </p>
-          <p class="text-sm text-stone-500 dark:text-stone-400">
-            다음을 시도해보세요:
-          </p>
-          <div class="flex flex-wrap justify-center gap-4">
-            <a href="/ko/blog" class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">모든 글 보기</a>
-            <a href="/ko/blog" class="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600">인기 태그</a>
-          </div>
         </div>
       )}
     </div>
@@ -119,7 +81,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -133,8 +95,8 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
               href={pageNum === 1 ? `/ko/blog/tags/${tag}` : `/ko/blog/tags/${tag}/${pageNum}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 pageNum === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={pageNum === page.currentPage ? 'page' : undefined}
             >
@@ -149,7 +111,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/zh/blog/[...page].astro
+++ b/src/pages/zh/blog/[...page].astro
@@ -2,6 +2,8 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import Layout from '../../../layouts/Layout.astro';
 
@@ -25,74 +27,35 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 };
 
 const { page } = Astro.props;
-const pageTitle = '技术博客 | Cor.inc';
-const pageDescription = '最新技术博客，涵盖AI/机器学习、软件工程、创业历程和创新。为开发者和工程师提供实用见解和知识。';
-
-// Categories for filtering
-const categories = [
-  { id: 'all', label: '全部' },
-  { id: 'ai', label: 'AI' },
-  { id: 'engineering', label: '工程' },
-  { id: 'founder', label: '创始人' },
-  { id: 'lab', label: '实验室' },
-];
+const pageTitle = '博客 | Cor.inc';
+const pageDescription = '整理 AI、产品和工程现场的经验，优先说明实际判断点，让非专业读者也容易阅读。';
+const countLabel = page.total > page.size
+  ? `显示 ${page.start + 1}-${page.end} / 共 ${page.total} 篇文章`
+  : `共 ${page.total} 篇文章`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        博客
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="Cor.inc Blog"
+      title="博客"
+      description={pageDescription}
+      countLabel={countLabel}
+      rssHref="/zh/rss.xml"
+      rssLabel="RSS"
+    />
 
-      <!-- RSS Feed Link -->
-      <div class="mt-4">
-        <a
-          href="/zh/rss.xml"
-          class="inline-flex items-center gap-2 text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-          title="订阅 RSS"
-        >
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-            <path d="M5 3a1 1 0 000 2c5.523 0 10 4.477 10 10a1 1 0 102 0C17 8.373 11.627 3 5 3z"/>
-            <path d="M4 9a1 1 0 011-1 7 7 0 017 7 1 1 0 11-2 0 5 5 0 00-5-5 1 1 0 01-1-1zM3 15a2 2 0 114 0 2 2 0 01-4 0z"/>
-          </svg>
-          RSS 订阅
-        </a>
-      </div>
-
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          显示 {page.start + 1}-{page.end} / 共 {page.total} 篇文章（第 {page.currentPage} 页，共 {page.lastPage} 页）
-        </p>
-      )}
-    </div>
-
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/zh/blog' : `/zh/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
     {page.data.length > 0 ? (
-      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+      <div class="mx-auto flex max-w-5xl flex-col gap-4">
         {page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))}
       </div>
     ) : (
-      <div class="text-center py-12">
+      <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
         <p class="text-lg text-stone-600 dark:text-stone-300">
           暂无博客文章
         </p>
@@ -105,7 +68,7 @@ const categories = [
         {page.url.prev && (
           <a
             href={page.url.prev}
-            class="rounded-lg px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-100 dark:text-stone-300 dark:hover:bg-stone-800"
+            class="rounded-lg bg-white px-4 py-2 text-sm font-medium text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800"
           >
             ← 上一页
           </a>
@@ -118,7 +81,7 @@ const categories = [
         {page.url.next && (
           <a
             href={page.url.next}
-            class="rounded-lg px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-100 dark:text-stone-300 dark:hover:bg-stone-800"
+            class="rounded-lg bg-white px-4 py-2 text-sm font-medium text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800"
           >
             下一页 →
           </a>

--- a/src/pages/zh/blog/[...slug].astro
+++ b/src/pages/zh/blog/[...slug].astro
@@ -4,9 +4,9 @@ import CategoryBadge from '../../../components/blog/CategoryBadge.astro';
 import PostCard from '../../../components/blog/PostCard.astro';
 import ShareButtons from '../../../components/blog/ShareButtons.astro';
 import TableOfContents from '../../../components/blog/TableOfContents.astro';
+import TagList from '../../../components/blog/TagList.astro';
 import TipButton from '../../../components/blog/TipButton.astro';
 import BlogLayout from '../../../layouts/BlogLayout.astro';
-import { getCurrentLocale } from '../../../utils/i18n';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog', ({ data }) => {
@@ -23,7 +23,6 @@ interface Props { post: CollectionEntry<'blog'> }
 
 const { post } = Astro.props;
 const { Content, headings } = await post.render();
-const currentLocale = getCurrentLocale(Astro.url);
 
 // Get related posts and navigation posts
 const allPosts = await getCollection('blog', ({ data }) => {
@@ -61,7 +60,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <BlogLayout post={post} relatedPosts={relatedPosts} nextPost={nextPost} prevPost={prevPost}>
-  <article class="mx-auto max-w-4xl px-4 py-16 sm:px-6 lg:px-8">
+  <article class="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-14 lg:px-8">
     <!-- Breadcrumb -->
     <nav class="mb-8" aria-label="Breadcrumb">
       <ol class="flex flex-wrap items-center gap-x-2 gap-y-2 text-sm text-stone-600 dark:text-stone-400">
@@ -93,7 +92,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     </header>
 
     {post.data.image && (
-      <div class="mb-8 overflow-hidden rounded-2xl">
+      <div class="mb-8 overflow-hidden rounded-lg">
         <img src={post.data.image.url} alt={post.data.image.alt} class="h-auto w-full" loading="eager" decoding="async" />
       </div>
     )}
@@ -109,19 +108,10 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
     <!-- Tags -->
     {post.data.tags.length > 0 && (
       <div class="mt-12 border-t border-stone-200 pt-8 dark:border-stone-700">
-        <h3 class="mb-4 text-sm font-medium uppercase tracking-wider text-stone-500 dark:text-stone-400">
+        <h3 class="mb-4 text-sm font-medium text-stone-500 dark:text-stone-400">
           标签
         </h3>
-        <div class="flex flex-wrap gap-2">
-          {post.data.tags.map(tag => (
-            <a
-              href={`/zh/blog/tags/${tag}`}
-              class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-600 transition-colors hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-300 dark:hover:bg-stone-600"
-            >
-              #{tag}
-            </a>
-          ))}
-        </div>
+        <TagList tags={post.data.tags} />
       </div>
     )}
 
@@ -169,7 +159,7 @@ const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
         <h2 class="mb-6 text-2xl font-bold text-stone-900 dark:text-stone-100">相关文章</h2>
         <div class="grid gap-8 md:grid-cols-3">
           {relatedPosts.map(relPost => (
-            <PostCard post={relPost} />
+            <PostCard post={relPost} variant="compact" />
           ))}
         </div>
       </div>

--- a/src/pages/zh/blog/category/[id]/[...page].astro
+++ b/src/pages/zh/blog/category/[id]/[...page].astro
@@ -2,10 +2,11 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../../components/blog/PostCard.astro';
 import Layout from '../../../../../layouts/Layout.astro';
-import { getCurrentLocale } from '../../../../../utils/i18n';
-import { getCategoryLabel, getCategoryDescription, BLOG_CATEGORIES } from '../../../../../config/categories';
+import { getCategoryLabel, getCategoryDescription } from '../../../../../config/categories';
 
 interface Props {
   page: Page<CollectionEntry<'blog'>>;
@@ -41,66 +42,33 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { page, categoryId } = Astro.props as Props;
 const id: string = (Astro.params.id as string | undefined) ?? categoryId ?? '';
-const currentLocale = getCurrentLocale(Astro.url);
 
 const categoryLabel = getCategoryLabel(id, 'zh');
 const pageTitle = `${categoryLabel} | 博客 | Cor.inc`;
 const categoryDesc = getCategoryDescription(id, 'zh');
 const pageDescription = categoryDesc || `${categoryLabel} 分类的博客文章`;
-
-// 判定: カテゴリ未選択、または存在しないカテゴリの場合は「すべて」をアクティブにする
-const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
+const countLabel = page.total > page.size
+  ? `显示 ${page.start + 1}-${page.end + 1} / 共 ${page.total} 篇文章`
+  : `共 ${page.total} 篇文章`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <h1 class="mb-4 text-balance text-4xl font-bold text-stone-900 dark:text-stone-100 sm:text-5xl">
-        {categoryLabel}
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          `显示 ${page.start + 1}-${page.end + 1} / 共 ${page.total} 篇文章（第 ${page.currentPage} 页，共 ${page.lastPage} 页）`
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="分类"
+      title={categoryLabel}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/zh/blog"
+      backLabel="返回博客"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      <a
-        href='/zh/blog'
-        class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-          isAllActive
-            ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-            : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-        }`}
-      >
-        全部
-      </a>
-      {BLOG_CATEGORIES.map((category) => (
-        <a
-          href={`/zh/blog/category/${category.id}`}
-          class={`rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 ${
-            category.id === id
-              ? 'bg-black text-white border-black dark:bg-white dark:text-black dark:border-white'
-              : 'bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900'
-          }`}
-        >
-          {category.label.zh || category.label.en}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav currentCategory={id} />
 
     <!-- 文章网格 -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.map(post => (
-        <PostCard post={post} />
+        <PostCard post={post} variant="feed" />
       ))}
     </div>
 
@@ -112,7 +80,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500'
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -125,8 +93,8 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
               href={num === 1 ? `/zh/blog/category/${id}` : `/zh/blog/category/${id}/${num}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 num === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={num === page.currentPage ? 'page' : undefined}
             >
@@ -140,7 +108,7 @@ const isAllActive = !id || !BLOG_CATEGORIES.find(cat => cat.id === id);
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500'
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >

--- a/src/pages/zh/blog/tags/[tag]/[...page].astro
+++ b/src/pages/zh/blog/tags/[tag]/[...page].astro
@@ -2,8 +2,9 @@
 import type { GetStaticPaths, Page } from 'astro';
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import BlogArchiveHeader from '../../../../../components/blog/BlogArchiveHeader.astro';
+import BlogCategoryNav from '../../../../../components/blog/BlogCategoryNav.astro';
 import PostCard from '../../../../../components/blog/PostCard.astro';
-import { BLOG_CATEGORIES } from '../../../../../config/categories';
 import Layout from '../../../../../layouts/Layout.astro';
 
 interface Props {
@@ -37,75 +38,36 @@ export const getStaticPaths: GetStaticPaths = async ({ paginate }) => {
 
 const { page, tag } = Astro.props as Props;
 const pageTitle = `"${tag}" 标签文章 | 博客 | Cor.inc`;
-const pageDescription = `标签为"${tag}"的文章。探索相关技术文章和教程。`;
-
-// Categories for filtering (share with config)
-const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.zh || cat.label.en }));
+const pageDescription = `标签为"${tag}"的文章，按发布时间从新到旧排列。`;
+const countLabel = page.total > page.size
+  ? `显示 ${page.start + 1}-${page.end + 1} / 共 ${page.total} 篇文章`
+  : `共 ${page.total} 篇文章`;
 ---
 
 <Layout title={pageTitle} description={pageDescription}>
-  <div class="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
-    <!-- Page Header -->
-    <div class="mb-12 text-center">
-      <div class="mb-4">
-        <a
-          href="/zh/blog"
-          class="inline-flex items-center text-sm text-stone-500 hover:text-stone-700 dark:text-stone-400 dark:hover:text-stone-200 transition-colors"
-        >
-          ← 返回博客
-        </a>
-      </div>
-      
-      <h1 class="mb-4 text-balance text-3xl font-bold text-stone-900 dark:text-stone-100 sm:text-4xl">
-        <span class="inline-flex max-w-full flex-wrap items-center justify-center gap-2">
-          <span class="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-            #{tag}
-          </span>
-          标签文章
-        </span>
-      </h1>
-      <p class="mx-auto max-w-2xl text-pretty text-lg text-stone-600 dark:text-stone-300">
-        {pageDescription}
-      </p>
-      
-      <!-- Pagination Info -->
-      {page.total > page.size && (
-        <p class="mt-4 text-sm text-stone-500 dark:text-stone-400">
-          显示 {page.start + 1}-{page.end + 1} 共 {page.total} 篇文章（第 {page.currentPage} 页，共 {page.lastPage} 页）
-        </p>
-      )}
-    </div>
+  <div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    <BlogArchiveHeader
+      eyebrow="标签"
+      title={`#${tag}`}
+      description={pageDescription}
+      countLabel={countLabel}
+      backHref="/zh/blog"
+      backLabel="返回博客"
+    />
 
-    <!-- Category Filter -->
-    <div class="mb-8 flex flex-wrap justify-center gap-2">
-      {categories.map(category => (
-        <a
-          href={category.id === 'all' ? '/zh/blog' : `/zh/blog/category/${category.id}`}
-          class="rounded-full px-4 py-2 text-sm font-medium border-2 transition-all duration-200 bg-white text-black border-gray-300 hover:bg-gray-50 dark:bg-black dark:text-white dark:border-gray-600 dark:hover:bg-gray-900"
-        >
-          {category.label}
-        </a>
-      ))}
-    </div>
+    <BlogCategoryNav />
 
     <!-- Blog Posts Grid -->
-    <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div class="mx-auto flex max-w-5xl flex-col gap-4">
       {page.data.length > 0 ? (
         page.data.map(post => (
-          <PostCard post={post} />
+          <PostCard post={post} variant="feed" />
         ))
       ) : (
-        <div class="col-span-full text-center py-12 space-y-4">
+        <div class="rounded-lg border border-stone-200 bg-white p-8 text-center dark:border-stone-800 dark:bg-stone-900">
           <p class="text-lg text-stone-600 dark:text-stone-300">
             没有找到标签为"{tag}"的文章。
           </p>
-          <p class="text-sm text-stone-500 dark:text-stone-400">
-            您可以：
-          </p>
-          <div class="flex flex-wrap justify-center gap-4">
-            <a href="/zh/blog" class="rounded-full bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700">浏览所有文章</a>
-            <a href="/zh/blog" class="rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600">热门标签</a>
-          </div>
         </div>
       )}
     </div>
@@ -119,7 +81,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.prev 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.prev}
         >
@@ -133,8 +95,8 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
               href={pageNum === 1 ? `/zh/blog/tags/${tag}` : `/zh/blog/tags/${tag}/${pageNum}`}
               class={`rounded-lg px-3 py-2 text-sm font-medium ${
                 pageNum === page.currentPage
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+                  ? 'bg-stone-950 text-white dark:bg-stone-100 dark:text-stone-950'
+                  : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
               }`}
               aria-current={pageNum === page.currentPage ? 'page' : undefined}
             >
@@ -149,7 +111,7 @@ const categories = BLOG_CATEGORIES.map((cat) => ({ id: cat.id, label: cat.label.
           class={`rounded-lg px-3 py-2 text-sm font-medium ${
             !page.url.next 
               ? 'cursor-not-allowed bg-stone-100 text-stone-400 dark:bg-stone-700 dark:text-stone-500' 
-              : 'bg-stone-100 text-stone-700 hover:bg-stone-200 dark:bg-stone-700 dark:text-stone-200 dark:hover:bg-stone-600'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50 dark:bg-stone-900 dark:text-stone-200 dark:ring-stone-800 dark:hover:bg-stone-800'
           }`}
           aria-disabled={!page.url.next}
         >


### PR DESCRIPTION
## ① なぜ

Issue #220 の「非エンジニア向けUI改善」のうち、公開ブログの読みやすさ・一覧性・カテゴリ/タグ導線を note/Qiita に近い体験へ寄せるためです。CMS投稿UIとは別に、読者が記事を探しやすく、本文を読み進めやすい public blog 体験にします。

Refs #220

## ② どう実装したか

- `BlogArchiveHeader` と `BlogCategoryNav` を追加し、一覧・カテゴリ・タグページの見出し/カテゴリ導線を共通化
- `PostCard` に `feed` / `compact` 表示を追加し、一覧は縦フィード、関連記事は軽量カードとして表示
- `BlogLayout` の記事本文 typography を調整し、見出し・段落・引用・画像・リンクカードを読みやすく整理
- `CategoryBadge` / `TagList` / `TipButton` の見た目と多言語リンクを public blog UI に合わせて調整
- 日本語/英語/スペイン語/韓国語/中国語の blog list/post/category/tag ページへ同じ構成を反映
- #224 の OGP PNG 化に合わせ、blog e2e の OGP 画像 assertion を `.svg` / `.png` 両対応に更新

## ③ 特にレビューしてほしい点

- public blog の一覧/カテゴリ/タグが、カードグリッドではなく読み物フィードとして自然に見えるか
- 記事詳細の本文幅、行間、見出し、関連記事の密度が非エンジニア読者にとって読みやすいか
- 多言語ページで導線やタグリンクが破綻していないか
- #225 News と #224 OGP PNG 生成に不要な影響がないか

## 含めないもの

- Worker CMS UI
- News collection / `/news`
- cases CMS
- OGP PNG生成処理
- SEO/security audit

## ④ テスト・確認方法

- `npm run build`
  - `astro check`: 0 errors
  - build: 439 pages built
- `npx playwright test e2e/blog.spec.ts`
  - 21 passed
- `git diff --check`

## ローカルスクリーンショット

- `test-results/blog-reading-ui-refresh/blog-list-desktop.png`
- `test-results/blog-reading-ui-refresh/blog-list-mobile.png`
- `test-results/blog-reading-ui-refresh/blog-post-desktop.png`
- `test-results/blog-reading-ui-refresh/blog-post-mobile.png`
- `test-results/blog-reading-ui-refresh/blog-category-ai-desktop.png`
- `test-results/blog-reading-ui-refresh/blog-tag-astro-mobile.png`

## 実ブラウザ / develop preview 証跡

未取得です。`develop` 反映後に `/blog/`, 代表記事, `/blog/category/ai/`, `/blog/tags/Astro/`, `/en/blog/` のスクリーンショットを取得します。
