### PR TITLE
feat(yomimono): CMSの非公開化と削除を追加

### DIFF
--- a/workers/yomimono/src/__tests__/github.test.ts
+++ b/workers/yomimono/src/__tests__/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { contentDir, readBlogArticle, updateBlogArticle } from '../github';
+import { contentDir, deleteBlogArticle, readBlogArticle, updateBlogArticle } from '../github';
 import type { Env } from '../types';
 
 function utf8ToBase64(str: string): string {
@@ -140,5 +140,45 @@ isDraft: false
       content: utf8ToBase64(markdown),
       sha: 'file-sha',
     });
+  });
+
+  it('deleteBlogArticle は sha 付き DELETE で対象collectionのMarkdownだけを削除する', async () => {
+    const request = vi.fn(async () => ({
+      data: { commit: { html_url: 'https://github.com/test/commit/delete' } },
+    }));
+    const result = await deleteBlogArticle(
+      mockEnv,
+      { request } as never,
+      'news-target',
+      'news-sha',
+      'editor@example.com',
+      'news',
+    );
+
+    expect(result).toEqual({
+      deleted: true,
+      path: 'src/content/news/news-target.md',
+      commitUrl: 'https://github.com/test/commit/delete',
+    });
+    expect(request).toHaveBeenCalledWith('DELETE /repos/{owner}/{repo}/contents/{path}', {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      path: 'src/content/news/news-target.md',
+      branch: 'main',
+      message: 'news(yomimono): news-target（削除: editor）',
+      sha: 'news-sha',
+    });
+  });
+
+  it('deleteBlogArticle は GitHub 409 を同時編集エラーに変換する', async () => {
+    const request = vi.fn(async () => {
+      const error = new Error('Conflict') as Error & { status?: number };
+      error.status = 409;
+      throw error;
+    });
+
+    await expect(
+      deleteBlogArticle(mockEnv, { request } as never, 'edit-target', 'stale-sha', 'editor@example.com'),
+    ).rejects.toThrow('記事が別の編集で更新されています。開き直してから削除してください');
   });
 });

--- a/workers/yomimono/src/__tests__/index-cases.test.ts
+++ b/workers/yomimono/src/__tests__/index-cases.test.ts
@@ -3,6 +3,7 @@ import type { Env } from '../types';
 
 const mocks = vi.hoisted(() => ({
   commitArticle: vi.fn(),
+  deleteBlogArticle: vi.fn(),
   listArticleSlugs: vi.fn(),
   listBlogArticles: vi.fn(),
   readBlogArticle: vi.fn(),
@@ -20,6 +21,7 @@ vi.mock('../github', () => ({
   makeOctokit: vi.fn(() => ({ mocked: true })),
   getFileContent: vi.fn(),
   commitArticle: mocks.commitArticle,
+  deleteBlogArticle: mocks.deleteBlogArticle,
   commitImage: vi.fn(),
   listArticleSlugs: mocks.listArticleSlugs,
   listBlogArticles: mocks.listBlogArticles,
@@ -131,6 +133,11 @@ describe('yomimono Worker — cases CMS posting path', () => {
       path: 'src/content/news/external-news.md',
       commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/update-news',
     });
+    mocks.deleteBlogArticle.mockResolvedValue({
+      deleted: true,
+      path: 'src/content/news/external-news.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/delete-news',
+    });
   });
 
   it('GET /manual/cases は cases 投稿 UI を返し、collection 指定の publish/validate を含む', async () => {
@@ -211,6 +218,19 @@ describe('yomimono Worker — cases CMS posting path', () => {
       },
     });
     expect(mocks.readBlogArticle).toHaveBeenCalledWith(env, { mocked: true }, 'external-news', 'news');
+  });
+
+  it('GET /edit は非公開化と二段確認付き削除UIを返す', async () => {
+    const res = await worker.fetch(req('/blog-admin/edit'), env);
+    const html = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(html).toContain('公開サイトから非表示にする');
+    expect(html).toContain('完全削除を開く（管理操作）');
+    expect(html).toContain('公開停止だけなら削除ではなく非公開化を使うことを理解しました');
+    expect(html).toContain('GitHubから完全削除する');
+    expect(html).toContain("postJson('/api/unpublish'");
+    expect(html).toContain("postJson('/api/delete'");
   });
 
   it('POST /api/validate は cases article を cases markdown として検査する', async () => {
@@ -354,5 +374,166 @@ describe('yomimono Worker — cases CMS posting path', () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'slug は変更できません。記事を開き直してください' });
     expect(mocks.updateBlogArticle).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/unpublish は既存newsを isDraft true に更新する', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/unpublish', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'news',
+          originalSlug: 'external-news',
+          sha: 'news-sha',
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      updated: true,
+      unpublished: true,
+      path: 'src/content/news/external-news.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/update-news',
+    });
+    const [_env, _octokit, slug, markdown, sha, _editor, collection] = mocks.updateBlogArticle.mock.calls[0];
+    expect(slug).toBe('external-news');
+    expect(markdown).toContain('isDraft: true');
+    expect(markdown).toContain('externalUrl: "https://example.com/article"');
+    expect(sha).toBe('news-sha');
+    expect(collection).toBe('news');
+  });
+
+  it('POST /api/unpublish は不正collectionをblogへフォールバックせず拒否する', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/unpublish', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'invalid',
+          originalSlug: 'external-news',
+          confirmSlug: 'external-news',
+          sha: 'news-sha',
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'collection は blog / news / cases のいずれかを指定してください' });
+    expect(mocks.updateBlogArticle).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/delete は確認slugとsha付きでGitHub file deleteを呼ぶ', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'news',
+          originalSlug: 'external-news',
+          confirmSlug: 'external-news',
+          confirmDelete: true,
+          sha: 'news-sha',
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      deleted: true,
+      path: 'src/content/news/external-news.md',
+      commitUrl: 'https://github.com/Cor-Incorporated/corsweb2024/commit/delete-news',
+    });
+    expect(mocks.deleteBlogArticle).toHaveBeenCalledWith(env, { mocked: true }, 'external-news', 'news-sha', 'yomimono', 'news');
+  });
+
+  it('POST /api/delete は確認slug不一致を拒否する', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'news',
+          originalSlug: 'external-news',
+          confirmSlug: 'other-news',
+          confirmDelete: true,
+          sha: 'news-sha',
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: '確認用URLが一致しません。削除を中止しました' });
+    expect(mocks.deleteBlogArticle).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/delete は confirmDelete 欠落を拒否する', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'news',
+          originalSlug: 'external-news',
+          confirmSlug: 'external-news',
+          sha: 'news-sha',
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: '完全削除の確認が必要です' });
+    expect(mocks.deleteBlogArticle).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/delete は不正collectionをblogへフォールバックせず拒否する', async () => {
+    const res = await worker.fetch(
+      req('/blog-admin/api/delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'invalid',
+          originalSlug: 'external-news',
+          confirmSlug: 'external-news',
+          confirmDelete: true,
+          sha: 'news-sha',
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'collection は blog / news / cases のいずれかを指定してください' });
+    expect(mocks.deleteBlogArticle).not.toHaveBeenCalled();
+  });
+
+  it('POST /api/delete は sha conflict を409で返す', async () => {
+    mocks.deleteBlogArticle.mockRejectedValueOnce(
+      new Error('記事が別の編集で更新されています。開き直してから削除してください'),
+    );
+    const res = await worker.fetch(
+      req('/blog-admin/api/delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          collection: 'news',
+          originalSlug: 'external-news',
+          confirmSlug: 'external-news',
+          confirmDelete: true,
+          sha: 'stale-sha',
+        }),
+      }),
+      env,
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({
+      error: '記事が別の編集で更新されています。開き直してから削除してください',
+    });
   });
 });

--- a/workers/yomimono/src/github.ts
+++ b/workers/yomimono/src/github.ts
@@ -200,6 +200,41 @@ export async function updateBlogArticle(
   }
 }
 
+export async function deleteBlogArticle(
+  env: Env,
+  octokit: Octokit,
+  slug: string,
+  sha: string,
+  authorEmail: string,
+  collection: Collection = 'blog',
+): Promise<{ deleted: true; path: string; commitUrl: string }> {
+  const path = blogArticlePath(env, slug, collection);
+  if (!sha) throw new Error('削除元の記事情報が不足しています。記事を開き直してください');
+
+  const author = authorEmail.split('@')[0];
+  const prefix = collection === 'news' ? 'news' : collection === 'cases' ? 'case' : 'post';
+  try {
+    const res = await octokit.request('DELETE /repos/{owner}/{repo}/contents/{path}', {
+      owner: env.GH_OWNER,
+      repo: env.GH_REPO,
+      path,
+      branch: env.PUBLISH_BRANCH,
+      message: `${prefix}(yomimono): ${slug}（削除: ${author}）`,
+      sha,
+    });
+    const data = res.data as { commit?: { html_url?: string } };
+    return { deleted: true, path, commitUrl: data.commit?.html_url ?? '' };
+  } catch (e: unknown) {
+    if ((e as { status?: number }).status === 409) {
+      throw new Error('記事が別の編集で更新されています。開き直してから削除してください');
+    }
+    if ((e as { status?: number }).status === 404) {
+      throw new Error('記事が見つかりません。すでに削除されている可能性があります');
+    }
+    throw e;
+  }
+}
+
 // 記事 .md を PUBLISH_BRANCH（既定 main）へコミット。
 // content-bot はこのパス（記事のみ）にしか書かない＝コードには触れない。
 export async function commitArticle(

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -13,6 +13,7 @@ import {
   getFileContent,
   commitArticle,
   commitImage,
+  deleteBlogArticle,
   listArticleSlugs,
   listBlogArticles,
   readBlogArticle,
@@ -160,6 +161,13 @@ function buildCollectionMarkdown(article: NormalizedArticle): string {
   if (article.collection === 'news') return buildNewsMarkdown(article, article.isDraft);
   if (article.collection === 'cases') return buildCasesMarkdown(article, article.isDraft);
   return buildMarkdown(article, article.isDraft);
+}
+
+function requireCollection(raw: unknown): { ok: true; collection: Collection } | { ok: false; error: string } {
+  if (raw === 'blog' || raw === 'news' || raw === 'cases') {
+    return { ok: true, collection: raw };
+  }
+  return { ok: false, error: 'collection は blog / news / cases のいずれかを指定してください' };
 }
 
 export default {
@@ -408,6 +416,84 @@ export default {
           return json(result);
         } catch (e: unknown) {
           if (e instanceof Error && /^記事が|^更新元/.test(e.message)) {
+            return json({ error: e.message }, 409);
+          }
+          throw e;
+        }
+      }
+
+      // 既存コンテンツを非公開化する。ファイルは残し、isDraft:true へ更新する。
+      if (req.method === 'POST' && path === '/api/unpublish') {
+        const body = await readJsonBody(req);
+        if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
+        const coll = requireCollection(body.collection);
+        if (!coll.ok) return json({ error: coll.error }, 400);
+        const collection = coll.collection;
+        const sha = typeof body.sha === 'string' ? body.sha : '';
+        if (!sha) return json({ error: '更新元の記事情報がありません。記事を開き直してください' }, 400);
+        const originalSlug = typeof body.originalSlug === 'string' ? body.originalSlug : '';
+        const confirmSlug = typeof body.confirmSlug === 'string' ? body.confirmSlug : originalSlug;
+        if (!originalSlug || !confirmSlug) return json({ error: 'slug は必須です' }, 400);
+        try {
+          assertSlug(originalSlug);
+          assertSlug(confirmSlug);
+        } catch (e) {
+          return json({ error: e instanceof Error ? e.message : 'slug が不正です' }, 400);
+        }
+        if (originalSlug !== confirmSlug) {
+          return json({ error: '確認用URLが一致しません。非公開化を中止しました' }, 400);
+        }
+        const octokit = makeOctokit(env);
+        const existing = await readBlogArticle(env, octokit, originalSlug, collection);
+        const norm = normalizeArticle({ ...existing.article, isDraft: true }, collection);
+        if (!norm.ok) return json({ error: norm.error }, norm.status);
+        const markdown = rebuildArticleMarkdown(existing.markdown, norm.article);
+        try {
+          const result = await updateBlogArticle(env, octokit, originalSlug, markdown, sha, EDITOR, collection);
+          return json({ ...result, unpublished: true });
+        } catch (e: unknown) {
+          if (e instanceof Error && /^記事が|^更新元/.test(e.message)) {
+            return json({ error: e.message }, 409);
+          }
+          throw e;
+        }
+      }
+
+      // 既存コンテンツを GitHub Contents API で削除する。破壊的操作のため sha と slug 再入力を必須にする。
+      if (req.method === 'POST' && path === '/api/delete') {
+        const body = await readJsonBody(req);
+        if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);
+        const coll = requireCollection(body.collection);
+        if (!coll.ok) return json({ error: coll.error }, 400);
+        const collection = coll.collection;
+        const sha = typeof body.sha === 'string' ? body.sha : '';
+        if (!sha) return json({ error: '削除元の記事情報がありません。記事を開き直してください' }, 400);
+        const originalSlug = typeof body.originalSlug === 'string' ? body.originalSlug : '';
+        const confirmSlug = typeof body.confirmSlug === 'string' ? body.confirmSlug : '';
+        if (body.confirmDelete !== true) {
+          return json({ error: '完全削除の確認が必要です' }, 400);
+        }
+        if (!originalSlug || !confirmSlug) {
+          return json({ error: '削除するURLを確認入力してください' }, 400);
+        }
+        try {
+          assertSlug(originalSlug);
+          assertSlug(confirmSlug);
+        } catch (e) {
+          return json({ error: e instanceof Error ? e.message : 'slug が不正です' }, 400);
+        }
+        if (originalSlug !== confirmSlug) {
+          return json({ error: '確認用URLが一致しません。削除を中止しました' }, 400);
+        }
+        const octokit = makeOctokit(env);
+        try {
+          const result = await deleteBlogArticle(env, octokit, originalSlug, sha, EDITOR, collection);
+          return json(result);
+        } catch (e: unknown) {
+          if (e instanceof Error && /^記事が見つかりません/.test(e.message)) {
+            return json({ error: e.message }, 404);
+          }
+          if (e instanceof Error && /^記事が|^削除元/.test(e.message)) {
             return json({ error: e.message }, 409);
           }
           throw e;

--- a/workers/yomimono/src/ui-edit.ts
+++ b/workers/yomimono/src/ui-edit.ts
@@ -53,6 +53,21 @@ const BODY = `<main class="wide">
         <span class="meta" id="e_msg"></span>
       </div>
       <div id="e_result"></div>
+      <section class="danger-zone" id="e_danger_box" aria-labelledby="e_danger_title">
+        <h3 id="e_danger_title">非公開化・削除</h3>
+        <p>通常は削除せず、まず下書き化してサイト上の一覧や詳細から非表示にしてください。完全削除はGitHub上のMarkdownファイルを削除します。</p>
+        <div class="row">
+          <button class="warn-btn" id="e_unpublish" type="button">公開サイトから非表示にする</button>
+          <span class="meta" id="e_danger_msg"></span>
+        </div>
+        <details id="e_delete_details">
+          <summary>完全削除を開く（管理操作）</summary>
+          <p>削除するとこのCMSから復元できません。削除前に対象URLをもう一度確認してください。</p>
+          <label class="checkline"><input id="e_delete_ack" type="checkbox"> 公開停止だけなら削除ではなく非公開化を使うことを理解しました</label>
+          <div class="field"><label>削除するURLを入力</label><input id="e_delete_confirm" autocomplete="off" placeholder="表示中のURLを入力"></div>
+          <button class="danger-btn" id="e_delete" type="button" disabled>GitHubから完全削除する</button>
+        </details>
+      </section>
     </section>
   </div>
 </main>`;
@@ -116,6 +131,11 @@ const JS = `
     $('e_original_slug').value = '';
     $('e_result').innerHTML = '';
     $('e_msg').textContent = '';
+    $('e_danger_msg').textContent = '';
+    $('e_delete_ack').checked = false;
+    $('e_delete_confirm').value = '';
+    $('e_delete').disabled = true;
+    $('e_delete_details').open = false;
   }
   function emptyHtml(){
     return '<div class="empty">'+esc(cfg().label)+'はまだ見つかりません。<br><a href="'+esc(BASE+cfg().newPath)+'">'+esc(cfg().label)+'を書く</a></div>';
@@ -166,6 +186,11 @@ const JS = `
       $('e_body').value=a.body||'';
       $('e_featured').checked=a.featured===true;
       $('e_draft').checked=a.isDraft===true;
+      $('e_danger_msg').textContent='';
+      $('e_delete_ack').checked=false;
+      $('e_delete_confirm').value='';
+      $('e_delete').disabled=true;
+      $('e_delete_details').open=false;
       $('e_form_box').hidden=false;
       $('e_msg').textContent=cfg().label+'を読み込みました';
     }).catch(function(e){
@@ -244,6 +269,51 @@ const JS = `
       loadList();
     }).catch(function(e){
       $('e_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>';
+      setBusy(btn,false,'');
+    });
+  });
+  $('e_unpublish').setAttribute('data-label','公開サイトから非表示にする');
+  $('e_unpublish').addEventListener('click',function(){
+    var slug=$('e_original_slug').value;
+    if(!slug || !$('e_sha').value){ $('e_danger_msg').innerHTML='<span style="color:#dc2626">記事を開き直してください</span>'; return; }
+    if(!confirm(cfg().label+'「'+slug+'」を下書き化し、公開サイトから非表示にします。GitHub上のファイルは削除しません。')) return;
+    var btn=this; setBusy(btn,true,'非公開化中...'); $('e_danger_msg').textContent='更新中...'; $('e_result').innerHTML='';
+    postJson('/api/unpublish',{collection:currentCollection,originalSlug:slug,confirmSlug:slug,sha:$('e_sha').value}).then(function(j){
+      var link=j&&j.commitUrl?'<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>':'';
+      $('e_result').innerHTML='<div class="done">下書き化しました。数分でサイトから非表示になります。 '+link+'</div>';
+      $('e_draft').checked=true;
+      $('e_danger_msg').textContent='';
+      setBusy(btn,false,'');
+      loadArticle(slug);
+    }).catch(function(e){
+      $('e_danger_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>';
+      setBusy(btn,false,'');
+    });
+  });
+  function updateDeleteReady(){
+    var slug=$('e_original_slug').value;
+    $('e_delete').disabled=!($('e_delete_ack').checked && $('e_delete_confirm').value.trim()===slug && slug && $('e_sha').value);
+  }
+  $('e_delete_ack').addEventListener('change',updateDeleteReady);
+  $('e_delete_confirm').addEventListener('input',updateDeleteReady);
+  $('e_delete').setAttribute('data-label','GitHubから完全削除する');
+  $('e_delete').addEventListener('click',function(){
+    var slug=$('e_original_slug').value;
+    var confirmSlug=$('e_delete_confirm').value.trim();
+    if(!$('e_delete_ack').checked){ $('e_danger_msg').innerHTML='<span style="color:#dc2626">削除確認のチェックを入れてください</span>'; return; }
+    if(confirmSlug!==slug){ $('e_danger_msg').innerHTML='<span style="color:#dc2626">確認用URLが一致しません</span>'; return; }
+    if(!slug || !$('e_sha').value){ $('e_danger_msg').innerHTML='<span style="color:#dc2626">記事を開き直してください</span>'; return; }
+    if(!confirm(cfg().label+'「'+slug+'」のMarkdownファイルをGitHubから完全削除します。この操作は通常更新とは別操作で、元に戻せません。')) return;
+    var btn=this; setBusy(btn,true,'削除中...'); $('e_danger_msg').textContent='削除中...'; $('e_result').innerHTML='';
+    postJson('/api/delete',{collection:currentCollection,originalSlug:slug,confirmSlug:confirmSlug,confirmDelete:true,sha:$('e_sha').value}).then(function(j){
+      var link=j&&j.commitUrl?'<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>':'';
+      $('e_result').innerHTML='<div class="done">削除しました。数分でサイトから消えます。 '+link+'</div>';
+      $('e_danger_msg').textContent='';
+      setBusy(btn,false,'');
+      resetForm();
+      loadList();
+    }).catch(function(e){
+      $('e_danger_msg').innerHTML='<span style="color:#dc2626">'+esc(e.message)+'</span>';
       setBusy(btn,false,'');
     });
   });

--- a/workers/yomimono/src/ui-shared.ts
+++ b/workers/yomimono/src/ui-shared.ts
@@ -27,6 +27,9 @@ export const CSS = `
   .ghost { background:#eef2f7; color:var(--ink); }
   .pub { background:var(--ok); color:#fff; }
   .pub:disabled { background:#bbb; cursor:not-allowed; }
+  .warn-btn { background:#fef3c7; color:#92400e; }
+  .danger-btn { background:var(--warn); color:#fff; }
+  .danger-btn:disabled { background:#f3a8a8; cursor:not-allowed; }
   .card { border:1px solid var(--line); border-radius:12px; padding:14px; margin:10px 0; }
   .card.sel { border-color:var(--accent); background:#f0f6ff; }
   .card label { display:flex; gap:10px; align-items:flex-start; cursor:pointer; }
@@ -50,6 +53,11 @@ export const CSS = `
   .done { background:#f0fdf4; border:1px solid #bbf7d0; color:#166534; border-radius:8px; padding:10px 12px; font-size:13px; }
   .done a { color:#166534; }
   .err { background:#fff1f2; border:1px solid #fecaca; color:#991b1b; border-radius:8px; padding:10px 12px; font-size:13px; margin:8px 0; }
+  .danger-zone { border:1px solid #fecaca; border-radius:12px; padding:16px; margin-top:18px; background:#fffafa; }
+  .danger-zone h3 { margin:0 0 4px; color:#991b1b; font-size:14px; }
+  .danger-zone p { margin:0 0 10px; color:#7f1d1d; font-size:12px; }
+  .danger-zone details { margin-top:12px; }
+  .danger-zone summary { cursor:pointer; color:#991b1b; font-size:12px; font-weight:700; }
   .spin { display:inline-block; width:15px; height:15px; border:2px solid #fff; border-top-color:transparent; border-radius:50%; animation:sp .8s linear infinite; vertical-align:-2px; margin-right:6px; }
   @keyframes sp { to { transform:rotate(360deg); } }
   .row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }


### PR DESCRIPTION
## ① なぜ
#235 で確認された通り、統合CMSは blog/news/cases の作成・取得・更新まではできる一方で、CRUDのDに相当する削除と、削除前に使うべき非公開化導線がありませんでした。企業サイトの公開コンテンツ管理として、誤削除を避けながら公開停止できる操作が必要です。

## ② どう実装したか
- `/api/unpublish` を追加し、既存Markdownは残したまま `isDraft: true` へ更新できるようにしました。
- `/api/delete` と `deleteBlogArticle` を追加し、GitHub Contents API の `DELETE /contents/{path}` を `sha` 必須で呼び出すようにしました。
- 削除系APIでは `collection` の不正値を `blog` へフォールバックせず、`blog / news / cases` 以外を400で拒否します。
- 既存編集UIに「非公開化・削除」セクションを追加し、通常更新とは分離しました。
- 完全削除はチェックボックス、slug再入力、最終confirm、`confirmDelete:true` の4条件を通さないと実行されないようにしました。

## ③ 特にレビューしてほしい点
- `sha` を使った同時編集/古い画面対策が十分か。
- `collection` と `slug` の信用境界が安全に閉じているか。
- 非公開化を通常導線、完全削除を管理操作として分離できているか。

## ④ テスト内容・確認方法
- `npm --prefix workers/yomimono test`（10 files / 239 tests）
- `npm --prefix workers/yomimono run typecheck`
- `git diff --check`

Refs #235
