### PR TITLE
feat(M1-I3): 既存記事編集フローを追加

### DIFF
--- a/workers/yomimono/src/__tests__/article-markdown.test.ts
+++ b/workers/yomimono/src/__tests__/article-markdown.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { parseBlogMarkdown, rebuildBlogMarkdown } from '../article-markdown';
+import type { NormalizedArticle } from '../validate';
+
+const original = `---
+title: "旧タイトル"
+description: "旧説明"
+pubDate: 2026-07-01
+author: "Terisuke"
+category: "ai"
+tags: ["生成AI","社内ルール"]
+image:
+  url: "/images/blog/sample.avif"
+  alt: "サンプル"
+lang: "ja"
+featured: true
+---
+
+# 旧タイトル
+
+本文です。
+`;
+
+describe('parseBlogMarkdown', () => {
+  it('blog frontmatter と本文を編集フォーム用 article に変換する', () => {
+    const parsed = parseBlogMarkdown('existing-post', original);
+    expect(parsed.article).toMatchObject({
+      slug: 'existing-post',
+      title: '旧タイトル',
+      description: '旧説明',
+      category: 'ai',
+      tags: ['生成AI', '社内ルール'],
+      body: '# 旧タイトル\n\n本文です。',
+      isDraft: false,
+    });
+    expect(parsed.frontmatter.pubDate).toBe('2026-07-01');
+  });
+});
+
+describe('rebuildBlogMarkdown', () => {
+  const updated: NormalizedArticle = {
+    slug: 'existing-post',
+    title: '新タイトル',
+    description: '新説明',
+    category: 'engineering',
+    tags: ['更新', 'CMS'],
+    body: '## 追記\n\n更新しました。',
+    collection: 'blog',
+    isDraft: true,
+  };
+
+  it('編集対象フィールドだけ差し替え、pubDate/image/featured を保持する', () => {
+    const rebuilt = rebuildBlogMarkdown(original, updated);
+    expect(rebuilt).toContain('title: "新タイトル"');
+    expect(rebuilt).toContain('description: "新説明"');
+    expect(rebuilt).toContain('category: "engineering"');
+    expect(rebuilt).toContain('tags: ["更新","CMS"]');
+    expect(rebuilt).toContain('isDraft: true');
+    expect(rebuilt).toContain('pubDate: 2026-07-01');
+    expect(rebuilt).toContain('image:\n  url: "/images/blog/sample.avif"\n  alt: "サンプル"');
+    expect(rebuilt).toContain('featured: true');
+    expect(rebuilt).toContain('## 追記\n\n更新しました。\n');
+  });
+
+  it('本文先頭の frontmatter 区切りだけ除去して保存する', () => {
+    const rebuilt = rebuildBlogMarkdown(original, { ...updated, body: '---\n本文' });
+    expect(rebuilt).toContain('\n---\n\n本文\n');
+    expect(rebuilt).not.toContain('\n---\n\n---\n本文');
+  });
+});

--- a/workers/yomimono/src/__tests__/github.test.ts
+++ b/workers/yomimono/src/__tests__/github.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { contentDir } from '../github';
+import { describe, it, expect, vi } from 'vitest';
+import { contentDir, readBlogArticle, updateBlogArticle } from '../github';
 import type { Env } from '../types';
+
+function utf8ToBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
 
 describe('contentDir — コレクション別コンテンツディレクトリパス', () => {
   const mockEnv: Env = {
@@ -53,5 +60,85 @@ describe('contentDir — コレクション別コンテンツディレクトリ�
     const casesDir = contentDir(mockEnv, 'cases');
     expect(casesDir).not.toContain('//');
     expect(casesDir).toMatch(/^[^/]+\/[^/]+\/[^/]+$/);
+  });
+});
+
+describe('readBlogArticle / updateBlogArticle — 既存記事編集', () => {
+  const mockEnv: Env = {
+    BLOG_DIR: 'src/content/blog',
+    NEWS_DIR: 'src/content/news',
+    CASES_DIR: 'src/content/cases',
+    GH_OWNER: 'test-owner',
+    GH_REPO: 'test-repo',
+    GH_APP_ID: '123',
+    GH_INSTALLATION_ID: '456',
+    GH_APP_PRIVATE_KEY: 'test-key',
+    PUBLISH_BRANCH: 'main',
+    STYLE_GUIDE_PATH: 'docs/blog-style-guide.md',
+    ANTHROPIC_API_KEY: 'test-key',
+    ACCESS_PASSWORD: 'x'.repeat(20),
+    SESSION_SECRET: 'test-secret',
+    BASE_PATH: '/',
+  };
+
+  const markdown = `---
+title: "編集対象"
+description: "説明"
+pubDate: 2026-07-08
+author: "Terisuke"
+category: "ai"
+tags: ["a","b"]
+lang: "ja"
+isDraft: false
+---
+
+本文
+`;
+
+  it('readBlogArticle は blog/ja/<slug>.md を読み、sha と article を返す', async () => {
+    const request = vi.fn(async () => ({
+      data: {
+        content: utf8ToBase64(markdown),
+        sha: 'file-sha',
+      },
+    }));
+    const article = await readBlogArticle(mockEnv, { request } as never, 'edit-target');
+    expect(request).toHaveBeenCalledWith('GET /repos/{owner}/{repo}/contents/{path}', {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      path: 'src/content/blog/ja/edit-target.md',
+      ref: 'main',
+    });
+    expect(article.sha).toBe('file-sha');
+    expect(article.article.title).toBe('編集対象');
+    expect(article.article.slug).toBe('edit-target');
+  });
+
+  it('updateBlogArticle は sha 付き PUT で同じ slug を更新する', async () => {
+    const request = vi.fn(async () => ({
+      data: { commit: { html_url: 'https://github.com/test/commit/1' } },
+    }));
+    const result = await updateBlogArticle(
+      mockEnv,
+      { request } as never,
+      'edit-target',
+      markdown,
+      'file-sha',
+      'editor@example.com',
+    );
+    expect(result).toEqual({
+      updated: true,
+      path: 'src/content/blog/ja/edit-target.md',
+      commitUrl: 'https://github.com/test/commit/1',
+    });
+    expect(request).toHaveBeenCalledWith('PUT /repos/{owner}/{repo}/contents/{path}', {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      path: 'src/content/blog/ja/edit-target.md',
+      branch: 'main',
+      message: 'post(yomimono): edit-target（更新: editor）',
+      content: utf8ToBase64(markdown),
+      sha: 'file-sha',
+    });
   });
 });

--- a/workers/yomimono/src/__tests__/validate-existing-edit.test.ts
+++ b/workers/yomimono/src/__tests__/validate-existing-edit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeArticle } from '../validate';
+
+describe('normalizeArticle — 既存記事編集の下書き状態', () => {
+  const base = {
+    slug: 'valid-slug-123',
+    title: 'タイトル',
+    description: '説明',
+    category: 'engineering',
+    tags: ['a', 'b'],
+    body: '## 本文\n\n内容',
+  };
+
+  it('isDraft は true のときだけ true に正規化する', () => {
+    const draft = normalizeArticle({ ...base, isDraft: true });
+    expect(draft.ok).toBe(true);
+    if (draft.ok) expect(draft.article.isDraft).toBe(true);
+
+    const published = normalizeArticle({ ...base, isDraft: false });
+    expect(published.ok).toBe(true);
+    if (published.ok) expect(published.article.isDraft).toBe(false);
+
+    const omitted = normalizeArticle(base);
+    expect(omitted.ok).toBe(true);
+    if (omitted.ok) expect(omitted.article.isDraft).toBe(false);
+  });
+});

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -430,6 +430,16 @@ describe('normalizeArticle — publish/validate 共通の検証・正規化', ()
     if (r.ok) expect(r.article.body.length).toBe(100_000);
   });
 
+  it('isDraft は true のときだけ保持する', () => {
+    const draft = normalizeArticle({ ...base, isDraft: true });
+    expect(draft.ok).toBe(true);
+    if (draft.ok) expect(draft.article.isDraft).toBe(true);
+
+    const published = normalizeArticle({ ...base, isDraft: false });
+    expect(published.ok).toBe(true);
+    if (published.ok) expect(published.article.isDraft).toBe(false);
+  });
+
   it('サニタイズ後に title が空なら 400', () => {
     const r = normalizeArticle({ ...base, title: '```' });
     expect(r.ok).toBe(false);

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -430,16 +430,6 @@ describe('normalizeArticle — publish/validate 共通の検証・正規化', ()
     if (r.ok) expect(r.article.body.length).toBe(100_000);
   });
 
-  it('isDraft は true のときだけ保持する', () => {
-    const draft = normalizeArticle({ ...base, isDraft: true });
-    expect(draft.ok).toBe(true);
-    if (draft.ok) expect(draft.article.isDraft).toBe(true);
-
-    const published = normalizeArticle({ ...base, isDraft: false });
-    expect(published.ok).toBe(true);
-    if (published.ok) expect(published.article.isDraft).toBe(false);
-  });
-
   it('サニタイズ後に title が空なら 400', () => {
     const r = normalizeArticle({ ...base, title: '```' });
     expect(r.ok).toBe(false);

--- a/workers/yomimono/src/article-markdown.ts
+++ b/workers/yomimono/src/article-markdown.ts
@@ -1,0 +1,133 @@
+import { normalizeCategory, type ArticleInput, type NormalizedArticle } from './validate';
+
+interface FrontmatterBlock {
+  key: string;
+  lines: string[];
+}
+
+interface ParsedFrontmatter {
+  blocks: FrontmatterBlock[];
+  body: string;
+}
+
+export interface ParsedBlogArticle {
+  article: ArticleInput;
+  frontmatter: Record<string, unknown>;
+}
+
+function splitMarkdown(markdown: string): ParsedFrontmatter {
+  const normalized = markdown.replace(/\r\n/g, '\n');
+  const match = normalized.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    throw new Error('frontmatter が見つかりません');
+  }
+
+  const blocks: FrontmatterBlock[] = [];
+  for (const line of match[1].split('\n')) {
+    const m = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (m) {
+      blocks.push({ key: m[1], lines: [line] });
+    } else if (blocks.length) {
+      blocks[blocks.length - 1].lines.push(line);
+    }
+  }
+  return { blocks, body: match[2].replace(/^\n/, '').replace(/\n$/, '') };
+}
+
+function scalarValue(raw: string | undefined): string {
+  const value = String(raw ?? '').trim();
+  if (!value) return '';
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+function parseValue(lines: string[]): unknown {
+  const first = lines[0] ?? '';
+  const raw = first.slice(first.indexOf(':') + 1).trim();
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.map(String) : [];
+    } catch {
+      return [];
+    }
+  }
+  return scalarValue(raw);
+}
+
+function parseFrontmatter(blocks: FrontmatterBlock[]): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  for (const block of blocks) {
+    values[block.key] = parseValue(block.lines);
+  }
+  return values;
+}
+
+function tagsValue(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.map(String).filter(Boolean) : [];
+}
+
+export function parseBlogMarkdown(slug: string, markdown: string): ParsedBlogArticle {
+  const parsed = splitMarkdown(markdown);
+  const frontmatter = parseFrontmatter(parsed.blocks);
+  return {
+    frontmatter,
+    article: {
+      slug,
+      title: String(frontmatter.title ?? ''),
+      description: String(frontmatter.description ?? ''),
+      category: normalizeCategory(String(frontmatter.category ?? undefined)),
+      tags: tagsValue(frontmatter.tags),
+      body: parsed.body,
+      isDraft: frontmatter.isDraft === true,
+    },
+  };
+}
+
+function replacementLines(article: NormalizedArticle): Record<string, string> {
+  return {
+    title: `title: ${JSON.stringify(article.title)}`,
+    description: `description: ${JSON.stringify(article.description)}`,
+    category: `category: "${article.category}"`,
+    tags: `tags: ${JSON.stringify(article.tags)}`,
+    isDraft: `isDraft: ${article.isDraft === true}`,
+  };
+}
+
+export function rebuildBlogMarkdown(originalMarkdown: string, article: NormalizedArticle): string {
+  const parsed = splitMarkdown(originalMarkdown);
+  const replacements = replacementLines(article);
+  const emitted = new Set<string>();
+  const lines: string[] = [];
+
+  for (const block of parsed.blocks) {
+    const replacement = replacements[block.key];
+    if (replacement) {
+      lines.push(replacement);
+      emitted.add(block.key);
+    } else {
+      lines.push(...block.lines);
+    }
+  }
+
+  const requiredOrder = ['title', 'description', 'category', 'tags', 'isDraft'];
+  for (const key of requiredOrder) {
+    if (!emitted.has(key)) {
+      lines.push(replacements[key]);
+    }
+  }
+
+  const body = article.body.replace(/^(?:\s*\n)*-{3,}[ \t]*(?:\n|$)/, '');
+  return ['---', ...lines, '---', '', body, ''].join('\n');
+}

--- a/workers/yomimono/src/github.ts
+++ b/workers/yomimono/src/github.ts
@@ -2,6 +2,23 @@ import { Octokit } from '@octokit/core';
 import { createAppAuth } from '@octokit/auth-app';
 import { assertSlug, safeImageName } from './validate';
 import type { Collection, Env } from './types';
+import { parseBlogMarkdown } from './article-markdown';
+
+export interface BlogArticleSummary {
+  slug: string;
+  title: string;
+  description: string;
+  category: string;
+  isDraft: boolean;
+  pubDate: string;
+}
+
+export interface BlogArticleFile extends BlogArticleSummary {
+  article: ReturnType<typeof parseBlogMarkdown>['article'];
+  markdown: string;
+  sha: string;
+  path: string;
+}
 
 export function makeOctokit(env: Env): Octokit {
   return new Octokit({
@@ -70,6 +87,101 @@ export async function listArticleSlugs(
       : [];
   } catch {
     return []; // 一覧取得失敗は致命的でない（重複回避が弱まるだけ）
+  }
+}
+
+function blogArticlePath(env: Env, slug: string): string {
+  assertSlug(slug);
+  return `${contentDir(env, 'blog')}/${slug}.md`;
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+export async function readBlogArticle(
+  env: Env,
+  octokit: Octokit,
+  slug: string,
+): Promise<BlogArticleFile> {
+  const path = blogArticlePath(env, slug);
+  const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+    owner: env.GH_OWNER,
+    repo: env.GH_REPO,
+    path,
+    ref: env.PUBLISH_BRANCH,
+  });
+  const data = res.data as { content?: string; sha?: string };
+  if (!data.content || !data.sha) throw new Error(`記事を取得できません: ${path}`);
+  const markdown = base64ToUtf8(data.content);
+  const parsed = parseBlogMarkdown(slug, markdown);
+  return {
+    slug,
+    title: asString(parsed.frontmatter.title),
+    description: asString(parsed.frontmatter.description),
+    category: asString(parsed.frontmatter.category),
+    isDraft: parsed.frontmatter.isDraft === true,
+    pubDate: asString(parsed.frontmatter.pubDate),
+    article: parsed.article,
+    markdown,
+    sha: data.sha,
+    path,
+  };
+}
+
+export async function listBlogArticles(
+  env: Env,
+  octokit: Octokit,
+): Promise<BlogArticleSummary[]> {
+  const slugs = await listArticleSlugs(env, octokit, 'blog');
+  const articles: BlogArticleSummary[] = [];
+  for (const slug of slugs) {
+    try {
+      const article = await readBlogArticle(env, octokit, slug);
+      articles.push({
+        slug: article.slug,
+        title: article.title || slug,
+        description: article.description,
+        category: article.category,
+        isDraft: article.isDraft,
+        pubDate: article.pubDate,
+      });
+    } catch {
+      // 一覧では壊れた単一記事で画面全体を落とさない。
+    }
+  }
+  return articles.sort((a, b) => b.pubDate.localeCompare(a.pubDate) || a.slug.localeCompare(b.slug));
+}
+
+export async function updateBlogArticle(
+  env: Env,
+  octokit: Octokit,
+  slug: string,
+  markdown: string,
+  sha: string,
+  authorEmail: string,
+): Promise<{ updated: true; path: string; commitUrl: string }> {
+  const path = blogArticlePath(env, slug);
+  if (!sha) throw new Error('更新元の記事情報が不足しています。記事を開き直してください');
+
+  const author = authorEmail.split('@')[0];
+  try {
+    const res = await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+      owner: env.GH_OWNER,
+      repo: env.GH_REPO,
+      path,
+      branch: env.PUBLISH_BRANCH,
+      message: `post(yomimono): ${slug}（更新: ${author}）`,
+      content: utf8ToBase64(markdown),
+      sha,
+    });
+    const data = res.data as { commit?: { html_url?: string } };
+    return { updated: true, path, commitUrl: data.commit?.html_url ?? '' };
+  } catch (e: unknown) {
+    if ((e as { status?: number }).status === 409) {
+      throw new Error('記事が別の編集で更新されています。開き直してから保存してください');
+    }
+    throw e;
   }
 }
 

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -9,12 +9,23 @@ import { collectTopics } from './collect';
 // buildNewsMarkdown は M3 で news を有効化する際に再import（基盤関数は generate.ts に維持）
 import { generateArticle, buildMarkdown, buildCasesMarkdown } from './generate';
 import { scanForViolations } from './guardrails';
-import { makeOctokit, getFileContent, commitArticle, commitImage, listArticleSlugs } from './github';
-import { sanitizeText, normalizeArticle, normalizeCollection, type ArticleInput } from './validate';
+import {
+  makeOctokit,
+  getFileContent,
+  commitArticle,
+  commitImage,
+  listArticleSlugs,
+  listBlogArticles,
+  readBlogArticle,
+  updateBlogArticle,
+} from './github';
+import { rebuildBlogMarkdown } from './article-markdown';
+import { assertSlug, sanitizeText, normalizeArticle, normalizeCollection, type ArticleInput } from './validate';
 import { HUB_HTML } from './ui-hub';
 import { AI_HTML } from './ui-ai';
 import { MANUAL_HTML } from './ui-manual';
 import { MANUAL_CASES_HTML } from './ui-manual-cases';
+import { EDIT_HTML } from './ui-edit';
 import { LOGIN_HTML } from './ui-login';
 import { STYLE_GUIDE_FALLBACK } from './style-guide';
 
@@ -221,6 +232,9 @@ export default {
       if (req.method === 'GET' && path === '/manual/cases') {
         return html(MANUAL_CASES_HTML, env);
       }
+      if (req.method === 'GET' && path === '/edit') {
+        return html(EDIT_HTML, env);
+      }
 
       // 既存記事スラッグ一覧（重複テーマ回避用）
       if (req.method === 'GET' && path === '/api/recent') {
@@ -232,6 +246,35 @@ export default {
         const octokit = makeOctokit(env);
         const slugs = await listArticleSlugs(env, octokit, collection);
         return json({ slugs });
+      }
+
+      // 既存ブログ記事の一覧・読み込み・更新（M1-I3）。
+      // M2/M3 の cases/news CMS とは分け、ここでは blog のみ編集対象にする。
+      if (req.method === 'GET' && path === '/api/articles') {
+        const collection = normalizeCollection(url.searchParams.get('collection'));
+        if (collection !== 'blog') {
+          return json({ error: '既存記事編集は現在 blog のみ対応しています' }, 400);
+        }
+        const octokit = makeOctokit(env);
+        const articles = await listBlogArticles(env, octokit);
+        return json({ articles });
+      }
+
+      if (req.method === 'GET' && path === '/api/article') {
+        const collection = normalizeCollection(url.searchParams.get('collection'));
+        if (collection !== 'blog') {
+          return json({ error: '既存記事編集は現在 blog のみ対応しています' }, 400);
+        }
+        const slug = url.searchParams.get('slug') || '';
+        if (!slug) return json({ error: 'slug は必須です' }, 400);
+        try {
+          assertSlug(slug);
+        } catch (e) {
+          return json({ error: e instanceof Error ? e.message : 'slug が不正です' }, 400);
+        }
+        const octokit = makeOctokit(env);
+        const file = await readBlogArticle(env, octokit, slug);
+        return json({ article: file.article, sha: file.sha, path: file.path });
       }
 
       // 画像アップロード（手動エディタ用）。public/images/blog/uploads/ にコミットしURLを返す。
@@ -352,6 +395,37 @@ export default {
         const octokit = makeOctokit(env);
         const result = await commitArticle(env, octokit, normalized.slug, markdown, EDITOR, collection);
         return json(result);
+      }
+
+      // 既存ブログ記事の更新。同じ slug/path を sha 付きで上書きし、同時編集を検出する。
+      if (req.method === 'POST' && path === '/api/update') {
+        const body = await readJsonBody(req);
+        if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
+        const collection = normalizeCollection(body.collection);
+        if (collection !== 'blog') {
+          return json({ error: '既存記事編集は現在 blog のみ対応しています' }, 400);
+        }
+        const sha = typeof body.sha === 'string' ? body.sha : '';
+        if (!sha) return json({ error: '更新元の記事情報がありません。記事を開き直してください' }, 400);
+        const norm = normalizeArticle(body.article as ArticleInput | undefined, 'blog');
+        if (!norm.ok) return json({ error: norm.error }, norm.status);
+        const normalized = norm.article;
+        const octokit = makeOctokit(env);
+        const existing = await readBlogArticle(env, octokit, normalized.slug);
+        const markdown = rebuildBlogMarkdown(existing.markdown, normalized);
+        const violations = scanForViolations(markdown);
+        if (violations.length > 0) {
+          return json({ error: 'ガードレール違反のため更新を中止しました', violations }, 422);
+        }
+        try {
+          const result = await updateBlogArticle(env, octokit, normalized.slug, markdown, sha, EDITOR);
+          return json(result);
+        } catch (e: unknown) {
+          if (e instanceof Error && /^記事が|^更新元/.test(e.message)) {
+            return json({ error: e.message }, 409);
+          }
+          throw e;
+        }
       }
 
       return json({ error: 'Not Found' }, 404);

--- a/workers/yomimono/src/ui-edit.ts
+++ b/workers/yomimono/src/ui-edit.ts
@@ -1,0 +1,136 @@
+import { head, header, tail } from './ui-shared';
+
+const BODY = `<main class="wide">
+  <p class="lead">公開済みの記事を選んで、タイトル・説明・カテゴリ・タグ・本文を修正できます。URL（slug）は事故防止のため変更しません。</p>
+
+  <div class="split">
+    <section class="step">
+      <h2>記事を選ぶ</h2>
+      <p class="hint">最近の記事から順に表示します。修正したい記事の「編集」を押してください。</p>
+      <div class="row" style="margin-bottom:10px">
+        <button class="ghost" id="e_reload" type="button">一覧を更新</button>
+        <span class="meta" id="e_list_status"></span>
+      </div>
+      <div class="article-list" id="e_list"></div>
+    </section>
+
+    <section class="step" id="e_form_box" hidden>
+      <h2>記事を修正する</h2>
+      <p class="hint">保存前に公開前チェックを実行します。問題がなければ同じURLの記事を更新します。</p>
+      <input id="e_sha" type="hidden">
+      <div class="field"><label>URL（変更不可）</label><input id="e_slug" readonly></div>
+      <div class="field"><label>タイトル</label><input id="e_title"></div>
+      <div class="field"><label>記事のまとめ</label><input id="e_desc"></div>
+      <div class="row" style="gap:14px">
+        <div class="field" style="flex:1;min-width:190px;margin:0"><label>カテゴリ</label>
+          <select id="e_cat"><option value="ai">AI</option><option value="engineering">エンジニアリング</option><option value="founder">創業</option><option value="lab">ラボ</option></select>
+        </div>
+        <div class="field" style="flex:2;min-width:220px;margin:0"><label>タグ（カンマ区切り）</label><input id="e_tags"></div>
+      </div>
+      <div class="field"><label>本文</label><textarea id="e_body" maxlength="100000"></textarea></div>
+      <label class="checkline"><input id="e_draft" type="checkbox"> 下書きとして保存する（公開一覧には出しません）</label>
+      <div class="row" style="margin-top:14px">
+        <button class="pub" id="e_save" type="button">更新する</button>
+        <span class="meta" id="e_msg"></span>
+      </div>
+      <div id="e_result"></div>
+    </section>
+  </div>
+</main>`;
+
+const JS = `
+  function getJson(p){
+    return fetch(BASE+p,{method:'GET'}).then(function(r){return r.json().then(function(j){if(!r.ok){throw new Error(j&&j.error?j.error:('HTTP '+r.status));}return j;});});
+  }
+  function postJson(p,b){
+    return fetch(BASE+p,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(b||{})}).then(function(r){return r.json().then(function(j){if(!r.ok){throw new Error(j&&j.error?j.error:('HTTP '+r.status));}return j;});});
+  }
+  function setBusy(btn,busy,label){
+    btn.disabled=busy;
+    btn.innerHTML=busy?'<span class="spin"></span>'+label:btn.getAttribute('data-label');
+  }
+  function renderList(items){
+    var box=$('e_list');
+    if(!items.length){ box.innerHTML='<div class="empty">編集できる記事が見つかりません。</div>'; return; }
+    box.innerHTML=items.map(function(a){
+      var state=a.isDraft?'<span class="badge">下書き</span>':'';
+      return '<article class="article-item"><div><b>'+esc(a.title||a.slug)+'</b>'+state+
+        '<p>'+esc(a.description||'説明なし')+'</p><small>'+esc(a.pubDate||'日付なし')+' / '+esc(a.category||'未分類')+' / '+esc(a.slug)+'</small></div>'+
+        '<button class="ghost" type="button" data-slug="'+esc(a.slug)+'">編集</button></article>';
+    }).join('');
+    var buttons=box.querySelectorAll('button[data-slug]');
+    for(var i=0;i<buttons.length;i++){
+      buttons[i].addEventListener('click',function(){ loadArticle(this.getAttribute('data-slug')); });
+    }
+  }
+  function loadList(){
+    $('e_list_status').textContent='読み込み中…';
+    getJson('/api/articles').then(function(j){
+      renderList(j.articles||[]);
+      $('e_list_status').textContent=(j.articles||[]).length+'件';
+    }).catch(function(e){
+      $('e_list').innerHTML='<div class="err">'+esc(e.message)+'</div>';
+      $('e_list_status').textContent='';
+    });
+  }
+  function loadArticle(slug){
+    $('e_msg').textContent='';
+    $('e_result').innerHTML='';
+    getJson('/api/article?slug='+encodeURIComponent(slug)).then(function(j){
+      var a=j.article||{};
+      $('e_sha').value=j.sha||'';
+      $('e_slug').value=a.slug||slug;
+      $('e_title').value=a.title||'';
+      $('e_desc').value=a.description||'';
+      $('e_cat').value=a.category||'ai';
+      $('e_tags').value=(a.tags||[]).join(', ');
+      $('e_body').value=a.body||'';
+      $('e_draft').checked=a.isDraft===true;
+      $('e_form_box').hidden=false;
+      $('e_msg').textContent='記事を読み込みました';
+    }).catch(function(e){
+      $('e_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>';
+    });
+  }
+  function gather(){
+    return {
+      slug:$('e_slug').value.trim(),
+      title:$('e_title').value.trim(),
+      description:$('e_desc').value.trim(),
+      category:$('e_cat').value,
+      tags:$('e_tags').value.split(',').map(function(s){return s.trim();}).filter(Boolean),
+      body:$('e_body').value,
+      isDraft:$('e_draft').checked
+    };
+  }
+  function validateLocal(a){
+    if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'URL が不正です。記事を開き直してください';
+    if(!a.title) return 'タイトルを入力してください';
+    if(!a.description) return '記事のまとめを入力してください';
+    if(!a.body.trim()) return '本文を入力してください';
+    if(!$('e_sha').value) return '更新元の記事情報がありません。記事を開き直してください';
+    return '';
+  }
+  $('e_reload').addEventListener('click',loadList);
+  $('e_save').setAttribute('data-label','更新する');
+  $('e_save').addEventListener('click',function(){
+    var article=gather();
+    var err=validateLocal(article);
+    if(err){ $('e_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
+    if(!confirm('この記事を同じURLで更新します。よろしいですか？')) return;
+    var btn=this; setBusy(btn,true,'更新中…'); $('e_msg').textContent='公開前チェック中…'; $('e_result').innerHTML='';
+    postJson('/api/update',{article:article,sha:$('e_sha').value}).then(function(j){
+      var link=j&&j.commitUrl?'<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>':'';
+      $('e_result').innerHTML='<div class="done">更新しました。数分でサイトに反映されます。 '+link+'</div>';
+      $('e_msg').textContent='';
+      setBusy(btn,false,'');
+      loadList();
+    }).catch(function(e){
+      $('e_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>';
+      setBusy(btn,false,'');
+    });
+  });
+  loadList();
+`;
+
+export const EDIT_HTML = head('既存記事を編集 — 読みもの 作成スタジオ') + header('edit') + BODY + tail(JS);

--- a/workers/yomimono/src/ui-hub.ts
+++ b/workers/yomimono/src/ui-hub.ts
@@ -1,6 +1,6 @@
 import { head, header, tail } from './ui-shared';
 
-// ログイン後の入口。AI生成 / ブログ手動作成 / 実績作成 の入口。
+// ログイン後の入口。AI生成 / ブログ作成 / 実績作成 / 既存記事編集 の入口。
 export const HUB_HTML =
   head('ハブ — 読みもの 作成スタジオ') +
   header('hub') +
@@ -13,5 +13,7 @@ export const HUB_HTML =
   '<p>テキストと画像を自分で貼ってブログ記事を作成。ライブプレビューで確認して公開します。</p></a>' +
   '<a href="__BASE__/manual/cases"><div class="ic">📁</div><h3>実績作成</h3>' +
   '<p>実績記事を作成し、works 詳細ページへ追加します。カテゴリ・リード文・公開日を入力して公開します。</p></a>' +
+  '<a href="__BASE__/edit"><div class="ic">✎</div><h3>既存記事を編集</h3>' +
+  '<p>公開済みの記事を選んで、誤字修正や追記を同じURLのまま保存します。</p></a>' +
   '</div></main>' +
   tail('');

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -33,6 +33,13 @@ export const CSS = `
   .card .t { font-weight:700; font-size:14px; }
   .card .s { font-size:13px; color:#374151; margin:4px 0; }
   .card .src a { font-size:11px; color:var(--accent); margin-right:10px; word-break:break-all; }
+  .article-list { display:grid; gap:10px; }
+  .article-item { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; border:1px solid var(--line); border-radius:10px; padding:12px; background:#fff; }
+  .article-item b { color:var(--navy); font-size:13px; }
+  .article-item p { margin:4px 0; color:#374151; font-size:12px; }
+  .article-item small { color:var(--muted); font-size:11px; word-break:break-all; }
+  .article-item button { flex:0 0 auto; padding:8px 12px; border-radius:8px; }
+  .empty { border:1px dashed var(--line); border-radius:10px; padding:16px; color:var(--muted); font-size:13px; background:#fff; }
   .badge { display:inline-block; font-size:11px; background:#eef2f7; color:var(--muted); border-radius:20px; padding:2px 9px; margin-left:6px; }
   .field { margin:10px 0; }
   .field label { display:block; font-size:12px; color:var(--muted); margin-bottom:4px; }
@@ -92,13 +99,6 @@ export const CSS = `
   /* .draft-bar の display:flex は [hidden]{display:none} より後に定義されるため
      specificity で hidden が負ける。属性セレクタを併用して hidden を優先する。 */
   .draft-bar[hidden] { display:none; }
-  .article-list { display:grid; gap:10px; }
-  .article-item { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; border:1px solid var(--line); border-radius:10px; padding:12px; background:#fff; }
-  .article-item b { color:var(--navy); font-size:13px; }
-  .article-item p { margin:4px 0; color:#374151; font-size:12px; }
-  .article-item small { color:var(--muted); font-size:11px; word-break:break-all; }
-  .article-item button { flex:0 0 auto; padding:8px 12px; border-radius:8px; }
-  .empty { border:1px dashed var(--line); border-radius:10px; padding:16px; color:var(--muted); font-size:13px; background:#fff; }
   .checkline { display:flex; gap:8px; align-items:center; color:var(--ink); font-size:13px; margin-top:10px; }
 `;
 

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -92,6 +92,14 @@ export const CSS = `
   /* .draft-bar の display:flex は [hidden]{display:none} より後に定義されるため
      specificity で hidden が負ける。属性セレクタを併用して hidden を優先する。 */
   .draft-bar[hidden] { display:none; }
+  .article-list { display:grid; gap:10px; }
+  .article-item { display:flex; justify-content:space-between; gap:12px; align-items:flex-start; border:1px solid var(--line); border-radius:10px; padding:12px; background:#fff; }
+  .article-item b { color:var(--navy); font-size:13px; }
+  .article-item p { margin:4px 0; color:#374151; font-size:12px; }
+  .article-item small { color:var(--muted); font-size:11px; word-break:break-all; }
+  .article-item button { flex:0 0 auto; padding:8px 12px; border-radius:8px; }
+  .empty { border:1px dashed var(--line); border-radius:10px; padding:16px; color:var(--muted); font-size:13px; background:#fff; }
+  .checkline { display:flex; gap:8px; align-items:center; color:var(--ink); font-size:13px; margin-top:10px; }
 `;
 
 // 共通JS（各ページIIFEの先頭で展開）。BASE はサーバが __BASE__ を注入。
@@ -138,7 +146,7 @@ export function head(title: string): string {
   );
 }
 
-export function header(active: 'hub' | 'ai' | 'manual' | 'manual-news' | 'manual-cases'): string {
+export function header(active: 'hub' | 'ai' | 'manual' | 'edit' | 'manual-news' | 'manual-cases'): string {
   const link = (href: string, label: string, key: string) =>
     '<a href="__BASE__' + href + '"' + (active === key ? ' class="on"' : '') + '>' + label + '</a>';
   return (
@@ -148,6 +156,7 @@ export function header(active: 'hub' | 'ai' | 'manual' | 'manual-news' | 'manual
     link('/ai', 'AI生成', 'ai') +
     link('/manual', 'ブログ作成', 'manual') +
     link('/manual/cases', '実績作成', 'manual-cases') +
+    link('/edit', '既存記事を編集', 'edit') +
     '</nav></div></header>'
   );
 }


### PR DESCRIPTION
## ① なぜ（解決したい課題）

#220 では新規投稿だけでなく、既存記事をCMSから安全に編集できることが Close Gate に含まれています。非エンジニアが既存Markdownを探し、内容を確認して編集PRを作れる導線が必要です。

Refs #220

## ② どう実装したか

- 既存記事編集用のUIを `/blog-admin/edit` として追加しました。
- GitHub上の記事取得・更新PR作成に必要な helper を追加しました。
- Markdown frontmatter / body の分解・復元処理を `article-markdown.ts` に分離しました。
- 既存編集向け validate と unit tests を追加しました。
- hub に既存記事編集導線を追加しました。

## ③ 特にレビューしてほしい点

- 既存記事のMarkdown復元でfrontmatterや本文を壊さないか。
- GitHub API helper の責務が既存投稿フローと過剰に結合していないか。
- 認証済み管理画面での導線が cases / manual と衝突しないか。

## ④ テスト内容・確認方法

- `npm --prefix workers/yomimono run typecheck`
- `npm --prefix workers/yomimono test -- --run`（8 files / 199 tests passed）
- `git diff --check`

## browser/live evidence

- 未検証: develop merge 後の Worker deploy は未実施です。
- 未検証: Worker live route の認証付き `/blog-admin/edit` 実ブラウザ証跡は未取得です。
- このPRは draft であり、merge/完了/Issue close の根拠にはまだしません。
