### PR TITLE
feat(yomimono): cases投稿UIを追加

### DIFF
--- a/docs/adr/ADR-0009-news-cases-cms-expansion.md
+++ b/docs/adr/ADR-0009-news-cases-cms-expansion.md
@@ -45,7 +45,7 @@ ADR-0008 の「静的＋記事bot・DBなし・Cloudflare Worker」アーキテ�
 ## 影響
 - **Milestone 構成（1PR=1意図・ワークツリー分岐）**:
   - **M1: yomimono collection 基盤 + UI改善基盤** — I1（collection 対応基盤）/ I2（UI改善基盤・共通）/ I3（既存記事編集）。**M1-I1 は PR #221 で develop マージ済**（test 172 緑・blog 回帰なし・`contentDir`/`normalizeArticle`/`buildMarkdown` の collection 分岐）。
-  - **M2: cases CMS** — I4（cases 投稿UI・改善版）。
+  - **M2: cases CMS** — I4（cases 投稿UI・改善版）。`/manual/cases` から `body.collection='cases'` で `src/content/cases/<slug>.md` へ投稿する経路を追加済み。
   - **M3: news 機能**（★news は M3 で有効化）— I5（news コレクション+投稿UI）/ I6（一覧・個別・NewsCard・SEO）/ I7（i18n+nav+sitemap+RSS）。
   - **M4: OGP PNG化**（★news リリース前完了推奨・先輩の直接要件）— I10（SVG→PNG・全ページ共通）。
 - **ADR-0008 からの進化**: ADR-0008「ブログ単機能」を「blog/news/cases の3コレクション・DBレス同 bot・非エンジニア向けUI」に拡張。ADR-0008 本体は温存し、本 ADR で拡張する関係（詳細は ADR-0008 末尾の追記参照）。

--- a/docs/yomimono-cms-setup.md
+++ b/docs/yomimono-cms-setup.md
@@ -2,7 +2,7 @@
 
 ADR-0008(rev.2) / Epic #130 の **A案（静的＋記事bot・DBなし・Cloudflare Workers バックエンド）** を動かすために、**諫山さん（org 管理者）の側で一度だけ**用意するものをまとめます。ここが揃えば、以降のコードは私（実装側）が組みます。**シークレットは諫山さんの管理下に置き、私はコードから参照する形**にします（鍵を私が保持しません）。
 
-> **コレクション拡張（ADR-0009 / Epic #220）**: 本基盤は **blog / news / cases の3コレクション**に拡張済み（同一 Worker・同一 GitHub App・`body.collection` で切替）。blog は稼働中・cases は M2・**news は M3 で有効化**。下記セットアップ（GitHub App・Cloudflare・シークレット・認証）は3コレクション共通で追加不要。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
+> **コレクション拡張（ADR-0009 / Epic #220）**: 本基盤は **blog / news / cases の3コレクション**に拡張済み（同一 Worker・同一 GitHub App・`body.collection` で切替）。blog と cases は稼働対象・**news は M3 で有効化**。下記セットアップ（GitHub App・Cloudflare・シークレット・認証）は3コレクション共通で追加不要。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
 
 ---
 

--- a/workers/yomimono/README.md
+++ b/workers/yomimono/README.md
@@ -3,7 +3,7 @@
 凪沙さんが **main マージ権限なしで毎日記事を投稿**できるようにする、サーバーレス・バックエンド＋管理画面。
 記事は DB を使わず **.md として git にコミット**され、既存の静的デプロイでそのまま公開される（A案：記事bot方式）。
 
-> **コレクション拡張（ADR-0009）**: 記事bot は **blog / news / cases の3コレクション配下**に書く（`src/content/{blog/ja,news,cases}/`）。blog は稼働中・cases は M2・**news は M3 で有効化**。切り替えは `body.collection`（既定 `'blog'`）。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
+> **コレクション拡張（ADR-0009）**: 記事bot は **blog / news / cases の3コレクション配下**に書く（`src/content/{blog/ja,news,cases}/`）。blog と cases は稼働対象・**news は M3 で有効化**。切り替えは `body.collection`（既定 `'blog'`）。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
 
 管理画面は **HP と同じドメインの隠しページ `https://cor-jp.com/blog-admin`** で開ける（cor-jp.com は Cloudflare の裏にいるため、`/blog-admin*` だけを Cloudflare Worker のルートに流す）。HP本体（静的・Firebase）はそのまま。
 
@@ -24,7 +24,7 @@
 | POST | `/api/validate` | コミットせずガードレール再チェック（編集後の確認用・`body.collection` 対応） |
 | POST | `/api/publish` | 記事botが `body.collection`（既定 `'blog'`）に応じて `src/content/{blog/ja,news,cases}/<slug>.md` を `main` にコミット |
 | GET  | `/manual/news` | ニュース投稿UI（**M3 で有効化・準備中**） |
-| GET  | `/manual/cases` | 実績投稿UI（**M2・準備中**） |
+| GET  | `/manual/cases` | 実績投稿UI（cases / `src/content/cases/<slug>.md` へ公開） |
 
 Worker は受信パスから `BASE_PATH`(=`/blog-admin`) を剥がして上記の論理パスにルーティングする。`BASE_PATH` 空ならルート直下（`*.workers.dev/` でのテスト）でもそのまま動く。
 

--- a/workers/yomimono/src/__tests__/index-cases.test.ts
+++ b/workers/yomimono/src/__tests__/index-cases.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Env } from '../types';
+
+const mocks = vi.hoisted(() => ({
+  commitArticle: vi.fn(),
+  listArticleSlugs: vi.fn(),
+}));
+
+vi.mock('../session', () => ({
+  verifySession: vi.fn(async () => true),
+  checkPassword: vi.fn(async () => true),
+  createSessionCookie: vi.fn(async () => 'yomimono_session=test; HttpOnly'),
+  clearSessionCookie: vi.fn(() => 'yomimono_session=; Max-Age=0'),
+}));
+
+vi.mock('../github', () => ({
+  makeOctokit: vi.fn(() => ({ mocked: true })),
+  getFileContent: vi.fn(),
+  commitArticle: mocks.commitArticle,
+  commitImage: vi.fn(),
+  listArticleSlugs: mocks.listArticleSlugs,
+}));
+
+const worker = (await import('../index')).default;
+
+const env: Env = {
+  ANTHROPIC_API_KEY: 'test-key',
+  GH_APP_PRIVATE_KEY: 'test-key',
+  GH_OWNER: 'Cor-Incorporated',
+  GH_REPO: 'corsweb2024',
+  GH_APP_ID: '123',
+  GH_INSTALLATION_ID: '456',
+  BLOG_DIR: 'src/content/blog',
+  NEWS_DIR: 'src/content/news',
+  CASES_DIR: 'src/content/cases',
+  PUBLISH_BRANCH: 'main',
+  STYLE_GUIDE_PATH: 'docs/blog-style-guide.md',
+  BASE_PATH: '/blog-admin',
+  ACCESS_PASSWORD: 'x'.repeat(20),
+  SESSION_SECRET: 'test-secret',
+};
+
+function req(path: string, init?: RequestInit): Request {
+  return new Request('https://cor-jp.com' + path, init);
+}
+
+const caseArticle = {
+  slug: 'new-case-study',
+  title: '新しい実績記事',
+  description: '実績記事の説明',
+  category: 'local-llm',
+  tags: ['AI', 'PoC'],
+  summary: '実績記事のリード文',
+  body: '## 課題\n\n本文\n\n## アプローチ\n\n本文\n\n## 実装\n\n本文\n\n## 成果\n\n本文',
+  publishedAt: '2026-07-08',
+  featured: true,
+};
+
+describe('yomimono Worker — cases CMS posting path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.commitArticle.mockResolvedValue({
+      committed: true,
+      path: 'src/content/cases/new-case-study.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/test',
+    });
+    mocks.listArticleSlugs.mockResolvedValue(['grift', 'local-llm-poc']);
+  });
+
+  it('GET /manual/cases は cases 投稿 UI を返し、collection 指定の publish/validate を含む', async () => {
+    const res = await worker.fetch(req('/blog-admin/manual/cases'), env);
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain('実績記事を公開する');
+    expect(html).toContain('value="local-llm"');
+    expect(html).toContain("api('/api/validate', { collection:'cases', article:a })");
+    expect(html).toContain("api('/api/publish', { collection:'cases', article:a })");
+  });
+
+  it('GET /api/recent?collection=cases は cases の slug 一覧を返す', async () => {
+    const res = await worker.fetch(req('/blog-admin/api/recent?collection=cases'), env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ slugs: ['grift', 'local-llm-poc'] });
+    expect(mocks.listArticleSlugs).toHaveBeenCalledWith(env, { mocked: true }, 'cases');
+  });
+
+  it('POST /api/validate は cases article を cases markdown として検査する', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/validate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ collection: 'cases', article: caseArticle }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ violations: [] });
+  });
+
+  it('POST /api/publish は cases ディレクトリ向けに commitArticle を呼ぶ', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/publish', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ collection: 'cases', article: caseArticle }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      committed: true,
+      path: 'src/content/cases/new-case-study.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/test',
+    });
+    expect(mocks.commitArticle).toHaveBeenCalledTimes(1);
+    const [calledEnv, _octokit, slug, markdown, editor, collection] = mocks.commitArticle.mock.calls[0];
+    expect(calledEnv).toBe(env);
+    expect(slug).toBe('new-case-study');
+    expect(markdown).toContain('summary: "実績記事のリード文"');
+    expect(markdown).toContain('category: "local-llm"');
+    expect(editor).toBe('yomimono');
+    expect(collection).toBe('cases');
+  });
+
+  it('news collection は M3 まで publish を拒否し続ける', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/publish', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ collection: 'news', article: caseArticle }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'news collection は現在準備中です（blog/cases のみ利用可能）',
+    });
+    expect(mocks.commitArticle).not.toHaveBeenCalled();
+  });
+});

--- a/workers/yomimono/src/__tests__/index-cases.test.ts
+++ b/workers/yomimono/src/__tests__/index-cases.test.ts
@@ -74,6 +74,15 @@ describe('yomimono Worker — cases CMS posting path', () => {
     expect(res.status).toBe(200);
     expect(html).toContain('実績記事を公開する');
     expect(html).toContain('value="local-llm"');
+    expect(html).toContain('id="m_draftBar"');
+    expect(html).toContain('data-md="quote"');
+    expect(html).toContain('data-md="hr"');
+    expect(html).toContain('URLを編集する（上級者向け）');
+    expect(html).toContain("titleToSlug($('m_title').value)");
+    expect(html).toContain("var DRAFT_KEY = 'draft:cases:new'");
+    expect(html).toContain('var IMG_CACHE_MAX = 20');
+    expect(html).toContain("out.push('<blockquote>')");
+    expect(html).toContain("out.push('<hr>')");
     expect(html).toContain("api('/api/validate', { collection:'cases', article:a })");
     expect(html).toContain("api('/api/publish', { collection:'cases', article:a })");
   });

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -14,6 +14,7 @@ import { sanitizeText, normalizeArticle, normalizeCollection, type ArticleInput 
 import { HUB_HTML } from './ui-hub';
 import { AI_HTML } from './ui-ai';
 import { MANUAL_HTML } from './ui-manual';
+import { MANUAL_CASES_HTML } from './ui-manual-cases';
 import { LOGIN_HTML } from './ui-login';
 import { STYLE_GUIDE_FALLBACK } from './style-guide';
 
@@ -216,6 +217,9 @@ export default {
       }
       if (req.method === 'GET' && path === '/manual') {
         return html(MANUAL_HTML, env);
+      }
+      if (req.method === 'GET' && path === '/manual/cases') {
+        return html(MANUAL_CASES_HTML, env);
       }
 
       // 既存記事スラッグ一覧（重複テーマ回避用）

--- a/workers/yomimono/src/ui-hub.ts
+++ b/workers/yomimono/src/ui-hub.ts
@@ -1,15 +1,17 @@
 import { head, header, tail } from './ui-shared';
 
-// ログイン後の入口。AI生成 / 手動作成 の2択。
+// ログイン後の入口。AI生成 / ブログ手動作成 / 実績作成 の入口。
 export const HUB_HTML =
   head('ハブ — 読みもの 作成スタジオ') +
   header('hub') +
   '<main>' +
-  '<p class="lead">記事の作り方を選んでください。どちらで書いても、記事は main マージ不要でそのまま cor-jp.com に公開されます。</p>' +
+  '<p class="lead">記事の作り方を選んでください。どれで書いても、記事は main マージ不要でそのまま cor-jp.com に公開されます。</p>' +
   '<div class="hub">' +
   '<a href="__BASE__/ai"><div class="ic">🤖</div><h3>AI生成</h3>' +
   '<p>最新トピックを収集し、社長の文体でAIが下書き。確認・編集して公開します。</p></a>' +
-  '<a href="__BASE__/manual"><div class="ic">✍️</div><h3>手動作成</h3>' +
-  '<p>テキストと画像を自分で貼って記事を作成。ライブプレビューで確認して公開します。</p></a>' +
+  '<a href="__BASE__/manual"><div class="ic">✍️</div><h3>ブログ作成</h3>' +
+  '<p>テキストと画像を自分で貼ってブログ記事を作成。ライブプレビューで確認して公開します。</p></a>' +
+  '<a href="__BASE__/manual/cases"><div class="ic">📁</div><h3>実績作成</h3>' +
+  '<p>実績記事を作成し、works 詳細ページへ追加します。カテゴリ・リード文・公開日を入力して公開します。</p></a>' +
   '</div></main>' +
   tail('');

--- a/workers/yomimono/src/ui-manual-cases.ts
+++ b/workers/yomimono/src/ui-manual-cases.ts
@@ -1,0 +1,201 @@
+import { head, header, tail } from './ui-shared';
+
+// 実績記事（cases）作成ページ。/api/validate /api/publish へ collection:'cases' を明示して送る。
+const BODY = `<main class="wide">
+  <p class="lead">実績記事を作成します。本文は「課題・アプローチ・実装・成果」の見出しで書くと、既存の works 詳細ページに自然につながります。</p>
+  <div class="step">
+    <div class="row" style="gap:14px">
+      <div class="field" style="flex:1;min-width:220px;margin:0"><label>タイトル</label><input id="m_title" placeholder="実績記事のタイトル"></div>
+      <div class="field" style="width:210px;margin:0"><label>カテゴリ</label>
+        <select id="m_cat">
+          <option value="grift">Grift</option>
+          <option value="confidential-ai">機密データAI</option>
+          <option value="local-llm">ローカルLLM</option>
+          <option value="ai-contract">AI受託・開発</option>
+          <option value="tech-culture">技術文化・発信</option>
+        </select>
+      </div>
+    </div>
+    <div class="field" style="margin-top:10px"><label>リード文（実績ページ上部に表示）</label><input id="m_summary" placeholder="1〜2行で、どんな実績かを説明"></div>
+    <div class="row" style="gap:14px;margin-top:10px">
+      <div class="field" style="flex:1;min-width:220px;margin:0"><label>説明（カード・OGP用の1〜2文）</label><input id="m_desc" placeholder="一覧やSNSで表示される短い説明"></div>
+      <div class="field" style="width:240px;margin:0"><label>タグ（カンマ区切り）</label><input id="m_tags" placeholder="AI, PoC"></div>
+    </div>
+    <div class="row" style="gap:14px;margin-top:10px">
+      <div class="field" style="flex:1;min-width:220px;margin:0"><label>slug（URL・英小文字/数字/ハイフン）</label><input id="m_slug" placeholder="case-study-slug"></div>
+      <div class="field" style="width:170px;margin:0"><label>公開日</label><input id="m_date" type="date"></div>
+      <div class="field" style="width:170px;margin:0"><label>注目表示</label><label style="display:flex;align-items:center;gap:8px;padding-top:9px"><input id="m_featured" type="checkbox" style="width:auto"> featured</label></div>
+    </div>
+  </div>
+
+  <div class="split">
+    <div class="step editor">
+      <div class="toolbar">
+        <strong style="font-size:13px;color:var(--navy)">本文（Markdown）</strong>
+        <button class="ghost" id="m_imgBtn" type="button">画像を追加</button>
+        <span class="meta" id="m_imgMsg"></span>
+        <input type="file" id="m_file" accept="image/*" multiple hidden>
+      </div>
+      <textarea id="m_body" class="drop" maxlength="100000" placeholder="## 課題
+
+お客様やプロジェクトが抱えていた問題。
+
+## アプローチ
+
+どう考え、どんな方針で臨んだか。
+
+## 実装
+
+実際に作ったもの・技術的なポイント。
+
+## 成果
+
+結果・効果。NDA案件は具体名や数値を抽象化してください。"></textarea>
+    </div>
+    <div class="step">
+      <div class="toolbar"><strong style="font-size:13px;color:var(--navy)">プレビュー</strong></div>
+      <div class="preview" id="m_prev"><p class="meta">ここに表示されます。</p></div>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="row">
+      <button class="pub" id="m_pub">実績記事を公開する</button>
+      <button class="ghost" id="m_check" type="button">公開前チェック</button>
+      <span class="meta" id="m_msg"></span>
+    </div>
+    <div id="m_result"></div>
+  </div>
+</main>`;
+
+const JS = `
+  (function(){ var d=new Date(), p=function(n){return (n<10?'0':'')+n;};
+    $('m_slug').value='case-'+d.getFullYear()+p(d.getMonth()+1)+p(d.getDate())+'-'+p(d.getHours())+p(d.getMinutes());
+    $('m_date').value=d.getFullYear()+'-'+p(d.getMonth()+1)+'-'+p(d.getDate());
+  })();
+
+  var imgCache = {};
+
+  function inline(t){
+    t = esc(t);
+    t = t.replace(/!\\[([^\\]]*)\\]\\(([^)\\s]+)\\)/g, function(m,alt,url){ var src = imgCache[url] ? imgCache[url] : esc(safeUrl(url)); return '<img src="'+src+'" alt="'+alt+'">'; });
+    t = t.replace(/\\[([^\\]]+)\\]\\(([^)\\s]+)\\)/g, function(m,tx,url){ return '<a href="'+esc(safeUrl(url))+'" target="_blank" rel="noopener">'+tx+'</a>'; });
+    t = t.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
+    t = t.replace(/(^|[^*])\\*([^*]+)\\*/g, '$1<em>$2</em>');
+    t = t.replace(/\`([^\`]+)\`/g, '<code>$1</code>');
+    return t;
+  }
+  function mdToHtml(md){
+    var lines = String(md||'').split(/\\r?\\n/);
+    var out = [], list = null, inCode = false, codeBuf = [];
+    function closeList(){ if(list){ out.push('</'+list+'>'); list=null; } }
+    for (var i=0;i<lines.length;i++){
+      var ln = lines[i];
+      if (/^\`\`\`/.test(ln)){
+        if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); inCode=false; codeBuf=[]; }
+        else { closeList(); inCode=true; }
+        continue;
+      }
+      if (inCode){ codeBuf.push(esc(ln)); continue; }
+      var mh = ln.match(/^(#{1,3})\\s+(.*)$/);
+      var mu = ln.match(/^\\s*[-*]\\s+(.*)$/);
+      var mo = ln.match(/^\\s*\\d+\\.\\s+(.*)$/);
+      if (mh){ closeList(); var lvl=mh[1].length; out.push('<h'+lvl+'>'+inline(mh[2])+'</h'+lvl+'>'); }
+      else if (mu){ if(list!=='ul'){ closeList(); list='ul'; out.push('<ul>'); } out.push('<li>'+inline(mu[1])+'</li>'); }
+      else if (mo){ if(list!=='ol'){ closeList(); list='ol'; out.push('<ol>'); } out.push('<li>'+inline(mo[1])+'</li>'); }
+      else if (/^\\s*$/.test(ln)){ closeList(); }
+      else { closeList(); out.push('<p>'+inline(ln)+'</p>'); }
+    }
+    if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); }
+    closeList();
+    return out.join('');
+  }
+  function updatePreview(){
+    var html = mdToHtml($('m_body').value);
+    $('m_prev').innerHTML = html || '<p class="meta">ここに表示されます。</p>';
+  }
+  var _pvTimer = null;
+  $('m_body').addEventListener('input', function(){ if(_pvTimer) clearTimeout(_pvTimer); _pvTimer=setTimeout(updatePreview, 120); });
+
+  function insertAtCursor(text){
+    var ta=$('m_body'), s=ta.selectionStart, e=ta.selectionEnd;
+    ta.value = ta.value.slice(0,s) + text + ta.value.slice(e);
+    ta.selectionStart = ta.selectionEnd = s + text.length;
+    ta.focus(); updatePreview();
+  }
+  function uploadFile(file){
+    if(!file || !/^image\\//.test(file.type||'')){ $('m_imgMsg').textContent='画像ファイルのみ対応です'; return; }
+    $('m_imgMsg').innerHTML='<span class="spin" style="border-color:#1b2c40;border-top-color:transparent"></span>アップロード中…';
+    var reader=new FileReader();
+    reader.onerror=function(){ $('m_imgMsg').innerHTML='<span style="color:#dc2626">画像の読み込みに失敗しました</span>'; };
+    reader.onload=function(){
+      var dataUrl=String(reader.result||'');
+      var base64=dataUrl.split(',')[1]||'';
+      api('/api/upload-image', { filename:file.name||'image.png', dataBase64:base64 }).then(function(j){
+        imgCache[j.url]=dataUrl;
+        insertAtCursor('\\n![' + (file.name||'画像') + '](' + j.url + ')\\n');
+        $('m_imgMsg').textContent='挿入しました: '+j.url;
+      }).catch(function(e){ $('m_imgMsg').innerHTML='<span style="color:#dc2626">画像アップロード失敗: '+esc(e.message)+'</span>'; });
+    };
+    reader.readAsDataURL(file);
+  }
+  $('m_imgBtn').addEventListener('click', function(){ $('m_file').click(); });
+  $('m_file').addEventListener('change', function(){ for(var i=0;i<this.files.length;i++) uploadFile(this.files[i]); this.value=''; });
+
+  var ta=$('m_body');
+  ta.addEventListener('dragover', function(e){ e.preventDefault(); ta.classList.add('over'); });
+  ta.addEventListener('dragleave', function(){ ta.classList.remove('over'); });
+  ta.addEventListener('drop', function(e){ e.preventDefault(); ta.classList.remove('over'); var f=e.dataTransfer&&e.dataTransfer.files; if(f) for(var i=0;i<f.length;i++) uploadFile(f[i]); });
+  ta.addEventListener('paste', function(e){ var it=e.clipboardData&&e.clipboardData.items; if(!it) return; for(var i=0;i<it.length;i++){ if(it[i].type&&it[i].type.indexOf('image')===0){ var f=it[i].getAsFile(); if(f){ e.preventDefault(); uploadFile(f); } } } });
+
+  function gather(){
+    var tags = $('m_tags').value.split(',').map(function(s){ return s.trim(); }).filter(Boolean);
+    return {
+      slug:$('m_slug').value.trim(),
+      title:$('m_title').value.trim(),
+      description:$('m_desc').value.trim(),
+      category:$('m_cat').value,
+      tags:tags,
+      body:$('m_body').value,
+      summary:$('m_summary').value.trim(),
+      publishedAt:$('m_date').value,
+      featured:$('m_featured').checked
+    };
+  }
+  function validateLocal(a){
+    if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'slug は英小文字・数字・ハイフン 3〜80字で入力してください';
+    if(!a.title) return 'タイトルを入力してください';
+    if(!a.summary) return 'リード文を入力してください';
+    if(!a.description) return '説明を入力してください';
+    if(a.publishedAt && !/^\\d{4}-\\d{2}-\\d{2}$/.test(a.publishedAt)) return '公開日は YYYY-MM-DD で入力してください';
+    if(!a.body.trim()) return '本文を入力してください';
+    return '';
+  }
+  function renderViolations(v){
+    if(v.length){ $('m_msg').innerHTML='<span style="color:#dc2626">違反 '+v.length+'件: '+esc(v.map(function(x){return x.name;}).join(', '))+'</span>'; }
+    else { $('m_msg').innerHTML='<span style="color:#16a34a">✓ 違反なし。公開できます</span>'; }
+  }
+  $('m_check').addEventListener('click', function(){
+    var a=gather(); var err=validateLocal(a);
+    if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
+    var btn=this; btn.disabled=true; $('m_msg').textContent='チェック中…';
+    api('/api/validate', { collection:'cases', article:a }).then(function(j){
+      renderViolations(j.violations||[]);
+      btn.disabled=false;
+    }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; });
+  });
+  $('m_pub').addEventListener('click', function(){
+    var a=gather(); var err=validateLocal(a);
+    if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
+    var btn=this; btn.disabled=true; btn.innerHTML='<span class="spin"></span>公開中…'; $('m_msg').textContent='';
+    api('/api/publish', { collection:'cases', article:a }).then(function(j){
+      var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
+      $('m_result').innerHTML='<div class="done">✓ 実績記事を公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
+      $('m_msg').textContent='';
+      btn.disabled=false; btn.innerHTML='実績記事を公開する';
+    }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.innerHTML='実績記事を公開する'; });
+  });
+  updatePreview();
+`;
+
+export const MANUAL_CASES_HTML = head('実績作成 — 読みもの 作成スタジオ') + header('manual-cases') + BODY + tail(JS);

--- a/workers/yomimono/src/ui-manual-cases.ts
+++ b/workers/yomimono/src/ui-manual-cases.ts
@@ -1,7 +1,12 @@
-import { head, header, tail } from './ui-shared';
+import { head, header, tail, toolbarButtonsHtml, draftBarHtml, UI_KIT_JS } from './ui-shared';
 
-// 実績記事（cases）作成ページ。/api/validate /api/publish へ collection:'cases' を明示して送る。
-const BODY = `<main class="wide">
+// 実績記事（cases）作成ページ。M1-I2 の非エンジニア向けUI改善キットを適用し、
+// /api/validate /api/publish へ collection:'cases' を明示して送る。
+const BODY =
+  `<main class="wide">
+  ` +
+  draftBarHtml('m') +
+  `
   <p class="lead">実績記事を作成します。本文は「課題・アプローチ・実装・成果」の見出しで書くと、既存の works 詳細ページに自然につながります。</p>
   <div class="step">
     <div class="row" style="gap:14px">
@@ -22,16 +27,21 @@ const BODY = `<main class="wide">
       <div class="field" style="width:240px;margin:0"><label>タグ（カンマ区切り）</label><input id="m_tags" placeholder="AI, PoC"></div>
     </div>
     <div class="row" style="gap:14px;margin-top:10px">
-      <div class="field" style="flex:1;min-width:220px;margin:0"><label>slug（URL・英小文字/数字/ハイフン）</label><input id="m_slug" placeholder="case-study-slug"></div>
       <div class="field" style="width:170px;margin:0"><label>公開日</label><input id="m_date" type="date"></div>
       <div class="field" style="width:170px;margin:0"><label>注目表示</label><label style="display:flex;align-items:center;gap:8px;padding-top:9px"><input id="m_featured" type="checkbox" style="width:auto"> featured</label></div>
     </div>
+    <details class="advanced"><summary>URLを編集する（上級者向け）</summary>
+      <div class="field" style="margin-top:8px"><label>URLの末尾（英小文字/数字/ハイフン・空欄でタイトルから自動生成）</label><input id="m_slug" placeholder="自動生成されます"></div>
+    </details>
   </div>
 
   <div class="split">
     <div class="step editor">
-      <div class="toolbar">
-        <strong style="font-size:13px;color:var(--navy)">本文（Markdown）</strong>
+      <div class="toolbar" id="m_toolbar">
+        <strong style="font-size:13px;color:var(--navy)">本文</strong>
+        ` +
+  toolbarButtonsHtml() +
+  `
         <button class="ghost" id="m_imgBtn" type="button">画像を追加</button>
         <span class="meta" id="m_imgMsg"></span>
         <input type="file" id="m_file" accept="image/*" multiple hidden>
@@ -61,21 +71,49 @@ const BODY = `<main class="wide">
   <div class="step">
     <div class="row">
       <button class="pub" id="m_pub">実績記事を公開する</button>
+      <button class="ghost" id="m_draft" type="button">下書きをブラウザに保存</button>
       <button class="ghost" id="m_check" type="button">公開前チェック</button>
       <span class="meta" id="m_msg"></span>
     </div>
     <div id="m_result"></div>
+    <details class="help"><summary>技術的なメモ（かっこのある方向け）</summary>
+      <div class="help-body">
+        <ul>
+          <li>公開は GitHub の main ブランチへコミットされ、数分で静的サイトに反映されます（main マージ不要）。</li>
+          <li>本文は Markdown 形式で保存されます。ツールバーが記号を自動挿入します。</li>
+          <li>「下書きをブラウザに保存」はこの端末のブラウザ（localStorage）にのみ保存されます。サーバーには送信されません。</li>
+          <li>入力中の内容は自動的にこのブラウザに保存されます（デバイスごと・公開時に消去）。</li>
+        </ul>
+      </div>
+    </details>
   </div>
 </main>`;
 
 const JS = `
-  (function(){ var d=new Date(), p=function(n){return (n<10?'0':'')+n;};
-    $('m_slug').value='case-'+d.getFullYear()+p(d.getMonth()+1)+p(d.getDate())+'-'+p(d.getHours())+p(d.getMinutes());
-    $('m_date').value=d.getFullYear()+'-'+p(d.getMonth()+1)+'-'+p(d.getDate());
-  })();
-
+  // === 状態 ===
+  var slugEdited = false;
+  var DRAFT_KEY = 'draft:cases:new';
+  var pendingDraft = null;
   var imgCache = {};
+  var IMG_CACHE_MAX = 20; // プレビュー用 data URL のキャッシュ上限（古いものから破棄）
+  var _pvTimer = null;
+  var _draftTimer = null; // 下書き自動保存タイマー（公開成功時にキャンセルして競合防止）
 
+  function todayString(){
+    var d=new Date(), p=function(n){return (n<10?'0':'')+n;};
+    return d.getFullYear()+'-'+p(d.getMonth()+1)+'-'+p(d.getDate());
+  }
+  function setDefaultDate(){ $('m_date').value = todayString(); }
+
+  // imgCache に data URL を登録。上限超過時は最古のエントリから削除（挿入順 = 古い順）。
+  function setImgCache(url, dataUrl){
+    if(!url || imgCache.hasOwnProperty(url)) { imgCache[url]=dataUrl; return; }
+    var keys = Object.keys(imgCache);
+    while(keys.length >= IMG_CACHE_MAX && keys.length > 0){ delete imgCache[keys.shift()]; }
+    imgCache[url]=dataUrl;
+  }
+
+  // === 最小 Markdown レンダラ（esc + safeUrl で安全に） ===
   function inline(t){
     t = esc(t);
     t = t.replace(/!\\[([^\\]]*)\\]\\(([^)\\s]+)\\)/g, function(m,alt,url){ var src = imgCache[url] ? imgCache[url] : esc(safeUrl(url)); return '<img src="'+src+'" alt="'+alt+'">'; });
@@ -87,36 +125,42 @@ const JS = `
   }
   function mdToHtml(md){
     var lines = String(md||'').split(/\\r?\\n/);
-    var out = [], list = null, inCode = false, codeBuf = [];
+    var out = [], list = null, bq = false, inCode = false, codeBuf = [];
     function closeList(){ if(list){ out.push('</'+list+'>'); list=null; } }
+    function closeBq(){ if(bq){ out.push('</blockquote>'); bq=false; } }
     for (var i=0;i<lines.length;i++){
       var ln = lines[i];
       if (/^\`\`\`/.test(ln)){
         if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); inCode=false; codeBuf=[]; }
-        else { closeList(); inCode=true; }
+        else { closeList(); closeBq(); inCode=true; }
         continue;
       }
       if (inCode){ codeBuf.push(esc(ln)); continue; }
       var mh = ln.match(/^(#{1,3})\\s+(.*)$/);
       var mu = ln.match(/^\\s*[-*]\\s+(.*)$/);
       var mo = ln.match(/^\\s*\\d+\\.\\s+(.*)$/);
-      if (mh){ closeList(); var lvl=mh[1].length; out.push('<h'+lvl+'>'+inline(mh[2])+'</h'+lvl+'>'); }
-      else if (mu){ if(list!=='ul'){ closeList(); list='ul'; out.push('<ul>'); } out.push('<li>'+inline(mu[1])+'</li>'); }
-      else if (mo){ if(list!=='ol'){ closeList(); list='ol'; out.push('<ol>'); } out.push('<li>'+inline(mo[1])+'</li>'); }
-      else if (/^\\s*$/.test(ln)){ closeList(); }
-      else { closeList(); out.push('<p>'+inline(ln)+'</p>'); }
+      var mq = ln.match(/^>\\s?(.*)$/);
+      var mhr = /^\\s*(?:-{3,}|\\*{3,}|_{3,})\\s*$/.test(ln);
+      if (mhr){ closeList(); closeBq(); out.push('<hr>'); }
+      else if (mh){ closeList(); closeBq(); var lvl=mh[1].length; out.push('<h'+lvl+'>'+inline(mh[2])+'</h'+lvl+'>'); }
+      else if (mu){ closeBq(); if(list!=='ul'){ closeList(); list='ul'; out.push('<ul>'); } out.push('<li>'+inline(mu[1])+'</li>'); }
+      else if (mo){ closeBq(); if(list!=='ol'){ closeList(); list='ol'; out.push('<ol>'); } out.push('<li>'+inline(mo[1])+'</li>'); }
+      else if (mq){ closeList(); if(!bq){ out.push('<blockquote>'); bq=true; } out.push('<p>'+inline(mq[1])+'</p>'); }
+      else if (/^\\s*$/.test(ln)){ closeList(); closeBq(); }
+      else { closeList(); closeBq(); out.push('<p>'+inline(ln)+'</p>'); }
     }
     if (inCode){ out.push('<pre><code>'+codeBuf.join('\\n')+'</code></pre>'); }
-    closeList();
+    closeList(); closeBq();
     return out.join('');
   }
   function updatePreview(){
     var html = mdToHtml($('m_body').value);
     $('m_prev').innerHTML = html || '<p class="meta">ここに表示されます。</p>';
   }
-  var _pvTimer = null;
-  $('m_body').addEventListener('input', function(){ if(_pvTimer) clearTimeout(_pvTimer); _pvTimer=setTimeout(updatePreview, 120); });
+  function schedulePreview(){ if(_pvTimer) clearTimeout(_pvTimer); _pvTimer=setTimeout(updatePreview, 120); }
 
+  // === 画像アップロード（D&D / ペースト / ボタン） ===
+  // アップロード直後の画像はまだ本番にデプロイされていないため、プレビューは data URL で即表示する（本文 markdown は /images/... のまま）。
   function insertAtCursor(text){
     var ta=$('m_body'), s=ta.selectionStart, e=ta.selectionEnd;
     ta.value = ta.value.slice(0,s) + text + ta.value.slice(e);
@@ -132,26 +176,48 @@ const JS = `
       var dataUrl=String(reader.result||'');
       var base64=dataUrl.split(',')[1]||'';
       api('/api/upload-image', { filename:file.name||'image.png', dataBase64:base64 }).then(function(j){
-        imgCache[j.url]=dataUrl;
+        setImgCache(j.url, dataUrl);
         insertAtCursor('\\n![' + (file.name||'画像') + '](' + j.url + ')\\n');
         $('m_imgMsg').textContent='挿入しました: '+j.url;
       }).catch(function(e){ $('m_imgMsg').innerHTML='<span style="color:#dc2626">画像アップロード失敗: '+esc(e.message)+'</span>'; });
     };
     reader.readAsDataURL(file);
   }
-  $('m_imgBtn').addEventListener('click', function(){ $('m_file').click(); });
-  $('m_file').addEventListener('change', function(){ for(var i=0;i<this.files.length;i++) uploadFile(this.files[i]); this.value=''; });
 
-  var ta=$('m_body');
-  ta.addEventListener('dragover', function(e){ e.preventDefault(); ta.classList.add('over'); });
-  ta.addEventListener('dragleave', function(){ ta.classList.remove('over'); });
-  ta.addEventListener('drop', function(e){ e.preventDefault(); ta.classList.remove('over'); var f=e.dataTransfer&&e.dataTransfer.files; if(f) for(var i=0;i<f.length;i++) uploadFile(f[i]); });
-  ta.addEventListener('paste', function(e){ var it=e.clipboardData&&e.clipboardData.items; if(!it) return; for(var i=0;i<it.length;i++){ if(it[i].type&&it[i].type.indexOf('image')===0){ var f=it[i].getAsFile(); if(f){ e.preventDefault(); uploadFile(f); } } } });
-
+  // === 入力データ収集 ===
+  function gatherAll(){
+    return {
+      title:$('m_title').value,
+      summary:$('m_summary').value,
+      desc:$('m_desc').value,
+      cat:$('m_cat').value,
+      tags:$('m_tags').value,
+      slug:$('m_slug').value,
+      publishedAt:$('m_date').value,
+      featured:$('m_featured').checked,
+      body:$('m_body').value
+    };
+  }
+  function applyDraft(d){
+    if(!d) return;
+    $('m_title').value = d.title || '';
+    $('m_summary').value = d.summary || '';
+    $('m_desc').value = d.desc || '';
+    $('m_cat').value = d.cat || 'grift';
+    $('m_tags').value = d.tags || '';
+    $('m_slug').value = d.slug || '';
+    $('m_date').value = d.publishedAt || todayString();
+    $('m_featured').checked = d.featured === true;
+    $('m_body').value = d.body || '';
+    slugEdited = !!($('m_slug').value.trim());
+    updatePreview();
+  }
   function gather(){
     var tags = $('m_tags').value.split(',').map(function(s){ return s.trim(); }).filter(Boolean);
+    // URLの末尾は空欄ならタイトルから自動生成（非エンジニアは意識しない）
+    var slug = $('m_slug').value.trim() || titleToSlug($('m_title').value);
     return {
-      slug:$('m_slug').value.trim(),
+      slug:slug,
       title:$('m_title').value.trim(),
       description:$('m_desc').value.trim(),
       category:$('m_cat').value,
@@ -163,18 +229,66 @@ const JS = `
     };
   }
   function validateLocal(a){
-    if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'slug は英小文字・数字・ハイフン 3〜80字で入力してください';
     if(!a.title) return 'タイトルを入力してください';
     if(!a.summary) return 'リード文を入力してください';
     if(!a.description) return '説明を入力してください';
     if(a.publishedAt && !/^\\d{4}-\\d{2}-\\d{2}$/.test(a.publishedAt)) return '公開日は YYYY-MM-DD で入力してください';
     if(!a.body.trim()) return '本文を入力してください';
+    if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'URLの末尾は英小文字・数字・ハイフン（3〜80字）で指定してください';
     return '';
   }
   function renderViolations(v){
     if(v.length){ $('m_msg').innerHTML='<span style="color:#dc2626">違反 '+v.length+'件: '+esc(v.map(function(x){return x.name;}).join(', '))+'</span>'; }
     else { $('m_msg').innerHTML='<span style="color:#16a34a">✓ 違反なし。公開できます</span>'; }
   }
+
+  // === 下書き（LocalStorage 自動保存・復元） ===
+  function scheduleDraftSave(){
+    if(_draftTimer) clearTimeout(_draftTimer);
+    _draftTimer = setTimeout(function(){ _draftTimer=null; saveDraft(DRAFT_KEY, gatherAll()); }, 800);
+  }
+  function cancelDraftSave(){ if(_draftTimer){ clearTimeout(_draftTimer); _draftTimer=null; } }
+  function resetForm(){
+    $('m_title').value=''; $('m_summary').value=''; $('m_desc').value=''; $('m_cat').value='grift';
+    $('m_tags').value=''; $('m_slug').value=''; setDefaultDate(); $('m_featured').checked=false; $('m_body').value='';
+    slugEdited = false; imgCache = {};
+    updatePreview();
+  }
+
+  // === 初期化 ===
+  setDefaultDate();
+  wireToolbar($('m_toolbar'), $('m_body'));
+  (function(){
+    var d = loadDraft(DRAFT_KEY);
+    if(d && (d.title || d.summary || d.desc || d.body)){ pendingDraft = d; $('m_draftBar').hidden = false; }
+  })();
+
+  // === イベント束ね ===
+  $('m_title').addEventListener('input', function(){
+    if(!slugEdited){ $('m_slug').value = titleToSlug($('m_title').value); }
+    scheduleDraftSave();
+  });
+  $('m_slug').addEventListener('input', function(){ slugEdited = !!($('m_slug').value.trim()); scheduleDraftSave(); });
+  $('m_summary').addEventListener('input', scheduleDraftSave);
+  $('m_desc').addEventListener('input', scheduleDraftSave);
+  $('m_tags').addEventListener('input', scheduleDraftSave);
+  $('m_cat').addEventListener('change', scheduleDraftSave);
+  $('m_date').addEventListener('change', scheduleDraftSave);
+  $('m_featured').addEventListener('change', scheduleDraftSave);
+  $('m_body').addEventListener('input', function(){ schedulePreview(); scheduleDraftSave(); });
+
+  $('m_restore').addEventListener('click', function(){ applyDraft(pendingDraft); $('m_draftBar').hidden = true; });
+  $('m_discard').addEventListener('click', function(){ clearDraft(DRAFT_KEY); pendingDraft = null; $('m_draftBar').hidden = true; });
+
+  $('m_imgBtn').addEventListener('click', function(){ $('m_file').click(); });
+  $('m_file').addEventListener('change', function(){ for(var i=0;i<this.files.length;i++) uploadFile(this.files[i]); this.value=''; });
+  var ta=$('m_body');
+  ta.addEventListener('dragover', function(e){ e.preventDefault(); ta.classList.add('over'); });
+  ta.addEventListener('dragleave', function(){ ta.classList.remove('over'); });
+  ta.addEventListener('drop', function(e){ e.preventDefault(); ta.classList.remove('over'); var f=e.dataTransfer&&e.dataTransfer.files; if(f) for(var i=0;i<f.length;i++) uploadFile(f[i]); });
+  ta.addEventListener('paste', function(e){ var it=e.clipboardData&&e.clipboardData.items; if(!it) return; for(var i=0;i<it.length;i++){ if(it[i].type&&it[i].type.indexOf('image')===0){ var f=it[i].getAsFile(); if(f){ e.preventDefault(); uploadFile(f); } } } });
+
+  // === 公開前チェック ===
   $('m_check').addEventListener('click', function(){
     var a=gather(); var err=validateLocal(a);
     if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
@@ -184,6 +298,8 @@ const JS = `
       btn.disabled=false;
     }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; });
   });
+
+  // === 実績記事を公開する（collection:'cases' を明示） ===
   $('m_pub').addEventListener('click', function(){
     var a=gather(); var err=validateLocal(a);
     if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
@@ -192,10 +308,26 @@ const JS = `
       var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
       $('m_result').innerHTML='<div class="done">✓ 実績記事を公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
       $('m_msg').textContent='';
+      cancelDraftSave();
+      clearDraft(DRAFT_KEY);
+      pendingDraft = null;
+      $('m_draftBar').hidden = true;
+      resetForm();
       btn.disabled=false; btn.innerHTML='実績記事を公開する';
     }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.innerHTML='実績記事を公開する'; });
   });
+
+  // === 下書きをブラウザに保存（localStorage のみ・サーバーへは送信しない） ===
+  $('m_draft').addEventListener('click', function(){
+    var btn=this; btn.disabled=true;
+    saveDraft(DRAFT_KEY, gatherAll());
+    $('m_result').innerHTML='<div class="done">✓ このブラウザに下書きを保存しました（次回訪問時に復元できます・サーバーには送信されません）</div>';
+    $('m_msg').textContent='';
+    btn.disabled=false;
+  });
+
   updatePreview();
 `;
 
-export const MANUAL_CASES_HTML = head('実績作成 — 読みもの 作成スタジオ') + header('manual-cases') + BODY + tail(JS);
+export const MANUAL_CASES_HTML =
+  head('実績作成 — 読みもの 作成スタジオ') + header('manual-cases') + BODY + tail(UI_KIT_JS + JS);

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -146,7 +146,8 @@ export function header(active: 'hub' | 'ai' | 'manual' | 'manual-news' | 'manual
     '<nav class="nav">' +
     link('/', 'ハブ', 'hub') +
     link('/ai', 'AI生成', 'ai') +
-    link('/manual', '手動作成', 'manual') +
+    link('/manual', 'ブログ作成', 'manual') +
+    link('/manual/cases', '実績作成', 'manual-cases') +
     '</nav></div></header>'
   );
 }


### PR DESCRIPTION
## ① なぜ（解決したい課題）

#220 ではブログだけでなく、実績・事例（cases）も非エンジニアがCMSから投稿できる状態にする必要があります。既存の手動投稿UIと同じ操作感で cases 用フォームを分離し、公開前の検証をWorker側で行えるようにします。

Refs #220

## ② どう実装したか

- `/blog-admin/manual/cases` の投稿UIを追加しました。
- 既存の hub から cases 投稿導線を追加しました。
- cases投稿用の入力項目と確認表示を `ui-manual-cases.ts` に分離しました。
- Worker API 側の分岐と tests を追加しました。
- README / CMS setup / ADR の対象範囲を更新しました。

## ③ 特にレビューしてほしい点

- cases と blog の手動投稿UIが混ざらず、非エンジニア向けの導線として自然か。
- Worker route の追加が既存 `/manual` と認証/session処理に影響しないか。

## ④ テスト内容・確認方法

- `npm --prefix workers/yomimono run typecheck`
- `npm --prefix workers/yomimono test -- --run`（7 files / 198 tests passed）
- `git diff --check`

## browser/live evidence

- 未検証: develop merge 後の Worker deploy は未実施です。
- 未検証: Worker live route の認証付き `/blog-admin/manual/cases` 実ブラウザ証跡は未取得です。
- このPRは draft であり、merge/完了/Issue close の根拠にはまだしません。
