### PR TITLE
feat(yomimono): 公開コンテンツCMSを統合

### DIFF
--- a/workers/yomimono/README.md
+++ b/workers/yomimono/README.md
@@ -3,7 +3,7 @@
 凪沙さんが **main マージ権限なしで毎日記事を投稿**できるようにする、サーバーレス・バックエンド＋管理画面。
 記事は DB を使わず **.md として git にコミット**され、既存の静的デプロイでそのまま公開される（A案：記事bot方式）。
 
-> **コレクション拡張（ADR-0009）**: 記事bot は **blog / news / cases の3コレクション配下**に書く（`src/content/{blog/ja,news,cases}/`）。blog と cases は稼働対象・**news は M3 で有効化**。切り替えは `body.collection`（既定 `'blog'`）。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
+> **コレクション拡張（ADR-0009）**: 記事bot は **blog / news / cases の3コレクション配下**に書く（`src/content/{blog/ja,news,cases}/`）。3コレクションとも投稿・一覧・読み込み・更新に対応する。切り替えは `body.collection` / `?collection=`（既定 `'blog'`）。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
 
 管理画面は **HP と同じドメインの隠しページ `https://cor-jp.com/blog-admin`** で開ける（cor-jp.com は Cloudflare の裏にいるため、`/blog-admin*` だけを Cloudflare Worker のルートに流す）。HP本体（静的・Firebase）はそのまま。
 
@@ -19,12 +19,17 @@
 | GET  | `/` | 管理画面HTML（凪沙さん用） → `cor-jp.com/blog-admin` |
 | GET  | `/health` | 死活確認 → `cor-jp.com/blog-admin/health` |
 | GET  | `/api/recent` | 既存記事スラッグ一覧（重複テーマ回避・`?collection=` で切替） |
+| GET  | `/api/articles` | 既存コンテンツ一覧（`?collection=blog/news/cases`） |
+| GET  | `/api/article` | 既存コンテンツ読み込み（`?collection=blog/news/cases&slug=...`、`sha` 付き） |
 | POST | `/api/collect` | 直近約27hのAI/DX/ローカルLLM記事から候補テーマを10〜15件返す |
 | POST | `/api/generate` | 選んだテーマで記事を1本生成（社長の文体）＋ガードレール検査結果を同梱 |
 | POST | `/api/validate` | コミットせずガードレール再チェック（編集後の確認用・`body.collection` 対応） |
 | POST | `/api/publish` | 記事botが `body.collection`（既定 `'blog'`）に応じて `src/content/{blog/ja,news,cases}/<slug>.md` を `main` にコミット |
-| GET  | `/manual/news` | ニュース投稿UI（**M3 で有効化・準備中**） |
+| POST | `/api/update` | 既存コンテンツを同じ slug のまま `sha` 付きで更新（競合検出あり） |
+| GET  | `/manual` | ブログ投稿UI（blog / `src/content/blog/ja/<slug>.md` へ公開） |
+| GET  | `/manual/news` | ニュース投稿UI（news / `src/content/news/<slug>.md` へ公開） |
 | GET  | `/manual/cases` | 実績投稿UI（cases / `src/content/cases/<slug>.md` へ公開） |
+| GET  | `/edit` | 既存コンテンツ編集UI（blog/news/cases 切替） |
 
 Worker は受信パスから `BASE_PATH`(=`/blog-admin`) を剥がして上記の論理パスにルーティングする。`BASE_PATH` 空ならルート直下（`*.workers.dev/` でのテスト）でもそのまま動く。
 

--- a/workers/yomimono/src/__tests__/article-markdown.test.ts
+++ b/workers/yomimono/src/__tests__/article-markdown.test.ts
@@ -124,14 +124,34 @@ featured: true
     expect(rebuilt).toContain('author: "Terisuke"');
   });
 
+  it('cases の単一引用符 tags を編集フォーム用 article に変換する', () => {
+    const originalCase = `---
+title: '旧実績'
+description: '旧説明'
+category: 'grift'
+tags: ['Grift', 'AI', '要件定義']
+publishedAt: 2026-07-01
+summary: '旧リード'
+isDraft: false
+featured: true
+---
+
+本文
+`;
+    const parsed = parseArticleMarkdown('case-slug', originalCase, 'cases');
+    expect(parsed.article.tags).toEqual(['Grift', 'AI', '要件定義']);
+  });
+
   it('cases は summary/publishedAt/featured を差し替え、未知 frontmatter を保持する', () => {
     const originalCase = `---
 title: "旧実績"
 description: "旧説明"
 publishedAt: 2026-07-01
+# updatedAt: 2026-07-15
 category: "grift"
 tags: ["AI"]
 summary: "旧リード"
+# securityNote は必要な場合だけ有効化する
 securityNote: "NDA"
 isDraft: false
 featured: false
@@ -155,6 +175,8 @@ featured: false
     const rebuilt = rebuildArticleMarkdown(originalCase, updated);
     expect(rebuilt).toContain('summary: "新リード"');
     expect(rebuilt).toContain('publishedAt: 2026-07-09');
+    expect(rebuilt).toContain('# updatedAt: 2026-07-15');
+    expect(rebuilt).toContain('# securityNote は必要な場合だけ有効化する');
     expect(rebuilt).toContain('featured: true');
     expect(rebuilt).toContain('securityNote: "NDA"');
     expect(rebuilt).toContain('## 成果\n\n更新本文\n');

--- a/workers/yomimono/src/__tests__/article-markdown.test.ts
+++ b/workers/yomimono/src/__tests__/article-markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseBlogMarkdown, rebuildBlogMarkdown } from '../article-markdown';
+import { parseBlogMarkdown, parseArticleMarkdown, rebuildBlogMarkdown, rebuildArticleMarkdown } from '../article-markdown';
 import type { NormalizedArticle } from '../validate';
 
 const original = `---
@@ -66,5 +66,97 @@ describe('rebuildBlogMarkdown', () => {
     const rebuilt = rebuildBlogMarkdown(original, { ...updated, body: '---\n本文' });
     expect(rebuilt).toContain('\n---\n\n本文\n');
     expect(rebuilt).not.toContain('\n---\n\n---\n本文');
+  });
+});
+
+describe('parseArticleMarkdown / rebuildArticleMarkdown — collection 別編集', () => {
+  const news = `---
+title: "旧ニュース"
+description: "旧説明"
+publishedAt: 2026-07-08
+author: "Terisuke"
+category: "media"
+tags: ["掲載"]
+lang: "ja"
+externalUrl: "https://example.com/old"
+source: "Example"
+isDraft: false
+featured: true
+---
+
+`;
+
+  it('news frontmatter を externalUrl/source/featured 付きで編集フォーム用 article に変換する', () => {
+    const parsed = parseArticleMarkdown('old-news', news, 'news');
+    expect(parsed.article).toMatchObject({
+      slug: 'old-news',
+      title: '旧ニュース',
+      category: 'media',
+      publishedAt: '2026-07-08',
+      externalUrl: 'https://example.com/old',
+      source: 'Example',
+      featured: true,
+      body: '',
+    });
+  });
+
+  it('news の optional externalUrl/source は空にしたら frontmatter から削除し、sha 更新用 markdown を再構築する', () => {
+    const updated: NormalizedArticle = {
+      slug: 'old-news',
+      title: '更新ニュース',
+      description: '更新説明',
+      category: 'info',
+      tags: ['更新'],
+      body: '## 本文\n\n内部ニュースです。',
+      collection: 'news',
+      publishedAt: '2026-07-09',
+      isDraft: true,
+      featured: false,
+    };
+    const rebuilt = rebuildArticleMarkdown(news, updated);
+    expect(rebuilt).toContain('title: "更新ニュース"');
+    expect(rebuilt).toContain('publishedAt: 2026-07-09');
+    expect(rebuilt).toContain('category: "info"');
+    expect(rebuilt).toContain('isDraft: true');
+    expect(rebuilt).toContain('featured: false');
+    expect(rebuilt).not.toContain('externalUrl:');
+    expect(rebuilt).not.toContain('source:');
+    expect(rebuilt).toContain('author: "Terisuke"');
+  });
+
+  it('cases は summary/publishedAt/featured を差し替え、未知 frontmatter を保持する', () => {
+    const originalCase = `---
+title: "旧実績"
+description: "旧説明"
+publishedAt: 2026-07-01
+category: "grift"
+tags: ["AI"]
+summary: "旧リード"
+securityNote: "NDA"
+isDraft: false
+featured: false
+---
+
+旧本文
+`;
+    const updated: NormalizedArticle = {
+      slug: 'case-slug',
+      title: '新実績',
+      description: '新説明',
+      category: 'local-llm',
+      tags: ['LLM'],
+      body: '## 成果\n\n更新本文',
+      collection: 'cases',
+      publishedAt: '2026-07-09',
+      summary: '新リード',
+      featured: true,
+      isDraft: false,
+    };
+    const rebuilt = rebuildArticleMarkdown(originalCase, updated);
+    expect(rebuilt).toContain('summary: "新リード"');
+    expect(rebuilt).toContain('publishedAt: 2026-07-09');
+    expect(rebuilt).toContain('featured: true');
+    expect(rebuilt).toContain('securityNote: "NDA"');
+    expect(rebuilt).toContain('## 成果\n\n更新本文\n');
   });
 });

--- a/workers/yomimono/src/__tests__/article-markdown.test.ts
+++ b/workers/yomimono/src/__tests__/article-markdown.test.ts
@@ -142,6 +142,55 @@ featured: true
     expect(parsed.article.tags).toEqual(['Grift', 'AI', '要件定義']);
   });
 
+  it('単一引用符 tags の値内カンマを分割せずに保持する', () => {
+    const markdown = `---
+title: '旧実績'
+description: '旧説明'
+category: 'grift'
+tags: ['A, B', 'C']
+publishedAt: 2026-07-01
+summary: '旧リード'
+---
+
+本文
+`;
+    const parsed = parseArticleMarkdown('case-slug', markdown, 'cases');
+    expect(parsed.article.tags).toEqual(['A, B', 'C']);
+  });
+
+  it('news は後から externalUrl/source を追加しても frontmatter に反映する', () => {
+    const originalNews = `---
+title: "旧ニュース"
+description: "旧説明"
+publishedAt: 2026-07-08
+category: "info"
+tags: ["更新"]
+isDraft: false
+featured: false
+---
+
+## 本文
+`;
+    const updated: NormalizedArticle = {
+      slug: 'old-news',
+      title: '外部掲載ニュース',
+      description: '外部掲載説明',
+      category: 'media',
+      tags: ['掲載'],
+      body: '',
+      collection: 'news',
+      publishedAt: '2026-07-09',
+      externalUrl: 'https://example.com/news',
+      source: 'Example',
+      featured: true,
+      isDraft: false,
+    };
+    const rebuilt = rebuildArticleMarkdown(originalNews, updated);
+    expect(rebuilt).toContain('externalUrl: "https://example.com/news"');
+    expect(rebuilt).toContain('source: "Example"');
+    expect(rebuilt).toContain('featured: true');
+  });
+
   it('cases は summary/publishedAt/featured を差し替え、未知 frontmatter を保持する', () => {
     const originalCase = `---
 title: "旧実績"

--- a/workers/yomimono/src/__tests__/generate.test.ts
+++ b/workers/yomimono/src/__tests__/generate.test.ts
@@ -13,12 +13,16 @@ describe('buildNewsMarkdown — news frontmatter 形式検証', () => {
     collection: 'news',
     publishedAt: '2026-07-08',
     externalUrl: 'https://example.com/article',
+    source: 'Example Media',
+    featured: true,
     isDraft: false,
   };
 
   it('news: externalUrl あり→frontmatter に externalUrl を含む', () => {
     const markdown = buildNewsMarkdown(newsArticle, false);
     expect(markdown).toContain('externalUrl: "https://example.com/article"');
+    expect(markdown).toContain('source: "Example Media"');
+    expect(markdown).toContain('featured: true');
     expect(markdown).toContain('title: "テストニュース"');
     expect(markdown).toContain('description: "テストニュース説明"');
     expect(markdown).toContain('category: "info"');
@@ -155,6 +159,7 @@ describe('buildMarkdown — blog との整合性検証', () => {
     tags: ['tag1', 'tag2'],
     body: '## テスト本文\n\n内容',
     collection: 'blog',
+    pubDate: '2026-07-08',
     isDraft: false,
   };
 
@@ -168,7 +173,7 @@ describe('buildMarkdown — blog との整合性検証', () => {
 
   it('blog: pubDate を使用（publishedAt ではなく）', () => {
     const markdown = buildMarkdown(blogArticle, false);
-    expect(markdown).toContain('pubDate:');
+    expect(markdown).toContain('pubDate: 2026-07-08');
     expect(markdown).not.toContain('publishedAt:');
   });
 });

--- a/workers/yomimono/src/__tests__/index-cases.test.ts
+++ b/workers/yomimono/src/__tests__/index-cases.test.ts
@@ -312,6 +312,30 @@ describe('yomimono Worker — cases CMS posting path', () => {
     expect(collection).toBe('news');
   });
 
+  it('POST /api/update は sha conflict を 409 で返す', async () => {
+    mocks.updateBlogArticle.mockRejectedValueOnce(
+      new Error('記事が別の編集で更新されています。開き直してから保存してください'),
+    );
+    const res = await worker.fetch(
+      req('/blog-admin/api/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'news',
+          originalSlug: 'external-news',
+          sha: 'stale-sha',
+          article: { ...newsArticle, title: '競合ニュース' },
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: '記事が別の編集で更新されています。開き直してから保存してください',
+    });
+  });
+
   it('POST /api/update は originalSlug と article.slug の差異を拒否する', async () => {
     const res = await worker.fetch(
       req('/blog-admin/api/update', {

--- a/workers/yomimono/src/__tests__/index-cases.test.ts
+++ b/workers/yomimono/src/__tests__/index-cases.test.ts
@@ -4,6 +4,9 @@ import type { Env } from '../types';
 const mocks = vi.hoisted(() => ({
   commitArticle: vi.fn(),
   listArticleSlugs: vi.fn(),
+  listBlogArticles: vi.fn(),
+  readBlogArticle: vi.fn(),
+  updateBlogArticle: vi.fn(),
 }));
 
 vi.mock('../session', () => ({
@@ -19,6 +22,9 @@ vi.mock('../github', () => ({
   commitArticle: mocks.commitArticle,
   commitImage: vi.fn(),
   listArticleSlugs: mocks.listArticleSlugs,
+  listBlogArticles: mocks.listBlogArticles,
+  readBlogArticle: mocks.readBlogArticle,
+  updateBlogArticle: mocks.updateBlogArticle,
 }));
 
 const worker = (await import('../index')).default;
@@ -56,6 +62,19 @@ const caseArticle = {
   featured: true,
 };
 
+const newsArticle = {
+  slug: 'external-news',
+  title: '外部掲載ニュース',
+  description: '外部掲載の説明',
+  category: 'media',
+  tags: ['news'],
+  body: '',
+  publishedAt: '2026-07-08',
+  externalUrl: 'https://example.com/article',
+  source: 'Example Media',
+  featured: true,
+};
+
 describe('yomimono Worker — cases CMS posting path', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,6 +84,53 @@ describe('yomimono Worker — cases CMS posting path', () => {
       commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/test',
     });
     mocks.listArticleSlugs.mockResolvedValue(['grift', 'local-llm-poc']);
+    mocks.listBlogArticles.mockResolvedValue([
+      {
+        collection: 'news',
+        slug: 'external-news',
+        title: '外部掲載ニュース',
+        description: '外部掲載の説明',
+        category: 'media',
+        isDraft: false,
+        pubDate: '2026-07-08',
+        publishedAt: '2026-07-08',
+        featured: true,
+      },
+    ]);
+    mocks.readBlogArticle.mockResolvedValue({
+      collection: 'news',
+      slug: 'external-news',
+      title: '外部掲載ニュース',
+      description: '外部掲載の説明',
+      category: 'media',
+      isDraft: false,
+      pubDate: '2026-07-08',
+      publishedAt: '2026-07-08',
+      featured: true,
+      article: newsArticle,
+      sha: 'news-sha',
+      path: 'src/content/news/external-news.md',
+      markdown:
+        '---\n' +
+        'title: "外部掲載ニュース"\n' +
+        'description: "外部掲載の説明"\n' +
+        'publishedAt: 2026-07-08\n' +
+        'author: "Terisuke"\n' +
+        'category: "media"\n' +
+        'tags: ["news"]\n' +
+        'lang: "ja"\n' +
+        'isDraft: false\n' +
+        'externalUrl: "https://example.com/article"\n' +
+        'source: "Example Media"\n' +
+        'featured: true\n' +
+        '---\n' +
+        '\n',
+    });
+    mocks.updateBlogArticle.mockResolvedValue({
+      updated: true,
+      path: 'src/content/news/external-news.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/update-news',
+    });
   });
 
   it('GET /manual/cases は cases 投稿 UI を返し、collection 指定の publish/validate を含む', async () => {
@@ -87,12 +153,64 @@ describe('yomimono Worker — cases CMS posting path', () => {
     expect(html).toContain("api('/api/publish', { collection:'cases', article:a })");
   });
 
+  it('GET /manual/news は news 投稿 UI を返し、本文なし外部URL投稿の説明を含む', async () => {
+    const res = await worker.fetch(req('/blog-admin/manual/news'), env);
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain('ニュースを保存する');
+    expect(html).toContain('value="media"');
+    expect(html).toContain("var DRAFT_KEY = 'draft:news:new'");
+    expect(html).toContain("api('/api/validate', { collection:'news', article:a })");
+    expect(html).toContain("api('/api/publish', { collection:'news', article:a })");
+    expect(html).toContain('外部URLがないニュースは本文を入力してください');
+  });
+
   it('GET /api/recent?collection=cases は cases の slug 一覧を返す', async () => {
     const res = await worker.fetch(req('/blog-admin/api/recent?collection=cases'), env);
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ slugs: ['grift', 'local-llm-poc'] });
     expect(mocks.listArticleSlugs).toHaveBeenCalledWith(env, { mocked: true }, 'cases');
+  });
+
+  it('GET /api/articles?collection=news は news 一覧を返す', async () => {
+    const res = await worker.fetch(req('/blog-admin/api/articles?collection=news'), env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      articles: [
+        {
+          collection: 'news',
+          slug: 'external-news',
+          title: '外部掲載ニュース',
+          description: '外部掲載の説明',
+          category: 'media',
+          isDraft: false,
+          pubDate: '2026-07-08',
+          publishedAt: '2026-07-08',
+          featured: true,
+        },
+      ],
+    });
+    expect(mocks.listBlogArticles).toHaveBeenCalledWith(env, { mocked: true }, 'news');
+  });
+
+  it('GET /api/article?collection=news は sha 付きで news 記事を返す', async () => {
+    const res = await worker.fetch(req('/blog-admin/api/article?collection=news&slug=external-news'), env);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({
+      sha: 'news-sha',
+      path: 'src/content/news/external-news.md',
+      article: {
+        slug: 'external-news',
+        externalUrl: 'https://example.com/article',
+        source: 'Example Media',
+      },
+    });
+    expect(mocks.readBlogArticle).toHaveBeenCalledWith(env, { mocked: true }, 'external-news', 'news');
   });
 
   it('POST /api/validate は cases article を cases markdown として検査する', async () => {
@@ -135,20 +253,82 @@ describe('yomimono Worker — cases CMS posting path', () => {
     expect(collection).toBe('cases');
   });
 
-  it('news collection は M3 まで publish を拒否し続ける', async () => {
+  it('POST /api/publish は news externalUrl ありなら本文なしで commitArticle を呼ぶ', async () => {
+    mocks.commitArticle.mockResolvedValueOnce({
+      committed: true,
+      path: 'src/content/news/external-news.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/news',
+    });
     const res = await worker.fetch(
       req('/blog-admin/api/publish', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ collection: 'news', article: caseArticle }),
+        body: JSON.stringify({ collection: 'news', article: newsArticle }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      committed: true,
+      path: 'src/content/news/external-news.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/news',
+    });
+    const [_env, _octokit, slug, markdown, _editor, collection] = mocks.commitArticle.mock.calls[0];
+    expect(slug).toBe('external-news');
+    expect(markdown).toContain('externalUrl: "https://example.com/article"');
+    expect(markdown).toContain('source: "Example Media"');
+    expect(markdown).toContain('featured: true');
+    expect(collection).toBe('news');
+  });
+
+  it('POST /api/update は news を sha 付きで同じ slug に更新する', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'news',
+          originalSlug: 'external-news',
+          sha: 'news-sha',
+          article: { ...newsArticle, title: '更新ニュース', isDraft: true },
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      updated: true,
+      path: 'src/content/news/external-news.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/update-news',
+    });
+    const [_env, _octokit, slug, markdown, sha, _editor, collection] = mocks.updateBlogArticle.mock.calls[0];
+    expect(slug).toBe('external-news');
+    expect(markdown).toContain('title: "更新ニュース"');
+    expect(markdown).toContain('isDraft: true');
+    expect(markdown).toContain('source: "Example Media"');
+    expect(sha).toBe('news-sha');
+    expect(collection).toBe('news');
+  });
+
+  it('POST /api/update は originalSlug と article.slug の差異を拒否する', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/update', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'news',
+          originalSlug: 'external-news',
+          sha: 'news-sha',
+          article: { ...newsArticle, slug: 'changed-news' },
+        }),
       }),
       env,
     );
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
-      error: 'news collection は現在準備中です（blog/cases のみ利用可能）',
-    });
-    expect(mocks.commitArticle).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual({ error: 'slug は変更できません。記事を開き直してください' });
+    expect(mocks.updateBlogArticle).not.toHaveBeenCalled();
   });
 });

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -264,6 +264,9 @@ describe('isHttpUrl — http(s) URL のみ受理', () => {
     'javascript:alert(1)',
     'data:text/html,<script>',
     'ftp://example.com',
+    'https://',
+    'http://',
+    'https://example.com bad',
     '//example.com',
     'mailto:foo@example.com',
   ])('不正URL(%s)は false', (u) => {
@@ -281,7 +284,7 @@ describe('normalizeArticle — news externalUrl 検証（P2・反証可能）', 
     body: '## 本文',
   };
 
-  it.each(['', '   ', 'not-a-url', 'javascript:alert(1)', 'ftp://example.com'])(
+  it.each(['', '   ', 'not-a-url', 'javascript:alert(1)', 'ftp://example.com', 'https://'])(
     '不正URL(%s)は externalUrl 無し扱い → body 必須（反証可能: 検証未導入なら body 無しで受理してしまう）',
     (badUrl) => {
       const r = normalizeArticle(

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -374,6 +374,15 @@ describe('normalizeArticle — cases collection', () => {
     }
   });
 
+  it('cases: summary が空白だけなら 400', () => {
+    const r = normalizeArticle({ ...casesBase, summary: '   ' }, 'cases');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(400);
+      expect(r.error).toContain('summary');
+    }
+  });
+
   it('cases: カテゴリ grift/confidential-ai/local-llm/ai-contract/tech-culture のみ・それ以外は grift', () => {
     const r = normalizeArticle({ ...casesBase, category: 'local-llm' }, 'cases');
     expect(r.ok).toBe(true);

--- a/workers/yomimono/src/__tests__/validate.test.ts
+++ b/workers/yomimono/src/__tests__/validate.test.ts
@@ -212,6 +212,26 @@ describe('normalizeArticle — news collection', () => {
     if (r.ok) expect(r.article.body).toBe('## 本文');
   });
 
+  it('news: source / featured / publishedAt / isDraft を正規化する', () => {
+    const r = normalizeArticle(
+      {
+        ...newsBase,
+        source: '```Example Media```',
+        featured: true,
+        publishedAt: '2026-07-08',
+        isDraft: true,
+      },
+      'news',
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.article.source).toBe('Example Media');
+      expect(r.article.featured).toBe(true);
+      expect(r.article.publishedAt).toBe('2026-07-08');
+      expect(r.article.isDraft).toBe(true);
+    }
+  });
+
   it('news: カテゴリ info/media/update/event/award のみ受理・それ以外は info へ', () => {
     const r = normalizeArticle({ ...newsBase, category: 'media' }, 'news');
     expect(r.ok).toBe(true);
@@ -504,5 +524,26 @@ describe('normalizeArticle — isDraft パススルー（非エンジニア向�
     );
     if (!r.ok) throw new Error('正規化失敗');
     expect(r.article.isDraft).toBe(true);
+  });
+});
+
+describe('normalizeArticle — blog pubDate', () => {
+  const base = {
+    slug: 'blog-slug',
+    title: 'ブログ',
+    description: '説明',
+    category: 'ai',
+    tags: [],
+    body: '本文',
+  };
+
+  it('blog: pubDate は実在日付だけ正規化する', () => {
+    const r = normalizeArticle({ ...base, pubDate: '2026-07-08' });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.article.pubDate).toBe('2026-07-08');
+
+    const invalid = normalizeArticle({ ...base, pubDate: '2026-02-30' });
+    expect(invalid.ok).toBe(true);
+    if (invalid.ok) expect(invalid.article.pubDate).toBeUndefined();
   });
 });

--- a/workers/yomimono/src/article-markdown.ts
+++ b/workers/yomimono/src/article-markdown.ts
@@ -70,10 +70,32 @@ function parseValue(lines: string[]): unknown {
 function parseLooseInlineArray(raw: string): string[] {
   const body = raw.replace(/^\[/, '').replace(/\]$/, '').trim();
   if (!body) return [];
-  return body
-    .split(',')
-    .map((item) => scalarValue(item))
-    .filter(Boolean);
+  const items: string[] = [];
+  let current = '';
+  let quote = '';
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (quote) {
+      current += ch;
+      if (ch === quote && body[i - 1] !== '\\') quote = '';
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      current += ch;
+      continue;
+    }
+    if (ch === ',') {
+      const value = scalarValue(current);
+      if (value) items.push(value);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  const value = scalarValue(current);
+  if (value) items.push(value);
+  return items;
 }
 
 function parseFrontmatter(blocks: FrontmatterBlock[]): Record<string, unknown> {

--- a/workers/yomimono/src/article-markdown.ts
+++ b/workers/yomimono/src/article-markdown.ts
@@ -1,4 +1,5 @@
 import { normalizeCategory, type ArticleInput, type NormalizedArticle } from './validate';
+import type { Collection } from './types';
 
 interface FrontmatterBlock {
   key: string;
@@ -79,41 +80,94 @@ function tagsValue(raw: unknown): string[] {
 }
 
 export function parseBlogMarkdown(slug: string, markdown: string): ParsedBlogArticle {
+  return parseArticleMarkdown(slug, markdown, 'blog');
+}
+
+export function parseArticleMarkdown(
+  slug: string,
+  markdown: string,
+  collection: Collection = 'blog',
+): ParsedBlogArticle {
   const parsed = splitMarkdown(markdown);
   const frontmatter = parseFrontmatter(parsed.blocks);
+  const category =
+    collection === 'news'
+      ? normalizeCategory(String(frontmatter.category ?? undefined), 'news')
+      : collection === 'cases'
+        ? normalizeCategory(String(frontmatter.category ?? undefined), 'cases')
+        : normalizeCategory(String(frontmatter.category ?? undefined));
   return {
     frontmatter,
     article: {
       slug,
       title: String(frontmatter.title ?? ''),
       description: String(frontmatter.description ?? ''),
-      category: normalizeCategory(String(frontmatter.category ?? undefined)),
+      category,
       tags: tagsValue(frontmatter.tags),
       body: parsed.body,
+      pubDate: typeof frontmatter.pubDate === 'string' ? frontmatter.pubDate : undefined,
+      publishedAt: typeof frontmatter.publishedAt === 'string' ? frontmatter.publishedAt : undefined,
+      externalUrl: typeof frontmatter.externalUrl === 'string' ? frontmatter.externalUrl : undefined,
+      source: typeof frontmatter.source === 'string' ? frontmatter.source : undefined,
+      summary: typeof frontmatter.summary === 'string' ? frontmatter.summary : undefined,
+      featured: frontmatter.featured === true,
       isDraft: frontmatter.isDraft === true,
     },
   };
 }
 
-function replacementLines(article: NormalizedArticle): Record<string, string> {
-  return {
+function replacementLines(article: NormalizedArticle): Record<string, string | null | undefined> {
+  const common: Record<string, string | null | undefined> = {
     title: `title: ${JSON.stringify(article.title)}`,
     description: `description: ${JSON.stringify(article.description)}`,
     category: `category: "${article.category}"`,
     tags: `tags: ${JSON.stringify(article.tags)}`,
     isDraft: `isDraft: ${article.isDraft === true}`,
   };
+  if (article.collection === 'blog') {
+    return {
+      ...common,
+      pubDate: article.pubDate ? `pubDate: ${article.pubDate}` : undefined,
+    };
+  }
+  if (article.collection === 'news') {
+    return {
+      ...common,
+      publishedAt: article.publishedAt ? `publishedAt: ${article.publishedAt}` : undefined,
+      externalUrl: article.externalUrl ? `externalUrl: ${JSON.stringify(article.externalUrl)}` : null,
+      source: article.source ? `source: ${JSON.stringify(article.source)}` : null,
+      featured: `featured: ${article.featured === true}`,
+    };
+  }
+  return {
+    ...common,
+    publishedAt: article.publishedAt ? `publishedAt: ${article.publishedAt}` : undefined,
+    summary: `summary: ${JSON.stringify(article.summary || '')}`,
+    featured: `featured: ${article.featured === true}`,
+  };
 }
 
 export function rebuildBlogMarkdown(originalMarkdown: string, article: NormalizedArticle): string {
+  return rebuildArticleMarkdown(originalMarkdown, article);
+}
+
+export function rebuildArticleMarkdown(originalMarkdown: string, article: NormalizedArticle): string {
   const parsed = splitMarkdown(originalMarkdown);
   const replacements = replacementLines(article);
   const emitted = new Set<string>();
   const lines: string[] = [];
 
   for (const block of parsed.blocks) {
-    const replacement = replacements[block.key];
-    if (replacement) {
+    if (Object.prototype.hasOwnProperty.call(replacements, block.key)) {
+      const replacement = replacements[block.key];
+      if (replacement === null) {
+        emitted.add(block.key);
+        continue;
+      }
+      if (!replacement) {
+        lines.push(...block.lines);
+        continue;
+      }
       lines.push(replacement);
       emitted.add(block.key);
     } else {
@@ -121,10 +175,16 @@ export function rebuildBlogMarkdown(originalMarkdown: string, article: Normalize
     }
   }
 
-  const requiredOrder = ['title', 'description', 'category', 'tags', 'isDraft'];
+  const requiredOrder =
+    article.collection === 'blog'
+      ? ['title', 'description', 'pubDate', 'category', 'tags', 'isDraft']
+      : article.collection === 'news'
+        ? ['title', 'description', 'publishedAt', 'category', 'tags', 'externalUrl', 'source', 'isDraft', 'featured']
+        : ['title', 'description', 'category', 'tags', 'publishedAt', 'summary', 'isDraft', 'featured'];
   for (const key of requiredOrder) {
-    if (!emitted.has(key)) {
-      lines.push(replacements[key]);
+    const replacement = replacements[key];
+    if (!emitted.has(key) && replacement) {
+      lines.push(replacement);
     }
   }
 

--- a/workers/yomimono/src/article-markdown.ts
+++ b/workers/yomimono/src/article-markdown.ts
@@ -61,10 +61,19 @@ function parseValue(lines: string[]): unknown {
       const parsed = JSON.parse(raw);
       return Array.isArray(parsed) ? parsed.map(String) : [];
     } catch {
-      return [];
+      return parseLooseInlineArray(raw);
     }
   }
   return scalarValue(raw);
+}
+
+function parseLooseInlineArray(raw: string): string[] {
+  const body = raw.replace(/^\[/, '').replace(/\]$/, '').trim();
+  if (!body) return [];
+  return body
+    .split(',')
+    .map((item) => scalarValue(item))
+    .filter(Boolean);
 }
 
 function parseFrontmatter(blocks: FrontmatterBlock[]): Record<string, unknown> {
@@ -147,6 +156,13 @@ function replacementLines(article: NormalizedArticle): Record<string, string | n
   };
 }
 
+function preservedCommentLines(block: FrontmatterBlock): string[] {
+  return block.lines.slice(1).filter((line) => {
+    const trimmed = line.trim();
+    return trimmed === '' || trimmed.startsWith('#');
+  });
+}
+
 export function rebuildBlogMarkdown(originalMarkdown: string, article: NormalizedArticle): string {
   return rebuildArticleMarkdown(originalMarkdown, article);
 }
@@ -161,6 +177,7 @@ export function rebuildArticleMarkdown(originalMarkdown: string, article: Normal
     if (Object.prototype.hasOwnProperty.call(replacements, block.key)) {
       const replacement = replacements[block.key];
       if (replacement === null) {
+        lines.push(...preservedCommentLines(block));
         emitted.add(block.key);
         continue;
       }
@@ -169,6 +186,7 @@ export function rebuildArticleMarkdown(originalMarkdown: string, article: Normal
         continue;
       }
       lines.push(replacement);
+      lines.push(...preservedCommentLines(block));
       emitted.add(block.key);
     } else {
       lines.push(...block.lines);

--- a/workers/yomimono/src/generate.ts
+++ b/workers/yomimono/src/generate.ts
@@ -73,11 +73,12 @@ ${recentTitles.map((t) => `- ${t}`).join('\n')}
 // JST基準の日付で frontmatter を組む（公開時はこの markdown をそのままコミット）。
 export function buildMarkdown(article: NormalizedArticle | Article, isDraft = false): string {
   const today = new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const pubDate = 'pubDate' in article && article.pubDate ? article.pubDate : today;
   const frontmatter = [
     '---',
     `title: ${JSON.stringify(article.title)}`,
     `description: ${JSON.stringify(article.description)}`,
-    `pubDate: ${today}`,
+    `pubDate: ${pubDate}`,
     'author: "Terisuke"',
     `category: "${article.category}"`,
     `tags: ${JSON.stringify(article.tags)}`,
@@ -108,6 +109,10 @@ export function buildNewsMarkdown(article: NormalizedArticle, isDraft = false): 
   if (article.externalUrl) {
     frontmatter.push(`externalUrl: ${JSON.stringify(article.externalUrl)}`);
   }
+  if (article.source) {
+    frontmatter.push(`source: ${JSON.stringify(article.source)}`);
+  }
+  frontmatter.push(`featured: ${article.featured || false}`);
   frontmatter.push('---', '');
   const body = article.body.replace(/^(?:\s*\n)*-{3,}[ \t]*(?:\n|$)/, '');
   return `${frontmatter.join('\n')}${body}\n`;

--- a/workers/yomimono/src/github.ts
+++ b/workers/yomimono/src/github.ts
@@ -2,19 +2,22 @@ import { Octokit } from '@octokit/core';
 import { createAppAuth } from '@octokit/auth-app';
 import { assertSlug, safeImageName } from './validate';
 import type { Collection, Env } from './types';
-import { parseBlogMarkdown } from './article-markdown';
+import { parseArticleMarkdown } from './article-markdown';
 
 export interface BlogArticleSummary {
+  collection: Collection;
   slug: string;
   title: string;
   description: string;
   category: string;
   isDraft: boolean;
   pubDate: string;
+  publishedAt?: string;
+  featured?: boolean;
 }
 
 export interface BlogArticleFile extends BlogArticleSummary {
-  article: ReturnType<typeof parseBlogMarkdown>['article'];
+  article: ReturnType<typeof parseArticleMarkdown>['article'];
   markdown: string;
   sha: string;
   path: string;
@@ -90,9 +93,9 @@ export async function listArticleSlugs(
   }
 }
 
-function blogArticlePath(env: Env, slug: string): string {
+function blogArticlePath(env: Env, slug: string, collection: Collection = 'blog'): string {
   assertSlug(slug);
-  return `${contentDir(env, 'blog')}/${slug}.md`;
+  return `${contentDir(env, collection)}/${slug}.md`;
 }
 
 function asString(value: unknown): string {
@@ -103,8 +106,9 @@ export async function readBlogArticle(
   env: Env,
   octokit: Octokit,
   slug: string,
+  collection: Collection = 'blog',
 ): Promise<BlogArticleFile> {
-  const path = blogArticlePath(env, slug);
+  const path = blogArticlePath(env, slug, collection);
   const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
     owner: env.GH_OWNER,
     repo: env.GH_REPO,
@@ -114,14 +118,19 @@ export async function readBlogArticle(
   const data = res.data as { content?: string; sha?: string };
   if (!data.content || !data.sha) throw new Error(`記事を取得できません: ${path}`);
   const markdown = base64ToUtf8(data.content);
-  const parsed = parseBlogMarkdown(slug, markdown);
+  const parsed = parseArticleMarkdown(slug, markdown, collection);
+  const pubDate = asString(parsed.frontmatter.pubDate);
+  const publishedAt = asString(parsed.frontmatter.publishedAt);
   return {
+    collection,
     slug,
     title: asString(parsed.frontmatter.title),
     description: asString(parsed.frontmatter.description),
     category: asString(parsed.frontmatter.category),
     isDraft: parsed.frontmatter.isDraft === true,
-    pubDate: asString(parsed.frontmatter.pubDate),
+    pubDate: collection === 'blog' ? pubDate : publishedAt,
+    publishedAt,
+    featured: parsed.frontmatter.featured === true,
     article: parsed.article,
     markdown,
     sha: data.sha,
@@ -132,19 +141,23 @@ export async function readBlogArticle(
 export async function listBlogArticles(
   env: Env,
   octokit: Octokit,
+  collection: Collection = 'blog',
 ): Promise<BlogArticleSummary[]> {
-  const slugs = await listArticleSlugs(env, octokit, 'blog');
+  const slugs = await listArticleSlugs(env, octokit, collection);
   const articles: BlogArticleSummary[] = [];
   for (const slug of slugs) {
     try {
-      const article = await readBlogArticle(env, octokit, slug);
+      const article = await readBlogArticle(env, octokit, slug, collection);
       articles.push({
+        collection,
         slug: article.slug,
         title: article.title || slug,
         description: article.description,
         category: article.category,
         isDraft: article.isDraft,
         pubDate: article.pubDate,
+        publishedAt: article.publishedAt,
+        featured: article.featured,
       });
     } catch {
       // 一覧では壊れた単一記事で画面全体を落とさない。
@@ -160,18 +173,20 @@ export async function updateBlogArticle(
   markdown: string,
   sha: string,
   authorEmail: string,
+  collection: Collection = 'blog',
 ): Promise<{ updated: true; path: string; commitUrl: string }> {
-  const path = blogArticlePath(env, slug);
+  const path = blogArticlePath(env, slug, collection);
   if (!sha) throw new Error('更新元の記事情報が不足しています。記事を開き直してください');
 
   const author = authorEmail.split('@')[0];
+  const prefix = collection === 'news' ? 'news' : collection === 'cases' ? 'case' : 'post';
   try {
     const res = await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
       owner: env.GH_OWNER,
       repo: env.GH_REPO,
       path,
       branch: env.PUBLISH_BRANCH,
-      message: `post(yomimono): ${slug}（更新: ${author}）`,
+      message: `${prefix}(yomimono): ${slug}（更新: ${author}）`,
       content: utf8ToBase64(markdown),
       sha,
     });

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -6,8 +6,7 @@ import {
   clearSessionCookie,
 } from './session';
 import { collectTopics } from './collect';
-// buildNewsMarkdown は M3 で news を有効化する際に再import（基盤関数は generate.ts に維持）
-import { generateArticle, buildMarkdown, buildCasesMarkdown } from './generate';
+import { generateArticle, buildMarkdown, buildNewsMarkdown, buildCasesMarkdown } from './generate';
 import { scanForViolations } from './guardrails';
 import {
   makeOctokit,
@@ -19,11 +18,12 @@ import {
   readBlogArticle,
   updateBlogArticle,
 } from './github';
-import { rebuildBlogMarkdown } from './article-markdown';
-import { assertSlug, sanitizeText, normalizeArticle, normalizeCollection, type ArticleInput } from './validate';
+import { rebuildArticleMarkdown } from './article-markdown';
+import { assertSlug, sanitizeText, normalizeArticle, normalizeCollection, type ArticleInput, type NormalizedArticle } from './validate';
 import { HUB_HTML } from './ui-hub';
 import { AI_HTML } from './ui-ai';
 import { MANUAL_HTML } from './ui-manual';
+import { MANUAL_NEWS_HTML } from './ui-manual-news';
 import { MANUAL_CASES_HTML } from './ui-manual-cases';
 import { EDIT_HTML } from './ui-edit';
 import { LOGIN_HTML } from './ui-login';
@@ -32,9 +32,6 @@ import { STYLE_GUIDE_FALLBACK } from './style-guide';
 // コミット attribution（Access廃止で個人メールが無いため固定名）。
 const EDITOR = 'yomimono';
 const MIN_PASSWORD_LEN = 16;
-// news コレクションは M3 まで公開準備中: エンドポイント層で一時拒否するメッセージ。
-// 基盤関数（normalizeArticle('news') / buildNewsMarkdown / contentDir / commitArticle）は維持・M3 で有効化。
-const NEWS_NOT_READY_MSG = 'news collection は現在準備中です（blog/cases のみ利用可能）';
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -159,6 +156,12 @@ function sanitizeTitles(input: unknown): string[] {
   return input.slice(0, 50).map((t) => sanitizeText(t, 200)).filter(Boolean);
 }
 
+function buildCollectionMarkdown(article: NormalizedArticle): string {
+  if (article.collection === 'news') return buildNewsMarkdown(article, article.isDraft);
+  if (article.collection === 'cases') return buildCasesMarkdown(article, article.isDraft);
+  return buildMarkdown(article, article.isDraft);
+}
+
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
@@ -234,6 +237,9 @@ export default {
       if (req.method === 'GET' && path === '/manual') {
         return html(MANUAL_HTML, env);
       }
+      if (req.method === 'GET' && path === '/manual/news') {
+        return html(MANUAL_NEWS_HTML, env);
+      }
       if (req.method === 'GET' && path === '/manual/cases') {
         return html(MANUAL_CASES_HTML, env);
       }
@@ -244,32 +250,21 @@ export default {
       // 既存記事スラッグ一覧（重複テーマ回避用）
       if (req.method === 'GET' && path === '/api/recent') {
         const collection = normalizeCollection(url.searchParams.get('collection'));
-        // news は M3 まで公開準備中: エンドポイント層で空配列を返す（基盤関数は維持・M3 で有効化）
-        if (collection === 'news') {
-          return json({ slugs: [] });
-        }
         const octokit = makeOctokit(env);
         const slugs = await listArticleSlugs(env, octokit, collection);
         return json({ slugs });
       }
 
-      // 既存ブログ記事の一覧・読み込み・更新（M1-I3）。
-      // M2/M3 の cases/news CMS とは分け、ここでは blog のみ編集対象にする。
+      // 既存コンテンツの一覧・読み込み・更新。collection で blog/news/cases を切り替える。
       if (req.method === 'GET' && path === '/api/articles') {
         const collection = normalizeCollection(url.searchParams.get('collection'));
-        if (collection !== 'blog') {
-          return json({ error: '既存記事編集は現在 blog のみ対応しています' }, 400);
-        }
         const octokit = makeOctokit(env);
-        const articles = await listBlogArticles(env, octokit);
+        const articles = await listBlogArticles(env, octokit, collection);
         return json({ articles });
       }
 
       if (req.method === 'GET' && path === '/api/article') {
         const collection = normalizeCollection(url.searchParams.get('collection'));
-        if (collection !== 'blog') {
-          return json({ error: '既存記事編集は現在 blog のみ対応しています' }, 400);
-        }
         const slug = url.searchParams.get('slug') || '';
         if (!slug) return json({ error: 'slug は必須です' }, 400);
         try {
@@ -278,7 +273,7 @@ export default {
           return json({ error: e instanceof Error ? e.message : 'slug が不正です' }, 400);
         }
         const octokit = makeOctokit(env);
-        const file = await readBlogArticle(env, octokit, slug);
+        const file = await readBlogArticle(env, octokit, slug, collection);
         return json({ article: file.article, sha: file.sha, path: file.path });
       }
 
@@ -355,20 +350,10 @@ export default {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const collection = normalizeCollection(body.collection);
-        // news は M3 まで一時拒否（基盤関数は維持・M3 で有効化）
-        if (collection === 'news') {
-          return json({ error: NEWS_NOT_READY_MSG }, 400);
-        }
         const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
         const normalized = norm.article;
-        // news は上で拒否済みなので blog/cases のみ（buildNewsMarkdown は M3 で有効化）
-        let markdown: string;
-        if (collection === 'cases') {
-          markdown = buildCasesMarkdown(normalized, normalized.isDraft);
-        } else {
-          markdown = buildMarkdown(normalized, normalized.isDraft);
-        }
+        const markdown = buildCollectionMarkdown(normalized);
         const violations = scanForViolations(markdown);
         return json({ violations });
       }
@@ -378,21 +363,11 @@ export default {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const collection = normalizeCollection(body.collection);
-        // news は M3 まで一時拒否（基盤関数は維持・M3 で有効化）
-        if (collection === 'news') {
-          return json({ error: NEWS_NOT_READY_MSG }, 400);
-        }
         const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
         const normalized = norm.article;
         // 公開直前にもう一度ガードレールを通す（最終防衛線）
-        // news は上で拒否済みなので blog/cases のみ（buildNewsMarkdown は M3 で有効化）
-        let markdown: string;
-        if (collection === 'cases') {
-          markdown = buildCasesMarkdown(normalized, normalized.isDraft);
-        } else {
-          markdown = buildMarkdown(normalized, normalized.isDraft);
-        }
+        const markdown = buildCollectionMarkdown(normalized);
         const violations = scanForViolations(markdown);
         if (violations.length > 0) {
           return json({ error: 'ガードレール違反のため公開を中止しました', violations }, 422);
@@ -407,23 +382,29 @@ export default {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
         const collection = normalizeCollection(body.collection);
-        if (collection !== 'blog') {
-          return json({ error: '既存記事編集は現在 blog のみ対応しています' }, 400);
-        }
         const sha = typeof body.sha === 'string' ? body.sha : '';
         if (!sha) return json({ error: '更新元の記事情報がありません。記事を開き直してください' }, 400);
-        const norm = normalizeArticle(body.article as ArticleInput | undefined, 'blog');
+        const norm = normalizeArticle(body.article as ArticleInput | undefined, collection);
         if (!norm.ok) return json({ error: norm.error }, norm.status);
         const normalized = norm.article;
+        const originalSlug = typeof body.originalSlug === 'string' ? body.originalSlug : normalized.slug;
+        try {
+          assertSlug(originalSlug);
+        } catch (e) {
+          return json({ error: e instanceof Error ? e.message : 'slug が不正です' }, 400);
+        }
+        if (originalSlug !== normalized.slug) {
+          return json({ error: 'slug は変更できません。記事を開き直してください' }, 400);
+        }
         const octokit = makeOctokit(env);
-        const existing = await readBlogArticle(env, octokit, normalized.slug);
-        const markdown = rebuildBlogMarkdown(existing.markdown, normalized);
+        const existing = await readBlogArticle(env, octokit, originalSlug, collection);
+        const markdown = rebuildArticleMarkdown(existing.markdown, normalized);
         const violations = scanForViolations(markdown);
         if (violations.length > 0) {
           return json({ error: 'ガードレール違反のため更新を中止しました', violations }, 422);
         }
         try {
-          const result = await updateBlogArticle(env, octokit, normalized.slug, markdown, sha, EDITOR);
+          const result = await updateBlogArticle(env, octokit, originalSlug, markdown, sha, EDITOR, collection);
           return json(result);
         } catch (e: unknown) {
           if (e instanceof Error && /^記事が|^更新元/.test(e.message)) {

--- a/workers/yomimono/src/ui-edit.ts
+++ b/workers/yomimono/src/ui-edit.ts
@@ -1,12 +1,23 @@
 import { head, header, tail } from './ui-shared';
 
 const BODY = `<main class="wide">
-  <p class="lead">公開済みの記事を選んで、タイトル・説明・カテゴリ・タグ・本文を修正できます。URL（slug）は事故防止のため変更しません。</p>
+  <p class="lead">既存コンテンツを選んで、同じURLのまま更新します。slug は事故防止のため変更できません。</p>
+
+  <section class="step">
+    <h2>種類を選ぶ</h2>
+    <p class="hint">編集する collection を切り替えると、一覧と入力項目も切り替わります。</p>
+    <div class="row" role="group" aria-label="編集するコンテンツ種別">
+      <button class="ghost collection-tab" id="tab_blog" type="button" data-collection="blog" aria-pressed="true">ブログ</button>
+      <button class="ghost collection-tab" id="tab_news" type="button" data-collection="news" aria-pressed="false">ニュース</button>
+      <button class="ghost collection-tab" id="tab_cases" type="button" data-collection="cases" aria-pressed="false">実績</button>
+      <span class="meta" id="e_collection_status"></span>
+    </div>
+  </section>
 
   <div class="split">
     <section class="step">
-      <h2>記事を選ぶ</h2>
-      <p class="hint">最近の記事から順に表示します。修正したい記事の「編集」を押してください。</p>
+      <h2 id="e_list_title">ブログを選ぶ</h2>
+      <p class="hint">最近のコンテンツから順に表示します。修正したい項目の「編集」を押してください。</p>
       <div class="row" style="margin-bottom:10px">
         <button class="ghost" id="e_reload" type="button">一覧を更新</button>
         <span class="meta" id="e_list_status"></span>
@@ -15,20 +26,28 @@ const BODY = `<main class="wide">
     </section>
 
     <section class="step" id="e_form_box" hidden>
-      <h2>記事を修正する</h2>
+      <h2 id="e_form_title">コンテンツを修正する</h2>
       <p class="hint">保存前に公開前チェックを実行します。問題がなければ同じURLの記事を更新します。</p>
       <input id="e_sha" type="hidden">
+      <input id="e_original_slug" type="hidden">
       <div class="field"><label>URL（変更不可）</label><input id="e_slug" readonly></div>
       <div class="field"><label>タイトル</label><input id="e_title"></div>
-      <div class="field"><label>記事のまとめ</label><input id="e_desc"></div>
+      <div class="field"><label>説明</label><input id="e_desc"></div>
       <div class="row" style="gap:14px">
-        <div class="field" style="flex:1;min-width:190px;margin:0"><label>カテゴリ</label>
-          <select id="e_cat"><option value="ai">AI</option><option value="engineering">エンジニアリング</option><option value="founder">創業</option><option value="lab">ラボ</option></select>
-        </div>
+        <div class="field" style="flex:1;min-width:190px;margin:0"><label>カテゴリ</label><select id="e_cat"></select></div>
+        <div class="field" style="width:170px;margin:0"><label id="e_date_label">公開日</label><input id="e_date" type="date"></div>
         <div class="field" style="flex:2;min-width:220px;margin:0"><label>タグ（カンマ区切り）</label><input id="e_tags"></div>
       </div>
-      <div class="field"><label>本文</label><textarea id="e_body" maxlength="100000"></textarea></div>
-      <label class="checkline"><input id="e_draft" type="checkbox"> 下書きとして保存する（公開一覧には出しません）</label>
+      <div class="field" id="e_summary_box" hidden><label>リード文</label><input id="e_summary"></div>
+      <div class="row" id="e_news_box" style="gap:14px" hidden>
+        <div class="field" style="flex:1;min-width:220px;margin:0"><label>外部URL（任意・本文なし可）</label><input id="e_external"></div>
+        <div class="field" style="width:220px;margin:0"><label>出典名（任意）</label><input id="e_source"></div>
+      </div>
+      <div class="field"><label id="e_body_label">本文</label><textarea id="e_body" maxlength="100000"></textarea></div>
+      <div class="row" style="margin-top:10px">
+        <label class="checkline" style="margin:0"><input id="e_featured" type="checkbox"> 注目表示する</label>
+        <label class="checkline" style="margin:0"><input id="e_draft" type="checkbox"> 下書きとして保存する</label>
+      </div>
       <div class="row" style="margin-top:14px">
         <button class="pub" id="e_save" type="button">更新する</button>
         <span class="meta" id="e_msg"></span>
@@ -39,6 +58,30 @@ const BODY = `<main class="wide">
 </main>`;
 
 const JS = `
+  var currentCollection = 'blog';
+  var configs = {
+    blog: {
+      label:'ブログ',
+      newPath:'/manual',
+      dateKey:'pubDate',
+      dateLabel:'公開日',
+      categories:[['ai','AI'],['engineering','エンジニアリング'],['founder','創業'],['lab','ラボ']]
+    },
+    news: {
+      label:'ニュース',
+      newPath:'/manual/news',
+      dateKey:'publishedAt',
+      dateLabel:'公開日',
+      categories:[['info','お知らせ'],['media','メディア掲載'],['update','更新情報'],['event','イベント'],['award','受賞']]
+    },
+    cases: {
+      label:'実績',
+      newPath:'/manual/cases',
+      dateKey:'publishedAt',
+      dateLabel:'公開日',
+      categories:[['grift','Grift'],['confidential-ai','機密データAI'],['local-llm','ローカルLLM'],['ai-contract','AI受託・開発'],['tech-culture','技術文化・発信']]
+    }
+  };
   function getJson(p){
     return fetch(BASE+p,{method:'GET'}).then(function(r){return r.json().then(function(j){if(!r.ok){throw new Error(j&&j.error?j.error:('HTTP '+r.status));}return j;});});
   }
@@ -49,13 +92,43 @@ const JS = `
     btn.disabled=busy;
     btn.innerHTML=busy?'<span class="spin"></span>'+label:btn.getAttribute('data-label');
   }
+  function cfg(){ return configs[currentCollection]; }
+  function setStatus(msg){ $('e_collection_status').textContent = msg || ''; }
+  function renderCategories(selected){
+    $('e_cat').innerHTML = cfg().categories.map(function(pair){
+      return '<option value="'+esc(pair[0])+'"'+(pair[0]===selected?' selected':'')+'>'+esc(pair[1])+'</option>';
+    }).join('');
+  }
+  function renderFields(){
+    var c = cfg();
+    $('e_list_title').textContent = c.label+'を選ぶ';
+    $('e_form_title').textContent = c.label+'を修正する';
+    $('e_date_label').textContent = c.dateLabel;
+    $('e_summary_box').hidden = currentCollection !== 'cases';
+    $('e_news_box').hidden = currentCollection !== 'news';
+    $('e_featured').closest('label').hidden = currentCollection === 'blog';
+    $('e_body_label').textContent = currentCollection === 'news' ? '本文（外部URLがない場合は必須）' : '本文';
+    renderCategories('');
+  }
+  function resetForm(){
+    $('e_form_box').hidden = true;
+    $('e_sha').value = '';
+    $('e_original_slug').value = '';
+    $('e_result').innerHTML = '';
+    $('e_msg').textContent = '';
+  }
+  function emptyHtml(){
+    return '<div class="empty">'+esc(cfg().label)+'はまだ見つかりません。<br><a href="'+esc(BASE+cfg().newPath)+'">'+esc(cfg().label)+'を書く</a></div>';
+  }
   function renderList(items){
     var box=$('e_list');
-    if(!items.length){ box.innerHTML='<div class="empty">編集できる記事が見つかりません。</div>'; return; }
+    if(!items.length){ box.innerHTML=emptyHtml(); return; }
     box.innerHTML=items.map(function(a){
       var state=a.isDraft?'<span class="badge">下書き</span>':'';
-      return '<article class="article-item"><div><b>'+esc(a.title||a.slug)+'</b>'+state+
-        '<p>'+esc(a.description||'説明なし')+'</p><small>'+esc(a.pubDate||'日付なし')+' / '+esc(a.category||'未分類')+' / '+esc(a.slug)+'</small></div>'+
+      var featured=a.featured?'<span class="badge">注目</span>':'';
+      var date=a.pubDate||a.publishedAt||'日付なし';
+      return '<article class="article-item"><div><b>'+esc(a.title||a.slug)+'</b>'+state+featured+
+        '<p>'+esc(a.description||'説明なし')+'</p><small>'+esc(date)+' / '+esc(a.category||'未分類')+' / '+esc(a.slug)+'</small></div>'+
         '<button class="ghost" type="button" data-slug="'+esc(a.slug)+'">編集</button></article>';
     }).join('');
     var buttons=box.querySelectorAll('button[data-slug]');
@@ -64,8 +137,9 @@ const JS = `
     }
   }
   function loadList(){
-    $('e_list_status').textContent='読み込み中…';
-    getJson('/api/articles').then(function(j){
+    resetForm();
+    $('e_list_status').textContent='読み込み中...';
+    getJson('/api/articles?collection='+encodeURIComponent(currentCollection)).then(function(j){
       renderList(j.articles||[]);
       $('e_list_status').textContent=(j.articles||[]).length+'件';
     }).catch(function(e){
@@ -76,40 +150,83 @@ const JS = `
   function loadArticle(slug){
     $('e_msg').textContent='';
     $('e_result').innerHTML='';
-    getJson('/api/article?slug='+encodeURIComponent(slug)).then(function(j){
+    getJson('/api/article?collection='+encodeURIComponent(currentCollection)+'&slug='+encodeURIComponent(slug)).then(function(j){
       var a=j.article||{};
       $('e_sha').value=j.sha||'';
+      $('e_original_slug').value=a.slug||slug;
       $('e_slug').value=a.slug||slug;
       $('e_title').value=a.title||'';
       $('e_desc').value=a.description||'';
-      $('e_cat').value=a.category||'ai';
+      renderCategories(a.category||cfg().categories[0][0]);
+      $('e_date').value=a[cfg().dateKey]||'';
       $('e_tags').value=(a.tags||[]).join(', ');
+      $('e_summary').value=a.summary||'';
+      $('e_external').value=a.externalUrl||'';
+      $('e_source').value=a.source||'';
       $('e_body').value=a.body||'';
+      $('e_featured').checked=a.featured===true;
       $('e_draft').checked=a.isDraft===true;
       $('e_form_box').hidden=false;
-      $('e_msg').textContent='記事を読み込みました';
+      $('e_msg').textContent=cfg().label+'を読み込みました';
     }).catch(function(e){
       $('e_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>';
     });
   }
   function gather(){
-    return {
+    var tags = $('e_tags').value.split(',').map(function(s){return s.trim();}).filter(Boolean);
+    var article = {
       slug:$('e_slug').value.trim(),
       title:$('e_title').value.trim(),
       description:$('e_desc').value.trim(),
       category:$('e_cat').value,
-      tags:$('e_tags').value.split(',').map(function(s){return s.trim();}).filter(Boolean),
+      tags:tags,
       body:$('e_body').value,
       isDraft:$('e_draft').checked
     };
+    if(currentCollection === 'blog'){
+      article.pubDate = $('e_date').value;
+    } else {
+      article.publishedAt = $('e_date').value;
+      article.featured = $('e_featured').checked;
+    }
+    if(currentCollection === 'news'){
+      article.externalUrl = $('e_external').value.trim();
+      article.source = $('e_source').value.trim();
+    }
+    if(currentCollection === 'cases'){
+      article.summary = $('e_summary').value.trim();
+    }
+    return article;
   }
   function validateLocal(a){
     if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'URL が不正です。記事を開き直してください';
+    if(a.slug !== $('e_original_slug').value) return 'URL は変更できません。記事を開き直してください';
     if(!a.title) return 'タイトルを入力してください';
-    if(!a.description) return '記事のまとめを入力してください';
-    if(!a.body.trim()) return '本文を入力してください';
+    if(!a.description) return '説明を入力してください';
+    var date = currentCollection === 'blog' ? a.pubDate : a.publishedAt;
+    if(date && !/^\\d{4}-\\d{2}-\\d{2}$/.test(date)) return '公開日は YYYY-MM-DD で入力してください';
+    if(currentCollection === 'cases' && !a.summary) return 'リード文を入力してください';
+    if(currentCollection === 'news'){
+      if(a.externalUrl && !/^https?:\\/\\//i.test(a.externalUrl)) return '外部URLは http(s) のURLを入力してください';
+      if(!a.externalUrl && !a.body.trim()) return '外部URLがないニュースは本文を入力してください';
+    } else if(!a.body.trim()) {
+      return '本文を入力してください';
+    }
     if(!$('e_sha').value) return '更新元の記事情報がありません。記事を開き直してください';
     return '';
+  }
+  function switchCollection(next){
+    if(!configs[next]) return;
+    currentCollection = next;
+    var tabs=document.querySelectorAll('.collection-tab');
+    for(var i=0;i<tabs.length;i++){
+      var on=tabs[i].getAttribute('data-collection')===next;
+      tabs[i].setAttribute('aria-pressed',on?'true':'false');
+      tabs[i].className=on?'primary collection-tab':'ghost collection-tab';
+    }
+    renderFields();
+    setStatus(cfg().label+'を表示中');
+    loadList();
   }
   $('e_reload').addEventListener('click',loadList);
   $('e_save').setAttribute('data-label','更新する');
@@ -117,9 +234,9 @@ const JS = `
     var article=gather();
     var err=validateLocal(article);
     if(err){ $('e_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
-    if(!confirm('この記事を同じURLで更新します。よろしいですか？')) return;
-    var btn=this; setBusy(btn,true,'更新中…'); $('e_msg').textContent='公開前チェック中…'; $('e_result').innerHTML='';
-    postJson('/api/update',{article:article,sha:$('e_sha').value}).then(function(j){
+    if(!confirm(cfg().label+'を同じURLで更新します。よろしいですか？')) return;
+    var btn=this; setBusy(btn,true,'更新中...'); $('e_msg').textContent='公開前チェック中...'; $('e_result').innerHTML='';
+    postJson('/api/update',{collection:currentCollection,originalSlug:$('e_original_slug').value,article:article,sha:$('e_sha').value}).then(function(j){
       var link=j&&j.commitUrl?'<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>':'';
       $('e_result').innerHTML='<div class="done">更新しました。数分でサイトに反映されます。 '+link+'</div>';
       $('e_msg').textContent='';
@@ -130,7 +247,11 @@ const JS = `
       setBusy(btn,false,'');
     });
   });
-  loadList();
+  var tabs=document.querySelectorAll('.collection-tab');
+  for(var i=0;i<tabs.length;i++){
+    tabs[i].addEventListener('click',function(){ switchCollection(this.getAttribute('data-collection')); });
+  }
+  switchCollection('blog');
 `;
 
-export const EDIT_HTML = head('既存記事を編集 — 読みもの 作成スタジオ') + header('edit') + BODY + tail(JS);
+export const EDIT_HTML = head('既存コンテンツを編集 — 読みもの 作成スタジオ') + header('edit') + BODY + tail(JS);

--- a/workers/yomimono/src/ui-hub.ts
+++ b/workers/yomimono/src/ui-hub.ts
@@ -1,19 +1,19 @@
 import { head, header, tail } from './ui-shared';
 
-// ログイン後の入口。AI生成 / ブログ作成 / 実績作成 / 既存記事編集 の入口。
+// ログイン後の入口。統合CMSの collection 別作成 / 既存コンテンツ編集の入口。
 export const HUB_HTML =
   head('ハブ — 読みもの 作成スタジオ') +
   header('hub') +
   '<main>' +
-  '<p class="lead">記事の作り方を選んでください。どれで書いても、記事は main マージ不要でそのまま cor-jp.com に公開されます。</p>' +
+  '<p class="lead">作成・編集するコンテンツの種類を選んでください。保存すると GitHub 経由で静的サイトへ反映されます。</p>' +
   '<div class="hub">' +
-  '<a href="__BASE__/ai"><div class="ic">🤖</div><h3>AI生成</h3>' +
-  '<p>最新トピックを収集し、社長の文体でAIが下書き。確認・編集して公開します。</p></a>' +
-  '<a href="__BASE__/manual"><div class="ic">✍️</div><h3>ブログ作成</h3>' +
-  '<p>テキストと画像を自分で貼ってブログ記事を作成。ライブプレビューで確認して公開します。</p></a>' +
-  '<a href="__BASE__/manual/cases"><div class="ic">📁</div><h3>実績作成</h3>' +
-  '<p>実績記事を作成し、works 詳細ページへ追加します。カテゴリ・リード文・公開日を入力して公開します。</p></a>' +
-  '<a href="__BASE__/edit"><div class="ic">✎</div><h3>既存記事を編集</h3>' +
-  '<p>公開済みの記事を選んで、誤字修正や追記を同じURLのまま保存します。</p></a>' +
+  '<a href="__BASE__/manual"><div class="ic">✍️</div><h3>ブログを書く</h3>' +
+  '<p>社内知見や技術記事をブログとして作成します。カテゴリ・タグ・本文を入力して公開します。</p></a>' +
+  '<a href="__BASE__/manual/news"><div class="ic">📰</div><h3>ニュースを書く</h3>' +
+  '<p>お知らせや外部掲載を news として作成します。外部URLがあれば本文なしでも保存できます。</p></a>' +
+  '<a href="__BASE__/manual/cases"><div class="ic">📁</div><h3>実績を書く</h3>' +
+  '<p>実績記事を作成し、works 詳細ページへ追加します。リード文・公開日・注目表示を入力できます。</p></a>' +
+  '<a href="__BASE__/edit"><div class="ic">✎</div><h3>既存コンテンツを編集</h3>' +
+  '<p>ブログ・ニュース・実績を選んで、同じURLのまま内容を更新します。</p></a>' +
   '</div></main>' +
   tail('');

--- a/workers/yomimono/src/ui-manual-news.ts
+++ b/workers/yomimono/src/ui-manual-news.ts
@@ -1,34 +1,34 @@
 import { head, header, tail, toolbarButtonsHtml, draftBarHtml, UI_KIT_JS } from './ui-shared';
 
-// 実績記事（cases）作成ページ。M1-I2 の非エンジニア向けUI改善キットを適用し、
-// /api/validate /api/publish へ collection:'cases' を明示して送る。
+// ニュース作成ページ。外部掲載リンクは externalUrl を入れれば本文なしで保存できる。
 const BODY =
   `<main class="wide">
   ` +
   draftBarHtml('m') +
   `
-  <p class="lead">実績記事を作成します。本文は「課題・アプローチ・実装・成果」の見出しで書くと、既存の works 詳細ページに自然につながります。</p>
+  <p class="lead">ニュースを作成します。外部掲載・登壇・更新情報などを news として保存できます。外部URLがないニュースは本文を入力してください。</p>
   <div class="step">
     <div class="row" style="gap:14px">
-      <div class="field" style="flex:1;min-width:220px;margin:0"><label>タイトル</label><input id="m_title" placeholder="実績記事のタイトル"></div>
-      <div class="field" style="width:210px;margin:0"><label>カテゴリ</label>
+      <div class="field" style="flex:1;min-width:220px;margin:0"><label>タイトル</label><input id="m_title" placeholder="ニュースのタイトル"></div>
+      <div class="field" style="width:190px;margin:0"><label>カテゴリ</label>
         <select id="m_cat">
-          <option value="grift">Grift</option>
-          <option value="confidential-ai">機密データAI</option>
-          <option value="local-llm">ローカルLLM</option>
-          <option value="ai-contract">AI受託・開発</option>
-          <option value="tech-culture">技術文化・発信</option>
+          <option value="info">お知らせ</option>
+          <option value="media">メディア掲載</option>
+          <option value="update">更新情報</option>
+          <option value="event">イベント</option>
+          <option value="award">受賞</option>
         </select>
       </div>
-    </div>
-    <div class="field" style="margin-top:10px"><label>リード文（実績ページ上部に表示）</label><input id="m_summary" placeholder="1〜2行で、どんな実績かを説明"></div>
-    <div class="row" style="gap:14px;margin-top:10px">
-      <div class="field" style="flex:1;min-width:220px;margin:0"><label>説明（カード・OGP用の1〜2文）</label><input id="m_desc" placeholder="一覧やSNSで表示される短い説明"></div>
-      <div class="field" style="width:240px;margin:0"><label>タグ（カンマ区切り）</label><input id="m_tags" placeholder="AI, PoC"></div>
-    </div>
-    <div class="row" style="gap:14px;margin-top:10px">
       <div class="field" style="width:170px;margin:0"><label>公開日</label><input id="m_date" type="date"></div>
-      <div class="field" style="width:170px;margin:0"><label>注目表示</label><label style="display:flex;align-items:center;gap:8px;padding-top:9px"><input id="m_featured" type="checkbox" style="width:auto"> featured</label></div>
+    </div>
+    <div class="field" style="margin-top:10px"><label>説明（カード・OGP用の1〜2文）</label><input id="m_desc" placeholder="一覧やSNSで表示される短い説明"></div>
+    <div class="row" style="gap:14px;margin-top:10px">
+      <div class="field" style="flex:1;min-width:220px;margin:0"><label>外部URL（任意・本文なし可）</label><input id="m_external" placeholder="https://example.com/news"></div>
+      <div class="field" style="width:220px;margin:0"><label>出典名（任意）</label><input id="m_source" placeholder="Cor.株式会社"></div>
+      <div class="field" style="width:240px;margin:0"><label>タグ（カンマ区切り）</label><input id="m_tags" placeholder="AI, お知らせ"></div>
+    </div>
+    <div class="row" style="gap:14px;margin-top:10px">
+      <label class="checkline" style="margin:0"><input id="m_featured" type="checkbox"> 注目表示する</label>
       <label class="checkline" style="margin:0"><input id="m_draft_state" type="checkbox"> 下書きとして保存する</label>
     </div>
     <details class="advanced"><summary>URLを編集する（上級者向け）</summary>
@@ -39,29 +39,16 @@ const BODY =
   <div class="split">
     <div class="step editor">
       <div class="toolbar" id="m_toolbar">
-        <strong style="font-size:13px;color:var(--navy)">本文</strong>
+        <strong style="font-size:13px;color:var(--navy)">本文（外部URLがない場合は必須）</strong>
         ` +
   toolbarButtonsHtml() +
   `
-        <button class="ghost" id="m_imgBtn" type="button">画像を追加</button>
-        <span class="meta" id="m_imgMsg"></span>
-        <input type="file" id="m_file" accept="image/*" multiple hidden>
       </div>
-      <textarea id="m_body" class="drop" maxlength="100000" placeholder="## 課題
+      <textarea id="m_body" maxlength="100000" placeholder="外部URLがないニュースでは本文を入力してください。
+例:
+## 概要
 
-お客様やプロジェクトが抱えていた問題。
-
-## アプローチ
-
-どう考え、どんな方針で臨んだか。
-
-## 実装
-
-実際に作ったもの・技術的なポイント。
-
-## 成果
-
-結果・効果。NDA案件は具体名や数値を抽象化してください。"></textarea>
+お知らせ本文。"></textarea>
     </div>
     <div class="step">
       <div class="toolbar"><strong style="font-size:13px;color:var(--navy)">プレビュー</strong></div>
@@ -71,53 +58,29 @@ const BODY =
 
   <div class="step">
     <div class="row">
-      <button class="pub" id="m_pub">実績記事を公開する</button>
+      <button class="pub" id="m_pub">ニュースを保存する</button>
       <button class="ghost" id="m_draft" type="button">下書きをブラウザに保存</button>
       <button class="ghost" id="m_check" type="button">公開前チェック</button>
       <span class="meta" id="m_msg"></span>
     </div>
     <div id="m_result"></div>
-    <details class="help"><summary>技術的なメモ（かっこのある方向け）</summary>
-      <div class="help-body">
-        <ul>
-          <li>公開は GitHub の main ブランチへコミットされ、数分で静的サイトに反映されます（main マージ不要）。</li>
-          <li>本文は Markdown 形式で保存されます。ツールバーが記号を自動挿入します。</li>
-          <li>「下書きをブラウザに保存」はこの端末のブラウザ（localStorage）にのみ保存されます。サーバーには送信されません。</li>
-          <li>入力中の内容は自動的にこのブラウザに保存されます（デバイスごと・公開時に消去）。</li>
-        </ul>
-      </div>
-    </details>
   </div>
 </main>`;
 
 const JS = `
-  // === 状態 ===
   var slugEdited = false;
-  var DRAFT_KEY = 'draft:cases:new';
+  var DRAFT_KEY = 'draft:news:new';
   var pendingDraft = null;
-  var imgCache = {};
-  var IMG_CACHE_MAX = 20; // プレビュー用 data URL のキャッシュ上限（古いものから破棄）
   var _pvTimer = null;
-  var _draftTimer = null; // 下書き自動保存タイマー（公開成功時にキャンセルして競合防止）
+  var _draftTimer = null;
 
   function todayString(){
     var d=new Date(), p=function(n){return (n<10?'0':'')+n;};
     return d.getFullYear()+'-'+p(d.getMonth()+1)+'-'+p(d.getDate());
   }
   function setDefaultDate(){ $('m_date').value = todayString(); }
-
-  // imgCache に data URL を登録。上限超過時は最古のエントリから削除（挿入順 = 古い順）。
-  function setImgCache(url, dataUrl){
-    if(!url || imgCache.hasOwnProperty(url)) { imgCache[url]=dataUrl; return; }
-    var keys = Object.keys(imgCache);
-    while(keys.length >= IMG_CACHE_MAX && keys.length > 0){ delete imgCache[keys.shift()]; }
-    imgCache[url]=dataUrl;
-  }
-
-  // === 最小 Markdown レンダラ（esc + safeUrl で安全に） ===
   function inline(t){
     t = esc(t);
-    t = t.replace(/!\\[([^\\]]*)\\]\\(([^)\\s]+)\\)/g, function(m,alt,url){ var src = imgCache[url] ? imgCache[url] : esc(safeUrl(url)); return '<img src="'+src+'" alt="'+alt+'">'; });
     t = t.replace(/\\[([^\\]]+)\\]\\(([^)\\s]+)\\)/g, function(m,tx,url){ return '<a href="'+esc(safeUrl(url))+'" target="_blank" rel="noopener">'+tx+'</a>'; });
     t = t.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
     t = t.replace(/(^|[^*])\\*([^*]+)\\*/g, '$1<em>$2</em>');
@@ -159,42 +122,16 @@ const JS = `
     $('m_prev').innerHTML = html || '<p class="meta">ここに表示されます。</p>';
   }
   function schedulePreview(){ if(_pvTimer) clearTimeout(_pvTimer); _pvTimer=setTimeout(updatePreview, 120); }
-
-  // === 画像アップロード（D&D / ペースト / ボタン） ===
-  // アップロード直後の画像はまだ本番にデプロイされていないため、プレビューは data URL で即表示する（本文 markdown は /images/... のまま）。
-  function insertAtCursor(text){
-    var ta=$('m_body'), s=ta.selectionStart, e=ta.selectionEnd;
-    ta.value = ta.value.slice(0,s) + text + ta.value.slice(e);
-    ta.selectionStart = ta.selectionEnd = s + text.length;
-    ta.focus(); updatePreview();
-  }
-  function uploadFile(file){
-    if(!file || !/^image\\//.test(file.type||'')){ $('m_imgMsg').textContent='画像ファイルのみ対応です'; return; }
-    $('m_imgMsg').innerHTML='<span class="spin" style="border-color:#1b2c40;border-top-color:transparent"></span>アップロード中…';
-    var reader=new FileReader();
-    reader.onerror=function(){ $('m_imgMsg').innerHTML='<span style="color:#dc2626">画像の読み込みに失敗しました</span>'; };
-    reader.onload=function(){
-      var dataUrl=String(reader.result||'');
-      var base64=dataUrl.split(',')[1]||'';
-      api('/api/upload-image', { filename:file.name||'image.png', dataBase64:base64 }).then(function(j){
-        setImgCache(j.url, dataUrl);
-        insertAtCursor('\\n![' + (file.name||'画像') + '](' + j.url + ')\\n');
-        $('m_imgMsg').textContent='挿入しました: '+j.url;
-      }).catch(function(e){ $('m_imgMsg').innerHTML='<span style="color:#dc2626">画像アップロード失敗: '+esc(e.message)+'</span>'; });
-    };
-    reader.readAsDataURL(file);
-  }
-
-  // === 入力データ収集 ===
   function gatherAll(){
     return {
       title:$('m_title').value,
-      summary:$('m_summary').value,
       desc:$('m_desc').value,
       cat:$('m_cat').value,
       tags:$('m_tags').value,
       slug:$('m_slug').value,
       publishedAt:$('m_date').value,
+      externalUrl:$('m_external').value,
+      source:$('m_source').value,
       featured:$('m_featured').checked,
       isDraft:$('m_draft_state').checked,
       body:$('m_body').value
@@ -203,12 +140,13 @@ const JS = `
   function applyDraft(d){
     if(!d) return;
     $('m_title').value = d.title || '';
-    $('m_summary').value = d.summary || '';
     $('m_desc').value = d.desc || '';
-    $('m_cat').value = d.cat || 'grift';
+    $('m_cat').value = d.cat || 'info';
     $('m_tags').value = d.tags || '';
     $('m_slug').value = d.slug || '';
     $('m_date').value = d.publishedAt || todayString();
+    $('m_external').value = d.externalUrl || '';
+    $('m_source').value = d.source || '';
     $('m_featured').checked = d.featured === true;
     $('m_draft_state').checked = d.isDraft === true;
     $('m_body').value = d.body || '';
@@ -217,7 +155,6 @@ const JS = `
   }
   function gather(){
     var tags = $('m_tags').value.split(',').map(function(s){ return s.trim(); }).filter(Boolean);
-    // URLの末尾は空欄ならタイトルから自動生成（非エンジニアは意識しない）
     var slug = $('m_slug').value.trim() || titleToSlug($('m_title').value);
     return {
       slug:slug,
@@ -226,103 +163,87 @@ const JS = `
       category:$('m_cat').value,
       tags:tags,
       body:$('m_body').value,
-      summary:$('m_summary').value.trim(),
       publishedAt:$('m_date').value,
+      externalUrl:$('m_external').value.trim(),
+      source:$('m_source').value.trim(),
       featured:$('m_featured').checked,
       isDraft:$('m_draft_state').checked
     };
   }
   function validateLocal(a){
     if(!a.title) return 'タイトルを入力してください';
-    if(!a.summary) return 'リード文を入力してください';
     if(!a.description) return '説明を入力してください';
     if(a.publishedAt && !/^\\d{4}-\\d{2}-\\d{2}$/.test(a.publishedAt)) return '公開日は YYYY-MM-DD で入力してください';
-    if(!a.body.trim()) return '本文を入力してください';
+    if(a.externalUrl && !/^https?:\\/\\//i.test(a.externalUrl)) return '外部URLは http(s) のURLを入力してください';
+    if(!a.externalUrl && !a.body.trim()) return '外部URLがないニュースは本文を入力してください';
     if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'URLの末尾は英小文字・数字・ハイフン（3〜80字）で指定してください';
     return '';
   }
   function renderViolations(v){
     if(v.length){ $('m_msg').innerHTML='<span style="color:#dc2626">違反 '+v.length+'件: '+esc(v.map(function(x){return x.name;}).join(', '))+'</span>'; }
-    else { $('m_msg').innerHTML='<span style="color:#16a34a">✓ 違反なし。公開できます</span>'; }
+    else { $('m_msg').innerHTML='<span style="color:#16a34a">✓ 違反なし。保存できます</span>'; }
   }
-
-  // === 下書き（LocalStorage 自動保存・復元） ===
   function scheduleDraftSave(){
     if(_draftTimer) clearTimeout(_draftTimer);
     _draftTimer = setTimeout(function(){ _draftTimer=null; saveDraft(DRAFT_KEY, gatherAll()); }, 800);
   }
   function cancelDraftSave(){ if(_draftTimer){ clearTimeout(_draftTimer); _draftTimer=null; } }
   function resetForm(){
-    $('m_title').value=''; $('m_summary').value=''; $('m_desc').value=''; $('m_cat').value='grift';
-    $('m_tags').value=''; $('m_slug').value=''; setDefaultDate(); $('m_featured').checked=false; $('m_draft_state').checked=false; $('m_body').value='';
-    slugEdited = false; imgCache = {};
+    $('m_title').value=''; $('m_desc').value=''; $('m_cat').value='info';
+    $('m_tags').value=''; $('m_slug').value=''; setDefaultDate(); $('m_external').value=''; $('m_source').value='';
+    $('m_featured').checked=false; $('m_draft_state').checked=false; $('m_body').value='';
+    slugEdited = false;
     updatePreview();
   }
 
-  // === 初期化 ===
   setDefaultDate();
   wireToolbar($('m_toolbar'), $('m_body'));
   (function(){
     var d = loadDraft(DRAFT_KEY);
-    if(d && (d.title || d.summary || d.desc || d.body)){ pendingDraft = d; $('m_draftBar').hidden = false; }
+    if(d && (d.title || d.desc || d.externalUrl || d.body)){ pendingDraft = d; $('m_draftBar').hidden = false; }
   })();
-
-  // === イベント束ね ===
   $('m_title').addEventListener('input', function(){
     if(!slugEdited){ $('m_slug').value = titleToSlug($('m_title').value); }
     scheduleDraftSave();
   });
   $('m_slug').addEventListener('input', function(){ slugEdited = !!($('m_slug').value.trim()); scheduleDraftSave(); });
-  $('m_summary').addEventListener('input', scheduleDraftSave);
   $('m_desc').addEventListener('input', scheduleDraftSave);
   $('m_tags').addEventListener('input', scheduleDraftSave);
   $('m_cat').addEventListener('change', scheduleDraftSave);
   $('m_date').addEventListener('change', scheduleDraftSave);
+  $('m_external').addEventListener('input', scheduleDraftSave);
+  $('m_source').addEventListener('input', scheduleDraftSave);
   $('m_featured').addEventListener('change', scheduleDraftSave);
   $('m_draft_state').addEventListener('change', scheduleDraftSave);
   $('m_body').addEventListener('input', function(){ schedulePreview(); scheduleDraftSave(); });
-
   $('m_restore').addEventListener('click', function(){ applyDraft(pendingDraft); $('m_draftBar').hidden = true; });
   $('m_discard').addEventListener('click', function(){ clearDraft(DRAFT_KEY); pendingDraft = null; $('m_draftBar').hidden = true; });
 
-  $('m_imgBtn').addEventListener('click', function(){ $('m_file').click(); });
-  $('m_file').addEventListener('change', function(){ for(var i=0;i<this.files.length;i++) uploadFile(this.files[i]); this.value=''; });
-  var ta=$('m_body');
-  ta.addEventListener('dragover', function(e){ e.preventDefault(); ta.classList.add('over'); });
-  ta.addEventListener('dragleave', function(){ ta.classList.remove('over'); });
-  ta.addEventListener('drop', function(e){ e.preventDefault(); ta.classList.remove('over'); var f=e.dataTransfer&&e.dataTransfer.files; if(f) for(var i=0;i<f.length;i++) uploadFile(f[i]); });
-  ta.addEventListener('paste', function(e){ var it=e.clipboardData&&e.clipboardData.items; if(!it) return; for(var i=0;i<it.length;i++){ if(it[i].type&&it[i].type.indexOf('image')===0){ var f=it[i].getAsFile(); if(f){ e.preventDefault(); uploadFile(f); } } } });
-
-  // === 公開前チェック ===
   $('m_check').addEventListener('click', function(){
     var a=gather(); var err=validateLocal(a);
     if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
     var btn=this; btn.disabled=true; $('m_msg').textContent='チェック中…';
-    api('/api/validate', { collection:'cases', article:a }).then(function(j){
+    api('/api/validate', { collection:'news', article:a }).then(function(j){
       renderViolations(j.violations||[]);
       btn.disabled=false;
     }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; });
   });
-
-  // === 実績記事を公開する（collection:'cases' を明示） ===
   $('m_pub').addEventListener('click', function(){
     var a=gather(); var err=validateLocal(a);
     if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }
-    var btn=this; btn.disabled=true; btn.innerHTML='<span class="spin"></span>公開中…'; $('m_msg').textContent='';
-    api('/api/publish', { collection:'cases', article:a }).then(function(j){
+    var btn=this; btn.disabled=true; btn.innerHTML='<span class="spin"></span>保存中…'; $('m_msg').textContent='';
+    api('/api/publish', { collection:'news', article:a }).then(function(j){
       var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
-      $('m_result').innerHTML='<div class="done">✓ 実績記事を公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
+      $('m_result').innerHTML='<div class="done">✓ ニュースを保存しました（数分でサイトに反映されます） '+link+'</div>';
       $('m_msg').textContent='';
       cancelDraftSave();
       clearDraft(DRAFT_KEY);
       pendingDraft = null;
       $('m_draftBar').hidden = true;
       resetForm();
-      btn.disabled=false; btn.innerHTML='実績記事を公開する';
-    }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.innerHTML='実績記事を公開する'; });
+      btn.disabled=false; btn.innerHTML='ニュースを保存する';
+    }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; btn.innerHTML='ニュースを保存する'; });
   });
-
-  // === 下書きをブラウザに保存（localStorage のみ・サーバーへは送信しない） ===
   $('m_draft').addEventListener('click', function(){
     var btn=this; btn.disabled=true;
     saveDraft(DRAFT_KEY, gatherAll());
@@ -330,9 +251,8 @@ const JS = `
     $('m_msg').textContent='';
     btn.disabled=false;
   });
-
   updatePreview();
 `;
 
-export const MANUAL_CASES_HTML =
-  head('実績作成 — 読みもの 作成スタジオ') + header('manual-cases') + BODY + tail(UI_KIT_JS + JS);
+export const MANUAL_NEWS_HTML =
+  head('ニュース作成 — 読みもの 作成スタジオ') + header('manual-news') + BODY + tail(UI_KIT_JS + JS);

--- a/workers/yomimono/src/ui-manual.ts
+++ b/workers/yomimono/src/ui-manual.ts
@@ -4,9 +4,7 @@ import { head, header, tail, toolbarButtonsHtml, draftBarHtml, UI_KIT_JS } from 
 // - slug は タイトルから自動生成（上級者は <details> で編集可・非エンジニアは触れない）
 // - ツールバーで太字/見出し/リンク等の Markdown 記号を挿入（insertMarkdown）
 // - LocalStorage 自動下書き（デバウンス保存・復元バー）+「下書きをブラウザに保存」（localStorage のみ）
-//   ※ サーバー下書き（isDraft:true コミット）は M1-I3 の updateArticle 実装まで非提供。
-//     現状の commitArticle は同 slug 重複を拒否するため、下書き保存→公開が同 slug で不可なため。
-//     validate.ts/index.ts の isDraft 伝播・テストは M1-I3 で使用するため維持（UIからの送信のみ削除）。
+// - サーバー下書き（isDraft:true）は通常公開と同じ新規作成として保存し、公開化は /edit から更新する。
 // - 画像はドラッグ&ドロップ/貼り付け/ボタンでアップロード（既存維持）。公開フロー・ガードレール不変。
 const BODY = `<main class="wide">
   ` + draftBarHtml('m') + `
@@ -21,6 +19,10 @@ const BODY = `<main class="wide">
     <div class="row" style="gap:14px;margin-top:10px">
       <div class="field" style="flex:1;min-width:220px;margin:0"><label>記事のまとめ（一覧に表示される短文）</label><input id="m_desc" placeholder="記事の要約。一覧やSNSで表示されます"></div>
       <div class="field" style="width:240px;margin:0"><label>タグ（カンマ区切り）</label><input id="m_tags" placeholder="AI, 業務効率"></div>
+    </div>
+    <div class="row" style="gap:14px;margin-top:10px">
+      <div class="field" style="width:170px;margin:0"><label>公開日</label><input id="m_date" type="date"></div>
+      <label class="checkline" style="margin:0"><input id="m_draft_state" type="checkbox"> 下書きとして保存する</label>
     </div>
     <details class="advanced"><summary>URLを編集する（上級者向け）</summary>
       <div class="field" style="margin-top:8px"><label>URLの末尾（英小文字/数字/ハイフン・空欄でタイトルから自動生成）</label><input id="m_slug" placeholder="自動生成されます"></div>
@@ -75,6 +77,12 @@ const JS = `
   var IMG_CACHE_MAX = 20; // プレビュー用 data URL のキャッシュ上限（古いものから破棄）
   var _pvTimer = null;
   var _draftTimer = null; // 下書き自動保存タイマー（公開成功時にキャンセルして競合防止）
+
+  function todayString(){
+    var d=new Date(), p=function(n){return (n<10?'0':'')+n;};
+    return d.getFullYear()+'-'+p(d.getMonth()+1)+'-'+p(d.getDate());
+  }
+  function setDefaultDate(){ $('m_date').value = todayString(); }
 
   // imgCache に data URL を登録。上限超過時は最古のエントリから削除（挿入順 = 古い順）。
   function setImgCache(url, dataUrl){
@@ -157,7 +165,7 @@ const JS = `
 
   // === 入力データ収集 ===
   function gatherAll(){
-    return { title:$('m_title').value, desc:$('m_desc').value, cat:$('m_cat').value, tags:$('m_tags').value, slug:$('m_slug').value, body:$('m_body').value };
+    return { title:$('m_title').value, desc:$('m_desc').value, cat:$('m_cat').value, tags:$('m_tags').value, slug:$('m_slug').value, pubDate:$('m_date').value, isDraft:$('m_draft_state').checked, body:$('m_body').value };
   }
   function applyDraft(d){
     if(!d) return;
@@ -166,6 +174,8 @@ const JS = `
     $('m_cat').value = d.cat || 'ai';
     $('m_tags').value = d.tags || '';
     $('m_slug').value = d.slug || '';
+    $('m_date').value = d.pubDate || todayString();
+    $('m_draft_state').checked = d.isDraft === true;
     $('m_body').value = d.body || '';
     slugEdited = !!($('m_slug').value.trim());
     updatePreview();
@@ -174,11 +184,12 @@ const JS = `
     var tags = $('m_tags').value.split(',').map(function(s){ return s.trim(); }).filter(Boolean);
     // slug は空欄ならタイトルから自動生成（slug 隠蔽・非エンジニアは意識しない）
     var slug = $('m_slug').value.trim() || titleToSlug($('m_title').value);
-    return { slug: slug, title: $('m_title').value.trim(), description: $('m_desc').value.trim(), category: $('m_cat').value, tags: tags, body: $('m_body').value };
+    return { slug: slug, title: $('m_title').value.trim(), description: $('m_desc').value.trim(), category: $('m_cat').value, tags: tags, pubDate:$('m_date').value, body: $('m_body').value, isDraft:$('m_draft_state').checked };
   }
   function validateLocal(a){
     if(!a.title) return 'タイトルを入力してください';
     if(!a.description) return '記事のまとめを入力してください';
+    if(a.pubDate && !/^\\d{4}-\\d{2}-\\d{2}$/.test(a.pubDate)) return '公開日は YYYY-MM-DD で入力してください';
     if(!a.body.trim()) return '本文を入力してください';
     if(!/^[a-z0-9-]{3,80}$/.test(a.slug)) return 'URLの末尾は英小文字・数字・ハイフン（3〜80字）で指定してください';
     return '';
@@ -194,12 +205,13 @@ const JS = `
   function cancelDraftSave(){ if(_draftTimer){ clearTimeout(_draftTimer); _draftTimer=null; } }
   function resetForm(){
     $('m_title').value=''; $('m_desc').value=''; $('m_cat').value='ai';
-    $('m_tags').value=''; $('m_slug').value=''; $('m_body').value='';
+    $('m_tags').value=''; $('m_slug').value=''; setDefaultDate(); $('m_draft_state').checked=false; $('m_body').value='';
     slugEdited = false; imgCache = {};
     updatePreview();
   }
 
   // === 初期化 ===
+  setDefaultDate();
   wireToolbar($('m_toolbar'), $('m_body'));
   (function(){
     var d = loadDraft(DRAFT_KEY);
@@ -215,6 +227,8 @@ const JS = `
   $('m_desc').addEventListener('input', scheduleDraftSave);
   $('m_tags').addEventListener('input', scheduleDraftSave);
   $('m_cat').addEventListener('change', scheduleDraftSave);
+  $('m_date').addEventListener('change', scheduleDraftSave);
+  $('m_draft_state').addEventListener('change', scheduleDraftSave);
   $('m_body').addEventListener('input', function(){ schedulePreview(); scheduleDraftSave(); });
 
   $('m_restore').addEventListener('click', function(){ applyDraft(pendingDraft); $('m_draftBar').hidden = true; });
@@ -241,7 +255,7 @@ const JS = `
     }).catch(function(e){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>'; btn.disabled=false; });
   });
 
-  // === 公開する（article のみ送信・isDraft は既定 false） ===
+  // === 公開する（isDraft:true ならサーバー下書きとして保存） ===
   $('m_pub').addEventListener('click', function(){
     var a=gather(); var err=validateLocal(a);
     if(err){ $('m_msg').innerHTML='<span style="color:#dc2626">'+esc(err)+'</span>'; return; }

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -155,8 +155,9 @@ export function header(active: 'hub' | 'ai' | 'manual' | 'edit' | 'manual-news' 
     link('/', 'ハブ', 'hub') +
     link('/ai', 'AI生成', 'ai') +
     link('/manual', 'ブログ作成', 'manual') +
+    link('/manual/news', 'ニュース作成', 'manual-news') +
     link('/manual/cases', '実績作成', 'manual-cases') +
-    link('/edit', '既存記事を編集', 'edit') +
+    link('/edit', '既存編集', 'edit') +
     '</nav></div></header>'
   );
 }

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -59,9 +59,15 @@ export function sanitizeText(s: unknown, maxLen: number): string {
 }
 
 // http(s) URL のみ受理（javascript: / data: 等の危険なスキームを排除）。
-const HTTP_URL_RE = /^https?:\/\//i;
 export function isHttpUrl(s: string): boolean {
-  return HTTP_URL_RE.test(s);
+  const value = String(s ?? '').trim();
+  if (!value || /\s/.test(value)) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 // YYYY-MM-DD 形式かつ実在する暦日付か検証（2026-99-99・2026-02-30 等のロールオーバーを拒否）。

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -104,7 +104,9 @@ export interface ArticleInput {
   category?: string;
   tags?: unknown;
   body?: string;
+  pubDate?: string;
   externalUrl?: string;
+  source?: string;
   summary?: string;
   publishedAt?: string;
   featured?: boolean;
@@ -117,7 +119,9 @@ type NormalizedArticleCommon = {
   description: string;
   tags: string[];
   body: string;
+  pubDate?: string;
   externalUrl?: string;
+  source?: string;
   summary?: string;
   publishedAt?: string;
   featured?: boolean;
@@ -175,7 +179,12 @@ export function normalizeArticle(
       ? a.tags.slice(0, 10).map((t) => sanitizeText(t, 50)).filter(Boolean)
       : [],
     body: String(a.body ?? '').slice(0, 100_000),
+    pubDate:
+      a.pubDate && isValidCalendarDate(a.pubDate)
+        ? sanitizeText(a.pubDate, 10)
+        : undefined,
     externalUrl: validExternalUrl,
+    source: a.source ? sanitizeText(a.source, 200) : undefined,
     summary: a.summary ? sanitizeText(a.summary, 1000) : undefined,
     publishedAt:
       a.publishedAt && isValidCalendarDate(a.publishedAt)

--- a/workers/yomimono/src/validate.ts
+++ b/workers/yomimono/src/validate.ts
@@ -199,6 +199,9 @@ export function normalizeArticle(
     featured: a.featured === true,
     isDraft: a.isDraft === true,
   };
+  if (coll === 'cases' && !common.summary) {
+    return { ok: false, error: 'article.summary は必須です', status: 400 };
+  }
   // coll をリテラル狭めし、各コレクションの厳密な category 型を持つユニオンメンバを構築する。
   let article: NormalizedArticle;
   if (coll === 'news') {


### PR DESCRIPTION
## ① なぜ

企業サイトの運用導線として、ブログ・ニュース・実績が別々の未完成UI/未対応APIに分かれていると、非エンジニアが公開コンテンツを一貫して管理できません。#232 の統合CMSレーンとして、作成・既存編集・公開前チェック・更新を collection 別に扱えるようにします。

Refs #232

## ② どう実装したか

- `NEWS_NOT_READY_MSG` による news 拒否を撤去
- `validate / publish / recent / articles / article / update` を `blog / news / cases` 対応へ拡張
- Markdown parse/rebuild を collection-aware にし、既存 frontmatter と `sha` conflict 検出を維持
- `/edit` を `ブログ / ニュース / 実績` の統合編集UIへ変更
- Hub を `ブログを書く / ニュースを書く / 実績を書く / 既存コンテンツを編集` に整理
- ニュース手動作成UIを追加し、`externalUrl` ありなら本文なし可、なしなら本文必須にした
- blog/cases の手動UIも公開日・draft・featured 等の統合編集と整合するように調整

## ③ 特にレビューしてほしい点

- collection 切替時に GitHub content path が `blog/news/cases` で誤らないか
- `/api/update` が slug 変更不可と `sha` conflict を維持できているか
- news の `externalUrl` あり/なし、body 必須条件、draft/featured/source/tags の扱い
- self-contained CMS UI の inline script/string escape に明確なXSSやHTML injectionの穴がないか
- 差分は大きいですが、API契約とUIが密結合のためこのPRを統合CMSの1 intentとして扱っています

## ④ テスト内容・確認方法

- `npm --prefix workers/yomimono test`
- `npm --prefix workers/yomimono run typecheck`
- `git diff --check`

ローカル結果:

- Worker unit tests: 10 files / 220 tests passed
- TypeScript: `tsc --noEmit` passed
- whitespace check: passed

## Live evidence

このPR単体では未取得です。merge 後、Cloudflare Worker route でログイン後に以下を確認します。

- `/blog-admin/`
- `/blog-admin/manual`
- `/blog-admin/manual/news`
- `/blog-admin/manual/cases`
- `/blog-admin/edit` の blog/news/cases 一覧・フォーム読込
