### PR TITLE
fix(yomimono): CMSの管理対象branchを明示

### DIFF
--- a/.github/workflows/deploy-yomimono-worker.yml
+++ b/.github/workflows/deploy-yomimono-worker.yml
@@ -1,0 +1,95 @@
+name: Deploy Yomimono Worker
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - 'workers/yomimono/**'
+      - '.github/workflows/deploy-yomimono-worker.yml'
+  workflow_dispatch:
+    inputs:
+      publish_branch:
+        description: 'Worker が読み書きする branch'
+        required: true
+        default: develop
+        type: choice
+        options:
+          - develop
+          - main
+
+permissions:
+  contents: read
+
+jobs:
+  deploy_yomimono_worker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: workers/yomimono/package-lock.json
+
+      - name: Install Worker dependencies
+        working-directory: workers/yomimono
+        run: npm ci
+
+      - name: Typecheck Worker
+        working-directory: workers/yomimono
+        run: npm run typecheck
+
+      - name: Test Worker
+        working-directory: workers/yomimono
+        run: npm test
+
+      - name: Resolve publish branch
+        id: branch
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            publish_branch="${{ inputs.publish_branch }}"
+          else
+            publish_branch="${GITHUB_REF_NAME}"
+          fi
+
+          case "$publish_branch" in
+            develop|main) ;;
+            *)
+              echo "Unsupported publish branch: $publish_branch" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "publish_branch=$publish_branch" >> "$GITHUB_OUTPUT"
+          echo "PUBLISH_BRANCH=$publish_branch" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Check Cloudflare API token
+        id: cloudflare_token
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Cloudflare API token missing::Set repository secret CLOUDFLARE_API_TOKEN to enable Worker deploy."
+            {
+              echo "Cloudflare deploy was skipped because CLOUDFLARE_API_TOKEN is not configured."
+              echo "Follow docs/cloudflare-api-token-request.md before relying on CI/CD deploy."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy Worker
+        if: steps.cloudflare_token.outputs.available == 'true'
+        working-directory: workers/yomimono
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npm exec -- wrangler deploy --var PUBLISH_BRANCH:${{ steps.branch.outputs.publish_branch }} --keep-vars

--- a/docs/cloudflare-api-token-request.md
+++ b/docs/cloudflare-api-token-request.md
@@ -1,0 +1,70 @@
+# Cloudflare API token 発行依頼
+
+## 現在の確認結果
+
+2026-07-09 時点で、以下を確認しました。
+
+- GitHub repo secret に `CLOUDFLARE_API_TOKEN` / `WRANGLER_*` / `CF_*` 系の secret は見つかりませんでした。
+- ローカル環境変数にも `CLOUDFLARE_*` / `WRANGLER_*` / `CF_*` 系の値はありませんでした。
+- ローカル `wrangler whoami` では `company@cor-jp.com` の OAuth セッションが有効でした。手動 deploy は可能ですが、GitHub Actions の自動 deploy には使えません。
+
+この token が無い場合、GitHub Actions から `cor-yomimono` Worker を自動 deploy できません。`develop` では `PUBLISH_BRANCH=develop`、`main` では `PUBLISH_BRANCH=main` を注入して deploy するため、repo secret `CLOUDFLARE_API_TOKEN` の追加が必要です。
+
+## 依頼したいこと
+
+Cloudflare Dashboard で Worker deploy 用の API token を発行し、GitHub repository secret として `CLOUDFLARE_API_TOKEN` を登録してください。
+
+トークン値はチャットや issue に貼らないでください。登録後に「secret 追加済み」とだけ共有してください。
+
+## 発行手順
+
+1. Cloudflare Dashboard に、`cor-jp.com` と Worker `cor-yomimono` を管理できるアカウントでログインします。
+2. 右上のユーザーアイコンから **My Profile** を開きます。
+3. **API Tokens** を開き、**Create Token** を押します。
+4. **Custom token** を選びます。
+5. Token name は `corsweb-yomimono-worker-deploy` など、用途が分かる名前にします。
+6. Permissions には、Wrangler deploy に必要な権限を付けます。
+   - Account: Workers Scripts: Edit
+   - Zone: Workers Routes: Edit
+   - Zone: Zone: Read
+   - Cloudflare UI の表記が変わっている場合は、Worker script deploy と route 更新に相当する Edit 権限を選んでください。
+7. Resources は、対象を絞ります。
+   - Account: Cor.Inc. が使っている Cloudflare account
+   - Zone: `cor-jp.com`
+8. TTL は 90〜180 日などの期限付き推奨です。期限なしにする場合は、別途ローテーション日を決めてください。
+9. 作成後、表示される token を一度だけコピーします。
+10. GitHub の `Cor-Incorporated/corsweb2024` を開きます。
+11. **Settings → Secrets and variables → Actions → New repository secret** を開きます。
+12. Name に `CLOUDFLARE_API_TOKEN`、Secret にコピーした token を入れて保存します。
+13. 保存後、Actions の **Deploy Yomimono Worker** を手動実行し、`publish_branch=develop` で deploy が通ることを確認します。
+
+## 登録後の確認方法
+
+登録後、以下のいずれかで確認します。
+
+```bash
+gh secret list -R Cor-Incorporated/corsweb2024 | rg CLOUDFLARE_API_TOKEN
+```
+
+GitHub Actions が成功した後は、以下が `develop` を返せば CMS と develop preview の参照先が一致しています。
+
+```bash
+curl -s https://cor-jp.com/blog-admin/health
+```
+
+期待値:
+
+```json
+{"ok":true,"publishBranch":"develop"}
+```
+
+## 暫定対応
+
+token 登録前に緊急で反映する必要がある場合は、Cloudflare にログイン済みのローカル環境から以下を実行します。
+
+```bash
+cd workers/yomimono
+npm exec -- wrangler deploy --var PUBLISH_BRANCH:develop --keep-vars
+```
+
+この暫定 deploy は CI/CD 証跡ではないため、issue close の最終証跡には GitHub Actions の成功ログを別途残してください。

--- a/docs/yomimono-cms-setup.md
+++ b/docs/yomimono-cms-setup.md
@@ -2,7 +2,7 @@
 
 ADR-0008(rev.2) / Epic #130 の **A案（静的＋記事bot・DBなし・Cloudflare Workers バックエンド）** を動かすために、**諫山さん（org 管理者）の側で一度だけ**用意するものをまとめます。ここが揃えば、以降のコードは私（実装側）が組みます。**シークレットは諫山さんの管理下に置き、私はコードから参照する形**にします（鍵を私が保持しません）。
 
-> **コレクション拡張（ADR-0009 / Epic #220）**: 本基盤は **blog / news / cases の3コレクション**に拡張済み（同一 Worker・同一 GitHub App・`body.collection` で切替）。blog と cases は稼働対象・**news は M3 で有効化**。下記セットアップ（GitHub App・Cloudflare・シークレット・認証）は3コレクション共通で追加不要。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
+> **コレクション拡張（ADR-0009 / Epic #220）**: 本基盤は **blog / news / cases の3コレクション**に拡張済み（同一 Worker・同一 GitHub App・`body.collection` で切替）。3コレクションとも投稿・一覧・読み込み・更新に対応する。下記セットアップ（GitHub App・Cloudflare・シークレット・認証）は3コレクション共通で追加不要。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
 
 ---
 
@@ -16,7 +16,7 @@ ADR-0008(rev.2) / Epic #130 の **A案（静的＋記事bot・DBなし・Cloudfl
    - **App ID** を控える
    - **Generate a private key**（.pem をダウンロード＝秘密鍵）
 4. **Install App** → `corsweb2024` のみを選択 → **Installation ID** を控える（インストール後のURLに含まれる）
-5. **main のブランチ保護に bot を許可pusherとして追加**（コード保護は維持・記事のみ書ける信頼アクター）:
+5. **main release 時は main のブランチ保護に bot を許可pusherとして追加**（コード保護は維持・記事のみ書ける信頼アクター）:
    ```bash
    # 現在の restrictions に App を追加（apps はアプリの slug を指定）
    gh api -X POST repos/Cor-Incorporated/corsweb2024/branches/main/protection/restrictions/apps \
@@ -25,7 +25,8 @@ ADR-0008(rev.2) / Epic #130 の **A案（静的＋記事bot・DBなし・Cloudfl
    JSON
    ```
    ※ App slug は作成時のURLスラッグ（例: `cor-yomimono-bot`）。
-   → 人のマージ権限は `kisayama0725` のまま、bot は **`src/content/{blog/ja,news,cases}/` 配下のコンテンツのみ**コミット（コード不接触・news は M3 で有効化）。
+   → 人のマージ権限は `kisayama0725` のまま、bot は **`src/content/{blog/ja,news,cases}/` 配下のコンテンツのみ**コミット（コード不接触）。
+   現在の develop preview 運用では `PUBLISH_BRANCH=develop` を使い、main release 時に CI/CD または deploy 変数で `PUBLISH_BRANCH=main` へ切り替える。
 
 ## 2. Cloudflare Workers（バックエンドの置き場・無料枠）
 1. **Cloudflare アカウント**（無料）を作成 or 既存利用
@@ -52,7 +53,7 @@ Worker 用意後、`wrangler secret put` で登録（値は諫山さんが入力
 ## 揃ったら私がやること（実装）
 1. `workers/yomimono/` に Worker（`/api/collect` `/api/generate` `/api/publish` ＋認証検証）を実装（#133）
 2. 情報収集（Claude+web_search・27h・ランキング）#134 / 生成（社長文体・ガードレール）#135 — 既存 `scripts/generate-blog-draft.mjs`・`blog-guardrails.mjs`・`docs/blog-style-guide.md` を再利用
-3. 公開（bot が `src/content/{blog/ja,news,cases}/` へコミット→自動デプロイ・`body.collection` で切替）#131/#136・news/cases 拡張は ADR-0009（Epic #220）
+3. 公開（bot が管理対象 branch の `src/content/{blog/ja,news,cases}/` へコミット→自動デプロイ・`body.collection` で切替）#131/#136・news/cases 拡張は ADR-0009（Epic #220）
 4. 管理ダッシュボードUI（モック済のフロー）#137
 5. 各段 ja不変・ガードレール・レビュー・PR・CI緑の規律で develop へ。本番反映の初回だけ動作をスクショ提示。
 

--- a/workers/yomimono/README.md
+++ b/workers/yomimono/README.md
@@ -1,7 +1,7 @@
 # 読みものCMS バックエンド（Cloudflare Worker / `cor-yomimono`）
 
-凪沙さんが **main マージ権限なしで毎日記事を投稿**できるようにする、サーバーレス・バックエンド＋管理画面。
-記事は DB を使わず **.md として git にコミット**され、既存の静的デプロイでそのまま公開される（A案：記事bot方式）。
+凪沙さんが **GitHub のマージ操作なしで毎日記事を投稿**できるようにする、サーバーレス・バックエンド＋管理画面。
+記事は DB を使わず **.md として git にコミット**され、管理対象 branch の静的デプロイでそのまま公開される（A案：記事bot方式）。
 
 > **コレクション拡張（ADR-0009）**: 記事bot は **blog / news / cases の3コレクション配下**に書く（`src/content/{blog/ja,news,cases}/`）。3コレクションとも投稿・一覧・読み込み・更新に対応する。切り替えは `body.collection` / `?collection=`（既定 `'blog'`）。詳細は `docs/adr/ADR-0009-news-cases-cms-expansion.md`。
 
@@ -9,7 +9,7 @@
 
 ```
 情報収集(/blog-admin/api/collect) → テーマ選定(人) → 生成(/blog-admin/api/generate) → レビュー(人) → 公開(/blog-admin/api/publish)
-                                       Claude                  Claude＋ガードレール          記事botがmainへcommit
+                                       Claude                  Claude＋ガードレール          記事botが管理対象branchへcommit
 ```
 
 ## エンドポイント（`BASE_PATH=/blog-admin` のため実URLは `cor-jp.com/blog-admin...`）
@@ -24,7 +24,7 @@
 | POST | `/api/collect` | 直近約27hのAI/DX/ローカルLLM記事から候補テーマを10〜15件返す |
 | POST | `/api/generate` | 選んだテーマで記事を1本生成（社長の文体）＋ガードレール検査結果を同梱 |
 | POST | `/api/validate` | コミットせずガードレール再チェック（編集後の確認用・`body.collection` 対応） |
-| POST | `/api/publish` | 記事botが `body.collection`（既定 `'blog'`）に応じて `src/content/{blog/ja,news,cases}/<slug>.md` を `main` にコミット |
+| POST | `/api/publish` | 記事botが `body.collection`（既定 `'blog'`）に応じて `src/content/{blog/ja,news,cases}/<slug>.md` を `PUBLISH_BRANCH` にコミット |
 | POST | `/api/update` | 既存コンテンツを同じ slug のまま `sha` 付きで更新（競合検出あり） |
 | GET  | `/manual` | ブログ投稿UI（blog / `src/content/blog/ja/<slug>.md` へ公開） |
 | GET  | `/manual/news` | ニュース投稿UI（news / `src/content/news/<slug>.md` へ公開） |
@@ -51,7 +51,7 @@ npx wrangler secret put SESSION_SECRET         # セッション署名鍵。`ope
 npm run deploy            # cor-jp.com/blog-admin* に公開（routes 設定済）
 ```
 
-`wrangler.toml` の `[vars]` に App ID / Installation ID 等の非シークレット設定が入っている（編集不要）。
+`wrangler.toml` の `[vars]` に App ID / Installation ID 等の非シークレット設定が入っている（編集不要）。`PUBLISH_BRANCH` は既定 `develop`。main release 用に同じ Worker を main 管理へ戻す場合は、CI/CD または deploy 時に `PUBLISH_BRANCH=main` を指定する。
 
 ## ルート（`cor-jp.com/blog-admin`）について
 
@@ -70,7 +70,7 @@ Cloudflare Access は使わず、Worker 自身がログインを管理する（A
 
 ### セキュリティ運用（重要）
 
-合言葉がこのツール（main 書込み＋API予算）の唯一の鍵なので、**高エントロピー必須**:
+合言葉がこのツール（管理対象 branch 書込み＋API予算）の唯一の鍵なので、**高エントロピー必須**:
 
 - `ACCESS_PASSWORD` は**ランダム生成**して password manager で配布する（覚えやすい語句は不可）。例:
   ```bash
@@ -84,9 +84,9 @@ Cloudflare Access は使わず、Worker 自身がログインを管理する（A
 
 `/api/collect` `/api/generate` は Opus + web_search を呼ぶため高コスト。認証済み社内ユーザーのみが叩ける前提だが、念のため Cloudflare ダッシュボード → **Security → WAF → Rate limiting rules** で当 Worker のパスに「1メール/分あたり N 回」の制限を1本入れておくと安全。
 
-## 記事botを main の許可プッシャーに追加（公開を通すため）
+## main release 時: 記事botを main の許可プッシャーに追加
 
-main はブランチ保護で push 制限がかかっている。記事bot（GitHub App）を許可リストに追加する:
+通常の develop 運用では `PUBLISH_BRANCH=develop` を読む。main release 後に同じ `/blog-admin` route を `PUBLISH_BRANCH=main` として使う場合、main はブランチ保護で push 制限がかかっているため、記事bot（GitHub App）を許可リストに追加する:
 
 ```bash
 gh api -X POST repos/Cor-Incorporated/corsweb2024/branches/main/protection/restrictions/apps \

--- a/workers/yomimono/src/__tests__/github.test.ts
+++ b/workers/yomimono/src/__tests__/github.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
-import { contentDir, deleteBlogArticle, readBlogArticle, updateBlogArticle } from '../github';
+import {
+  contentDir,
+  deleteBlogArticle,
+  listArticleSlugsDetailed,
+  readBlogArticle,
+  updateBlogArticle,
+} from '../github';
 import type { Env } from '../types';
 
 function utf8ToBase64(str: string): string {
@@ -114,6 +120,24 @@ isDraft: false
     expect(article.article.slug).toBe('edit-target');
   });
 
+  it('readBlogArticle は env.PUBLISH_BRANCH を ref として使う', async () => {
+    const envDevelop = { ...mockEnv, PUBLISH_BRANCH: 'develop' };
+    const request = vi.fn(async () => ({
+      data: {
+        content: utf8ToBase64(markdown),
+        sha: 'file-sha',
+      },
+    }));
+    await readBlogArticle(envDevelop, { request } as never, 'edit-target');
+
+    expect(request).toHaveBeenCalledWith('GET /repos/{owner}/{repo}/contents/{path}', {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      path: 'src/content/blog/ja/edit-target.md',
+      ref: 'develop',
+    });
+  });
+
   it('updateBlogArticle は sha 付き PUT で同じ slug を更新する', async () => {
     const request = vi.fn(async () => ({
       data: { commit: { html_url: 'https://github.com/test/commit/1' } },
@@ -139,6 +163,45 @@ isDraft: false
       message: 'post(yomimono): edit-target（更新: editor）',
       content: utf8ToBase64(markdown),
       sha: 'file-sha',
+    });
+  });
+
+  it('updateBlogArticle は env.PUBLISH_BRANCH を branch として使う', async () => {
+    const envDevelop = { ...mockEnv, PUBLISH_BRANCH: 'develop' };
+    const request = vi.fn(async () => ({
+      data: { commit: { html_url: 'https://github.com/test/commit/2' } },
+    }));
+    await updateBlogArticle(envDevelop, { request } as never, 'edit-target', markdown, 'file-sha', 'editor@example.com');
+
+    expect(request).toHaveBeenCalledWith('PUT /repos/{owner}/{repo}/contents/{path}', {
+      owner: 'test-owner',
+      repo: 'test-repo',
+      path: 'src/content/blog/ja/edit-target.md',
+      branch: 'develop',
+      message: 'post(yomimono): edit-target（更新: editor）',
+      content: utf8ToBase64(markdown),
+      sha: 'file-sha',
+    });
+  });
+
+  it('listArticleSlugsDetailed は対象ディレクトリ404を source/warning 付きで返す', async () => {
+    const envDevelop = { ...mockEnv, PUBLISH_BRANCH: 'develop' };
+    const request = vi.fn(async () => {
+      const error = new Error('Not Found') as Error & { status?: number };
+      error.status = 404;
+      throw error;
+    });
+
+    const result = await listArticleSlugsDetailed(envDevelop, { request } as never, 'news');
+
+    expect(result).toEqual({
+      slugs: [],
+      source: {
+        collection: 'news',
+        branch: 'develop',
+        dir: 'src/content/news',
+      },
+      warning: '管理対象 branch "develop" に src/content/news が見つかりません',
     });
   });
 

--- a/workers/yomimono/src/__tests__/index-cases.test.ts
+++ b/workers/yomimono/src/__tests__/index-cases.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   deleteBlogArticle: vi.fn(),
   listArticleSlugs: vi.fn(),
   listBlogArticles: vi.fn(),
+  listBlogArticlesWithSource: vi.fn(),
   readBlogArticle: vi.fn(),
   updateBlogArticle: vi.fn(),
 }));
@@ -25,6 +26,7 @@ vi.mock('../github', () => ({
   commitImage: vi.fn(),
   listArticleSlugs: mocks.listArticleSlugs,
   listBlogArticles: mocks.listBlogArticles,
+  listBlogArticlesWithSource: mocks.listBlogArticlesWithSource,
   readBlogArticle: mocks.readBlogArticle,
   updateBlogArticle: mocks.updateBlogArticle,
 }));
@@ -41,7 +43,7 @@ const env: Env = {
   BLOG_DIR: 'src/content/blog',
   NEWS_DIR: 'src/content/news',
   CASES_DIR: 'src/content/cases',
-  PUBLISH_BRANCH: 'main',
+  PUBLISH_BRANCH: 'develop',
   STYLE_GUIDE_PATH: 'docs/blog-style-guide.md',
   BASE_PATH: '/blog-admin',
   ACCESS_PASSWORD: 'x'.repeat(20),
@@ -99,6 +101,28 @@ describe('yomimono Worker — cases CMS posting path', () => {
         featured: true,
       },
     ]);
+    mocks.listBlogArticlesWithSource.mockImplementation(async (_env, _octokit, collection = 'blog') => {
+      const dir = collection === 'news' ? env.NEWS_DIR : collection === 'cases' ? env.CASES_DIR : `${env.BLOG_DIR}/ja`;
+      return {
+        articles:
+          collection === 'news'
+            ? [
+                {
+                  collection: 'news',
+                  slug: 'external-news',
+                  title: '外部掲載ニュース',
+                  description: '外部掲載の説明',
+                  category: 'media',
+                  isDraft: false,
+                  pubDate: '2026-07-08',
+                  publishedAt: '2026-07-08',
+                  featured: true,
+                },
+              ]
+            : [],
+        source: { collection, branch: env.PUBLISH_BRANCH, dir },
+      };
+    });
     mocks.readBlogArticle.mockResolvedValue({
       collection: 'news',
       slug: 'external-news',
@@ -199,8 +223,34 @@ describe('yomimono Worker — cases CMS posting path', () => {
           featured: true,
         },
       ],
+      source: {
+        collection: 'news',
+        branch: 'develop',
+        dir: 'src/content/news',
+      },
     });
-    expect(mocks.listBlogArticles).toHaveBeenCalledWith(env, { mocked: true }, 'news');
+    expect(mocks.listBlogArticlesWithSource).toHaveBeenCalledWith(env, { mocked: true }, 'news');
+  });
+
+  it('GET /api/articles?collection=news は対象ディレクトリ未存在時に source と warning を返す', async () => {
+    mocks.listBlogArticlesWithSource.mockResolvedValueOnce({
+      articles: [],
+      source: { collection: 'news', branch: 'develop', dir: 'src/content/news' },
+      warning: '管理対象 branch "develop" に src/content/news が見つかりません',
+    });
+    const res = await worker.fetch(req('/blog-admin/api/articles?collection=news'), env);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      articles: [],
+      source: {
+        collection: 'news',
+        branch: 'develop',
+        dir: 'src/content/news',
+      },
+      warning: '管理対象 branch "develop" に src/content/news が見つかりません',
+    });
+    expect(mocks.listBlogArticlesWithSource).toHaveBeenCalledWith(env, { mocked: true }, 'news');
   });
 
   it('GET /api/article?collection=news は sha 付きで news 記事を返す', async () => {
@@ -229,6 +279,7 @@ describe('yomimono Worker — cases CMS posting path', () => {
     expect(html).toContain('完全削除を開く（管理操作）');
     expect(html).toContain('公開停止だけなら削除ではなく非公開化を使うことを理解しました');
     expect(html).toContain('GitHubから完全削除する');
+    expect(html).toContain('管理対象: ');
     expect(html).toContain("postJson('/api/unpublish'");
     expect(html).toContain("postJson('/api/delete'");
   });

--- a/workers/yomimono/src/__tests__/index.test.ts
+++ b/workers/yomimono/src/__tests__/index.test.ts
@@ -12,7 +12,7 @@ const env: Env = {
   BLOG_DIR: 'src/content/blog/ja',
   NEWS_DIR: 'src/content/news',
   CASES_DIR: 'src/content/cases',
-  PUBLISH_BRANCH: 'main',
+  PUBLISH_BRANCH: 'develop',
   STYLE_GUIDE_PATH: 'docs/blog-style-guide.md',
   BASE_PATH: '/blog-admin',
   ACCESS_PASSWORD: 'correct-horse-battery-staple',
@@ -54,7 +54,7 @@ describe('yomimono Worker security headers', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('application/json');
-    expect(await response.json()).toEqual({ ok: true });
+    expect(await response.json()).toEqual({ ok: true, publishBranch: 'develop' });
     expectSecurityHeaders(response);
   });
 

--- a/workers/yomimono/src/github.ts
+++ b/workers/yomimono/src/github.ts
@@ -23,6 +23,18 @@ export interface BlogArticleFile extends BlogArticleSummary {
   path: string;
 }
 
+export interface CollectionSource {
+  collection: Collection;
+  branch: string;
+  dir: string;
+}
+
+export interface ArticleListResult {
+  articles: BlogArticleSummary[];
+  source: CollectionSource;
+  warning?: string;
+}
+
 export function makeOctokit(env: Env): Octokit {
   return new Octokit({
     authStrategy: createAppAuth,
@@ -55,6 +67,14 @@ export function contentDir(env: Env, collection: Collection = 'blog'): string {
   return `${env.BLOG_DIR}/ja`;
 }
 
+export function collectionSource(env: Env, collection: Collection = 'blog'): CollectionSource {
+  return {
+    collection,
+    branch: env.PUBLISH_BRANCH,
+    dir: contentDir(env, collection),
+  };
+}
+
 // リポジトリのファイル内容を取得（文体ガイド等）。
 export async function getFileContent(env: Env, octokit: Octokit, path: string): Promise<string> {
   const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
@@ -75,21 +95,42 @@ export async function listArticleSlugs(
   collection: Collection = 'blog',
 ): Promise<string[]> {
   try {
-    const dir = contentDir(env, collection);
+    const result = await listArticleSlugsDetailed(env, octokit, collection);
+    return result.slugs;
+  } catch {
+    return []; // 一覧取得失敗は致命的でない（重複回避が弱まるだけ）
+  }
+}
+
+export async function listArticleSlugsDetailed(
+  env: Env,
+  octokit: Octokit,
+  collection: Collection = 'blog',
+): Promise<{ slugs: string[]; source: CollectionSource; warning?: string }> {
+  const source = collectionSource(env, collection);
+  try {
     const res = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
       owner: env.GH_OWNER,
       repo: env.GH_REPO,
-      path: dir,
+      path: source.dir,
       ref: env.PUBLISH_BRANCH,
     });
     const items = res.data as Array<{ name: string; type: string }>;
-    return Array.isArray(items)
+    const slugs = Array.isArray(items)
       ? items
           .filter((it) => it.type === 'file' && it.name.endsWith('.md'))
           .map((it) => it.name.replace(/\.md$/, ''))
       : [];
-  } catch {
-    return []; // 一覧取得失敗は致命的でない（重複回避が弱まるだけ）
+    return { slugs, source };
+  } catch (e: unknown) {
+    if ((e as { status?: number }).status === 404) {
+      return {
+        slugs: [],
+        source,
+        warning: `管理対象 branch "${source.branch}" に ${source.dir} が見つかりません`,
+      };
+    }
+    throw e;
   }
 }
 
@@ -143,7 +184,26 @@ export async function listBlogArticles(
   octokit: Octokit,
   collection: Collection = 'blog',
 ): Promise<BlogArticleSummary[]> {
-  const slugs = await listArticleSlugs(env, octokit, collection);
+  const { slugs } = await listArticleSlugsDetailed(env, octokit, collection);
+  return readArticleSummaries(env, octokit, collection, slugs);
+}
+
+export async function listBlogArticlesWithSource(
+  env: Env,
+  octokit: Octokit,
+  collection: Collection = 'blog',
+): Promise<ArticleListResult> {
+  const { slugs, source, warning } = await listArticleSlugsDetailed(env, octokit, collection);
+  const articles = await readArticleSummaries(env, octokit, collection, slugs);
+  return { articles, source, ...(warning ? { warning } : {}) };
+}
+
+async function readArticleSummaries(
+  env: Env,
+  octokit: Octokit,
+  collection: Collection,
+  slugs: string[],
+): Promise<BlogArticleSummary[]> {
   const articles: BlogArticleSummary[] = [];
   for (const slug of slugs) {
     try {
@@ -235,7 +295,7 @@ export async function deleteBlogArticle(
   }
 }
 
-// 記事 .md を PUBLISH_BRANCH（既定 main）へコミット。
+// 記事 .md を PUBLISH_BRANCH（develop/main をCIまたはdeploy時に指定）へコミット。
 // content-bot はこのパス（記事のみ）にしか書かない＝コードには触れない。
 export async function commitArticle(
   env: Env,

--- a/workers/yomimono/src/index.ts
+++ b/workers/yomimono/src/index.ts
@@ -15,7 +15,7 @@ import {
   commitImage,
   deleteBlogArticle,
   listArticleSlugs,
-  listBlogArticles,
+  listBlogArticlesWithSource,
   readBlogArticle,
   updateBlogArticle,
 } from './github';
@@ -181,7 +181,7 @@ export default {
     if (base && path === base) path = '/';
     else if (base && path.startsWith(base + '/')) path = path.slice(base.length);
 
-    if (path === '/health') return json({ ok: true });
+    if (path === '/health') return json({ ok: true, publishBranch: env.PUBLISH_BRANCH });
 
     try {
       // --- 認証不要: ログイン画面 + ログイン/ログアウトAPI ---
@@ -267,8 +267,8 @@ export default {
       if (req.method === 'GET' && path === '/api/articles') {
         const collection = normalizeCollection(url.searchParams.get('collection'));
         const octokit = makeOctokit(env);
-        const articles = await listBlogArticles(env, octokit, collection);
-        return json({ articles });
+        const result = await listBlogArticlesWithSource(env, octokit, collection);
+        return json(result);
       }
 
       if (req.method === 'GET' && path === '/api/article') {
@@ -366,7 +366,7 @@ export default {
         return json({ violations });
       }
 
-      // ⑥ 公開（記事botが main へコミット → 既存の静的デプロイで公開）
+      // ⑥ 公開（記事botが現在の管理対象 branch へコミット → 既存の静的デプロイで公開）
       if (req.method === 'POST' && path === '/api/publish') {
         const body = await readJsonBody(req);
         if (!body) return json({ error: 'リクエストボディが不正なJSONです' }, 400);

--- a/workers/yomimono/src/ui-ai.ts
+++ b/workers/yomimono/src/ui-ai.ts
@@ -3,7 +3,7 @@ import { head, header, tail } from './ui-shared';
 // AI生成ページ（情報収集→テーマ選択→生成→レビュー→公開）。
 // 共通JS(BASE/esc/safeUrl/$/api)は ui-shared の COMMON_JS から供給される。
 const BODY = `<main>
-  <p class="lead">情報収集 → テーマ選定 → 生成 → レビュー → 公開（main マージ不要で公開されます）</p>
+  <p class="lead">情報収集 → テーマ選定 → 生成 → レビュー → 公開（現在の管理対象 branch に保存されます）</p>
   <section class="step" id="s1">
     <h2><span class="num">1</span>情報収集</h2>
     <p class="hint">直近およそ27時間の AI / DX / ローカルLLM などの話題から、中小企業に刺さる候補テーマを集めます。</p>
@@ -147,7 +147,7 @@ const JS = `
 
   function finishPublish(slot, uid, j){
     var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
-    slot.innerHTML = '<div class="done">✓ 公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
+    slot.innerHTML = '<div class="done">✓ 公開しました（現在の管理対象 branch にコミット → 数分でサイトに反映されます） '+link+'</div>';
   }
 `;
 

--- a/workers/yomimono/src/ui-edit.ts
+++ b/workers/yomimono/src/ui-edit.ts
@@ -140,9 +140,12 @@ const JS = `
   function emptyHtml(){
     return '<div class="empty">'+esc(cfg().label)+'はまだ見つかりません。<br><a href="'+esc(BASE+cfg().newPath)+'">'+esc(cfg().label)+'を書く</a></div>';
   }
-  function renderList(items){
+  function renderList(items, warning){
     var box=$('e_list');
-    if(!items.length){ box.innerHTML=emptyHtml(); return; }
+    if(!items.length){
+      box.innerHTML=(warning?'<div class="err">'+esc(warning)+'</div>':'')+emptyHtml();
+      return;
+    }
     box.innerHTML=items.map(function(a){
       var state=a.isDraft?'<span class="badge">下書き</span>':'';
       var featured=a.featured?'<span class="badge">注目</span>':'';
@@ -156,12 +159,18 @@ const JS = `
       buttons[i].addEventListener('click',function(){ loadArticle(this.getAttribute('data-slug')); });
     }
   }
+  function sourceText(source, count){
+    if(!source) return cfg().label+'を表示中';
+    return cfg().label+'を表示中 / 管理対象: '+(source.branch||'未設定')+' / '+(source.dir||'不明')+' / '+count+'件';
+  }
   function loadList(){
     resetForm();
     $('e_list_status').textContent='読み込み中...';
     getJson('/api/articles?collection='+encodeURIComponent(currentCollection)).then(function(j){
-      renderList(j.articles||[]);
-      $('e_list_status').textContent=(j.articles||[]).length+'件';
+      var items=j.articles||[];
+      renderList(items,j.warning||'');
+      $('e_list_status').textContent=items.length+'件';
+      setStatus(sourceText(j.source,items.length));
     }).catch(function(e){
       $('e_list').innerHTML='<div class="err">'+esc(e.message)+'</div>';
       $('e_list_status').textContent='';

--- a/workers/yomimono/src/ui-manual-cases.ts
+++ b/workers/yomimono/src/ui-manual-cases.ts
@@ -80,7 +80,7 @@ const BODY =
     <details class="help"><summary>技術的なメモ（かっこのある方向け）</summary>
       <div class="help-body">
         <ul>
-          <li>公開は GitHub の main ブランチへコミットされ、数分で静的サイトに反映されます（main マージ不要）。</li>
+          <li>公開は GitHub の現在の管理対象 branch へコミットされ、数分で静的サイトに反映されます。</li>
           <li>本文は Markdown 形式で保存されます。ツールバーが記号を自動挿入します。</li>
           <li>「下書きをブラウザに保存」はこの端末のブラウザ（localStorage）にのみ保存されます。サーバーには送信されません。</li>
           <li>入力中の内容は自動的にこのブラウザに保存されます（デバイスごと・公開時に消去）。</li>
@@ -311,7 +311,7 @@ const JS = `
     var btn=this; btn.disabled=true; btn.innerHTML='<span class="spin"></span>公開中…'; $('m_msg').textContent='';
     api('/api/publish', { collection:'cases', article:a }).then(function(j){
       var link = j && j.commitUrl ? ('<a href="'+esc(safeUrl(j.commitUrl))+'" target="_blank" rel="noopener">コミットを見る</a>') : '';
-      $('m_result').innerHTML='<div class="done">✓ 実績記事を公開しました（main にコミット → 数分でサイトに反映されます） '+link+'</div>';
+      $('m_result').innerHTML='<div class="done">✓ 実績記事を公開しました（現在の管理対象 branch にコミット → 数分でサイトに反映されます） '+link+'</div>';
       $('m_msg').textContent='';
       cancelDraftSave();
       clearDraft(DRAFT_KEY);

--- a/workers/yomimono/src/ui-manual.ts
+++ b/workers/yomimono/src/ui-manual.ts
@@ -58,7 +58,7 @@ const BODY = `<main class="wide">
     <details class="help"><summary>技術的なメモ（かっこのある方向け）</summary>
       <div class="help-body">
         <ul>
-          <li>公開は GitHub の main ブランチへコミットされ、数分で静的サイトに反映されます（main マージ不要）。</li>
+          <li>公開は GitHub の現在の管理対象 branch へコミットされ、数分で静的サイトに反映されます。</li>
           <li>本文は Markdown 形式で保存されます。ツールバーが記号を自動挿入します。</li>
           <li>「下書きをブラウザに保存」はこの端末のブラウザ（localStorage）にのみ保存されます。サーバーには送信されません。</li>
           <li>入力中の内容は自動的にこのブラウザに保存されます（デバイスごと・公開時に消去）。</li>

--- a/workers/yomimono/wrangler.toml
+++ b/workers/yomimono/wrangler.toml
@@ -18,7 +18,7 @@ GH_INSTALLATION_ID = "142454743"
 BLOG_DIR = "src/content/blog"
 NEWS_DIR = "src/content/news"
 CASES_DIR = "src/content/cases"
-PUBLISH_BRANCH = "main"
+PUBLISH_BRANCH = "develop"
 STYLE_GUIDE_PATH = "docs/blog-style-guide.md"
 # ↓ BASE_PATH は上の routes の pattern と必ず一致させること（/blog-admin ⇔ cor-jp.com/blog-admin*）
 BASE_PATH = "/blog-admin"          # cor-jp.com/blog-admin* に載せるためのプレフィックス


### PR DESCRIPTION
## ① なぜ

読み物作成スタジオの Worker が `PUBLISH_BRANCH=main` 固定で GitHub contents を読んでおり、develop preview に存在する news / cases と CMS の一覧が一致していませんでした。非エンジニア向けの一元管理UIとして、現在どの branch / dir を管理しているかを明示する必要があります。

## ② どう実装したか

- `workers/yomimono/wrangler.toml` の既定 `PUBLISH_BRANCH` を `develop` に変更
- `/health` に `publishBranch` を追加
- `/api/articles` に `source.collection / source.branch / source.dir` と、対象ディレクトリが無い場合の `warning` を追加
- `/edit` の collection status に `管理対象: develop / src/content/... / n件` を表示
- README / セットアップ文書の `main` 固定表現を branch-aware に修正
- `Deploy Yomimono Worker` workflow を追加し、push先または手動入力に応じて `PUBLISH_BRANCH=develop/main` を注入
- GitHub repo secret `CLOUDFLARE_API_TOKEN` が無い場合の発行依頼手順を `docs/cloudflare-api-token-request.md` に追加

## ③ 特にレビューしてほしい点

- `/api/articles` のレスポンス拡張が既存UI/API利用者に対して後方互換になっているか
- 同じ `/blog-admin` route を `develop/main` で切り替える運用として、workflow の `PUBLISH_BRANCH` 決定ロジックが妥当か
- `CLOUDFLARE_API_TOKEN` 未設定時に workflow を warning + deploy skip とする扱いでよいか

## ④ テスト・確認方法

- `npm --prefix workers/yomimono ci`
- `npm --prefix workers/yomimono test`（10 files / 243 tests passed）
- `npm --prefix workers/yomimono run typecheck`
- `npm exec -- wrangler deploy --dry-run --var PUBLISH_BRANCH:develop --keep-vars`（`workers/yomimono` cwd、`PUBLISH_BRANCH: "develop"` を確認）
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-yomimono-worker.yml"); puts "YAML OK"'`

Refs: #237
