### PR TITLE
fix(yomimono): Worker用Vitest設定を追加

### DIFF
--- a/workers/yomimono/vitest.config.ts
+++ b/workers/yomimono/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## ① なぜ

PR #238 merge 後の `Deploy Yomimono Worker` workflow で、Worker package の `npm test` が repo root の `vitest.config.ts` を拾い、root dependencies を install していない CI 環境で `Cannot find package 'vitest'` になりました。

## ② どう実装したか

- `workers/yomimono/vitest.config.ts` を追加
- Worker package の tests は `src/__tests__/**/*.test.ts` だけを対象にし、`node` 環境で実行するよう固定

## ③ 特にレビューしてほしい点

- Worker package 単体CIが root config / root dependencies に依存しない構成になっているか

## ④ テスト・確認方法

- `cd workers/yomimono && npm test`（10 files / 243 tests passed）
- `cd workers/yomimono && npm run typecheck`
- `git diff --check`

Refs: #237
