### PR TITLE
fix(blog): 一覧件数の表示範囲を修正

### DIFF
--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -30,7 +30,7 @@ const { page } = Astro.props;
 const pageTitle = 'ブログ | Cor.inc';
 const pageDescription = 'AI活用、開発、経営の現場で得た知見を、専門外の方にも読みやすい形でまとめています。';
 const countLabel = page.total > page.size
-  ? `${page.total}記事中 ${page.start + 1}-${page.end}記事を表示`
+  ? `${page.total}記事中 ${page.start + 1}-${page.end + 1}記事を表示`
   : `${page.total}記事`;
 ---
 

--- a/src/pages/blog/category/[id]/[...page].astro
+++ b/src/pages/blog/category/[id]/[...page].astro
@@ -52,7 +52,7 @@ const categoryDesc = getCategoryDescription(id, currentLocale === 'ja' ? 'ja' : 
 const pageDescription = categoryDesc || (currentLocale === 'ja'
   ? `${categoryLabel} に属するブログ記事一覧` : `Blog posts in ${categoryLabel}`);
 const countLabel = page.total > page.size
-  ? `${page.total}記事中 ${page.start + 1}-${page.end}記事を表示`
+  ? `${page.total}記事中 ${page.start + 1}-${page.end + 1}記事を表示`
   : `${page.total}記事`;
 ---
 

--- a/src/pages/en/blog/[...page].astro
+++ b/src/pages/en/blog/[...page].astro
@@ -30,7 +30,7 @@ const { page } = Astro.props;
 const pageTitle = 'Blog | Cor.inc';
 const pageDescription = 'Clear notes from AI, product, and engineering work, written for readers who need the practical decision points first.';
 const countLabel = page.total > page.size
-  ? `Showing ${page.start + 1}-${page.end} of ${page.total} articles`
+  ? `Showing ${page.start + 1}-${page.end + 1} of ${page.total} articles`
   : `${page.total} articles`;
 ---
 

--- a/src/pages/es/blog/[...page].astro
+++ b/src/pages/es/blog/[...page].astro
@@ -30,7 +30,7 @@ const { page } = Astro.props;
 const pageTitle = 'Blog | Cor.inc';
 const pageDescription = 'Notas claras sobre IA, producto e ingeniería, escritas para leer primero los puntos de decisión prácticos.';
 const countLabel = page.total > page.size
-  ? `Mostrando ${page.start + 1}-${page.end} de ${page.total} artículos`
+  ? `Mostrando ${page.start + 1}-${page.end + 1} de ${page.total} artículos`
   : `${page.total} artículos`;
 ---
 

--- a/src/pages/ko/blog/[...page].astro
+++ b/src/pages/ko/blog/[...page].astro
@@ -30,7 +30,7 @@ const { page } = Astro.props;
 const pageTitle = '블로그 | Cor.inc';
 const pageDescription = 'AI, 제품, 엔지니어링 현장에서 얻은 배움을 의사결정에 필요한 내용부터 읽기 쉽게 정리합니다.';
 const countLabel = page.total > page.size
-  ? `총 ${page.total}개 중 ${page.start + 1}-${page.end}개 글 표시`
+  ? `총 ${page.total}개 중 ${page.start + 1}-${page.end + 1}개 글 표시`
   : `총 ${page.total}개 글`;
 ---
 

--- a/src/pages/zh/blog/[...page].astro
+++ b/src/pages/zh/blog/[...page].astro
@@ -30,7 +30,7 @@ const { page } = Astro.props;
 const pageTitle = '博客 | Cor.inc';
 const pageDescription = '整理 AI、产品和工程现场的经验，优先说明实际判断点，让非专业读者也容易阅读。';
 const countLabel = page.total > page.size
-  ? `显示 ${page.start + 1}-${page.end} / 共 ${page.total} 篇文章`
+  ? `显示 ${page.start + 1}-${page.end + 1} / 共 ${page.total} 篇文章`
   : `共 ${page.total} 篇文章`;
 ---
 


### PR DESCRIPTION
## ① なぜ（解決したい課題）

#226 のレビューで、Astro pagination の `page.end` をそのまま表示しているため、ブログ一覧・カテゴリ一覧の件数レンジが1件少なく見える既存バグが指摘されました。タグ一覧はすでに `page.end + 1` の正しい表記だったため、一覧UIの表示を揃えます。

Refs #220

## ② どう実装したか

- 日本語ブログ一覧・カテゴリ一覧の count label を `page.end + 1` に修正しました。
- en/es/ko/zh のブログ一覧も同様に修正しました。
- タグ一覧は既に正しいため変更していません。

## ③ 特にレビューしてほしい点

- Astro paginate の `start/end` index 解釈がタグ一覧と揃っているか。
- 多言語の文言として不自然な変更になっていないか。

## ④ テスト内容・確認方法

- `npm run build`（439 pages built）
- `npx playwright test e2e/blog.spec.ts`（21 passed）
- `git diff --check`

## browser/live evidence

- #226 merge後の develop preview は `/tmp/corsweb-220-evidence/blog-ui` にスクリーンショットとHTML確認を保存済みです。
- このPR自体の develop preview 証跡は merge 後に再取得します。
