### PR TITLE
fix(news): OGP画像参照をPNGに統一

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -55,7 +55,7 @@ const OG_PAGE_SLUGS: Record<string, string> = {
   '/privacy': 'privacy',
 };
 const ogBaseKey = basePath.replace(/\/+$/, '') || '/';
-const ogPageSlug = OG_PAGE_SLUGS[ogBaseKey];
+const ogPageSlug = OG_PAGE_SLUGS[ogBaseKey] ?? (ogBaseKey.startsWith('/news/') ? 'news' : undefined);
 // ページ固有 OG 画像（ogImage prop）があれば最優先。なければ path 別 → logo.png。
 const ogImage = ogImageProp
   ? new URL(ogImageProp, Astro.site)

--- a/src/pages/news/[...page].astro
+++ b/src/pages/news/[...page].astro
@@ -49,7 +49,6 @@ const itemListJsonLd = {
   description={t.meta.news.description}
   title={t.meta.news.title}
   availableLocales={['ja']}
-  ogImage="/og/page/news.svg"
 >
   <main class="mx-auto max-w-2xl px-4 py-16 sm:px-6 sm:py-20 lg:max-w-7xl lg:px-8">
     <div class="mx-auto flex max-w-3xl flex-col gap-4 pb-10 text-start sm:pb-12">

--- a/src/pages/news/[...slug].astro
+++ b/src/pages/news/[...slug].astro
@@ -38,7 +38,7 @@ const formattedUpdatedAt = data.updatedAt
     })
   : null;
 const fullUrl = new URL(Astro.url.pathname, Astro.site).toString();
-const ogImageUrl = data.ogImage || '/og/page/news.svg';
+const ogImageUrl = data.ogImage || '/og/page/news.png';
 
 const articleJsonLd = {
   '@context': 'https://schema.org',
@@ -103,7 +103,7 @@ const breadcrumbJsonLd = {
   title={`${data.title} | Cor.株式会社 ニュース`}
   description={data.description}
   availableLocales={['ja']}
-  ogImage={ogImageUrl}
+  ogImage={data.ogImage}
   ogType="article"
   publishedTime={data.publishedAt.toISOString()}
   modifiedTime={data.updatedAt?.toISOString()}


### PR DESCRIPTION
## ① なぜ（解決したい課題）

News static v1 の merge 後、`/news/` と `/news/news-static-v1/` のSNS metaで `og:image` / `twitter:image` が SVG を参照していました。#220 の OGP PNG Close Gate では、develop preview 上でPNG参照まで揃っている必要があります。

Refs #220

## ② どう実装したか

- ニュース一覧は `Layout.astro` の path-based PNG fallback を使うよう、明示 `ogImage` を削除しました。
- ニュース詳細は `/og/page/news.png` を明示し、JSON-LD image と SNS meta をPNGに揃えました。
- SVG route は既存互換のため残しています。

## ③ 特にレビューしてほしい点

- `data.ogImage` が指定されたニュース記事は引き続き個別画像を優先する挙動で問題ないか。
- ニュース一覧・詳細ともPNG metaに統一されているか。

## ④ テスト内容・確認方法

- `npm run build` 成功（既存 warning/hint のみ）
- `dist/news/index.html` と `dist/news/news-static-v1/index.html` で以下が `/og/page/news.png` を参照することを確認
  - `og:image`
  - `og:image:secure_url`
  - `twitter:image`

## 未検証

- develop merge 後の Firebase preview 実URLでの再確認は未実施です。
