### PR TITLE
docs(adr): グランドデザイン正本 ADR-0013〜0015(一極集中・intent 7キー・正本配置)

### DIFF
--- a/docs/adr/ADR-0013-contact-consolidation-cloudia.md
+++ b/docs/adr/ADR-0013-contact-consolidation-cloudia.md
@@ -1,0 +1,34 @@
+# ADR-0013 問い合わせ一極集中（Cloudia UI + contact-chat）
+
+## ステータス: Accepted (2026-07-11)
+
+## 背景
+- ADR-0005（Contact 段階移行）・ADR-0012（Cloudia 統合）で、Contact のチャットボット化と Cloudia の org 移管・Cloudflare 化を決定済み。
+- Grift LP（griftai）は自前フォームを持たず、全 CTA を `cor-jp.com/contact/?intent=...` へ橋渡しする（griftai ADR-0002 / 本リポ ADR-0010）。
+- 各導線の終着点が「corsweb の Contact」であることは事実上決まっていたが、「全問い合わせの受け口は Cloudia + contact-chat のペアである」というグランドデザインは明文化されていなかった。
+
+## 決定
+
+### 一極集中の定義
+- Cor.inc に関わる**すべての問い合わせ導線**（corsweb 主 CTA・業種別 LP・Grift LP・ブログ CTA・将来の 050 AI 受付）の終着点を、次の**ペア**に固定する:
+  1. **UI**: Cloudia（Cor-Incorporated/cloudia、LINE 風チャット + 8 表情）— corsweb `/contact/` に同一オリジンで埋め込み（#254）
+  2. **API**: `workers/contact-chat`（本リポ配下の Cloudflare Worker、`/api/contact/*`）— 問い合わせ処理の正本（#250）
+- 「一極集中」の実体は **Worker への集約**であり、UI 実装が何であれ問い合わせデータは contact-chat を必ず経由する。
+
+### fallback フォームの維持（単一障害点の回避）
+- SSGFORM ベースの従来フォームは **恒久的に fallback として維持**する（cloudia #19）。
+- 発動条件: (a) Cloudia の障害・応答不能時、(b) JavaScript 無効環境、(c) チャット UI が利用困難なユーザー（a11y）。
+- fallback からの送信も intent / source を可能な範囲で引き継ぐ。
+
+### 公開順序との整合
+- Epic #243 の公開順序「導線の真実性 → 有料入口 → 信頼証拠 → Cloudia → 050 AI 受付 → 背景演出」を維持する。
+- Cloudia 本線化（#254）までは従来フォームが主 UI であり、本 ADR は最終状態（グランドデザイン）を定義するものである。
+
+## 影響
+- corsweb: #250（contact-chat 構造化 intent フロー）、#254（Cloudia 埋め込み）、#252（計測）
+- cloudia: #7（contact-chat 直結）、#8（埋め込み + a11y）、#14（LINE 風 UI）、#19（fallback フォーム）
+- griftai: CTA 橋渡し先は変更なし（`/contact/?intent=...` のまま。Contact の中身が Cloudia に変わっても URL 契約は不変）
+
+## 参照
+- ADR-0005 / ADR-0010 / ADR-0012 / ADR-0014（intent ルーティング） / ADR-0015（正本配置）
+- griftai ADR-0002、cloudia ADR-0001〜0007

--- a/docs/adr/ADR-0014-intent-7keys-and-routing.md
+++ b/docs/adr/ADR-0014-intent-7keys-and-routing.md
@@ -1,0 +1,41 @@
+# ADR-0014 intent 正本の 7 キー化と intent ルーティング
+
+## ステータス: Accepted (2026-07-11)
+
+## 背景
+- ADR-0010 で intent 正本 6 キーを定義した。
+- 「受託開発の相談」（Cor.inc に開発を依頼したい企業からの相談）に相当する専用キーが存在せず、`confidential-ai-assessment` 等に混在していた。
+- グランドデザインとして、受託相談は将来 **Grift の Cor.inc 専用テナント**（Grift 製品のドッグフーディング）でヒアリング〜見積の上流工程を自動対応する方針が決定した。
+
+## 決定
+
+### intent 正本（7 キー）
+ADR-0010 の 6 キーに `contract-dev` を追加し、正本を以下の 7 キーとする:
+
+| intent | 意味 | 処理 |
+|---|---|---|
+| `confidential-ai-assessment` | 機密データAI活用診断 | contact-chat → メール通知（人間対応） |
+| `local-llm-poc` | ローカルLLM / セキュアAI PoC | contact-chat → メール通知（人間対応） |
+| `grift-team-beta` | Grift Team Beta | contact-chat → メール通知（人間対応） |
+| `grift-paid-trial` | Grift Paid Trial | contact-chat → メール通知（人間対応） |
+| `estimate-audit` | Estimate Audit（見積監査） | contact-chat → メール通知（人間対応） |
+| `contract-dev` | **受託開発の相談（新設）** | **Grift Cor テナントへ自動ハンドオフ（Phase 3）** |
+| `press-speaking-other` | 取材・登壇・その他 | contact-chat → メール通知（人間対応） |
+
+### ルーティング原則
+- **自動ハンドオフの対象は `contract-dev` のみ**。
+  - `grift-team-beta` / `grift-paid-trial` / `estimate-audit` は「依頼企業側に Grift を導入する」製品販売リードであり、Grift テナントでの自動対応は困難なため**人間対応を維持**する。
+- Cloudia は intent を初期文脈として受け取り（`?intent=` クエリ、cloudia 実装済み）、`contract-dev` 検知時のみ Grift ハンドオフフローに入る（未知キーは従来フローへフォールバック）。
+- ハンドオフ前に PII を Grift へ送る場合はユーザーの明示確認を必須とする（ADR-0012 の PII 原則を継承）。
+
+### コード反映
+- 本 ADR はキー定義の正本のみを更新する。コード反映は以下で実施:
+  - corsweb: `src/config/site.ts` の `ContactIntent` への追加・contact-chat 対応（#250）
+  - cloudia: `constants/intents.ts` への追加とルーター実装（Phase 3 issue)
+  - griftai: `contract-dev` は Grift LP の CTA からは使用しない（Grift LP の intent は grift-* / estimate-audit のみ）
+
+## 影響
+- 各リポの intent 一覧（corsweb `ContactIntent` 型 / cloudia `CONTACT_INTENTS` / griftai `cor-cta.ts`）は本表に追従する。差分検知は各リポの check スクリプト・ユニットテストで担保する。
+
+## 参照
+- ADR-0010（6 キー初版） / ADR-0013（一極集中） / ADR-0015（正本配置）

--- a/docs/adr/ADR-0015-cross-repo-adr-canon.md
+++ b/docs/adr/ADR-0015-cross-repo-adr-canon.md
@@ -1,0 +1,26 @@
+# ADR-0015 横断 ADR の正本配置と参照方式
+
+## ステータス: Accepted (2026-07-11)
+
+## 背景
+- corsweb / griftai / cloudia の 3 リポジトリは intent 契約・導線設計・公開順序を共有するが、同一 ADR を各リポにコピー配置すると更新時に必ず同期漏れが発生する。
+- 現状すでに intent 正本は corsweb（ADR-0010 → ADR-0014）にあり、griftai / cloudia は事実上これに従っている。
+
+## 決定
+
+### 正本 = corsweb
+- クロスリポジトリ契約（intent キー、Cloudia/contact-chat 一極集中、Grift ハンドオフ API 契約、公開順序）の ADR 正本は **corsweb `docs/adr/`** に置く。
+- 対象: ADR-0010 / 0013 / 0014 / 0015（以後の横断 ADR も同様）。
+
+### 他リポは「参照 ADR」1 枚のみ
+- griftai / cloudia には、正本へのリンク（permalink）と「本リポはこれに従う」旨のみを書いた**参照 ADR を各 1 枚**置く。
+- 参照 ADR には正本の内容をコピーしない。実装ガード（check スクリプト・型・テスト）との対応関係のみ記載してよい。
+
+### Issue の配置
+- Issue は**実装するリポジトリ**に置く。横断の親子関係は issue 本文の相互参照（`Cor-Incorporated/<repo>#<n>` 形式）で表現する。
+
+### 再検討タイミング
+- monorepo カットオーバー（corsweb #255 / cloudia #11）実施時に、正本の配置（monorepo への移設）を再検討する。それまで本方式を維持する。
+
+## 参照
+- ADR-0013 / ADR-0014、griftai 参照 ADR、cloudia 参照 ADR


### PR DESCRIPTION
## 概要
Phase 1–4 グランドデザインの正本 ADR を追加します(docs のみ)。

- **ADR-0013**: 問い合わせ一極集中 — 全導線の終着点を Cloudia UI + `workers/contact-chat` のペアに固定。SSGFORM fallback は恒久維持
- **ADR-0014**: intent 正本 7 キー化 — `contract-dev`(受託開発相談)を新設。**Grift Cor テナント自動ハンドオフは contract-dev のみ**、grift-team-beta / grift-paid-trial / estimate-audit は製品販売リードのため人間対応を維持
- **ADR-0015**: 横断 ADR の正本 = corsweb、griftai/cloudia は参照 ADR 1枚のみ(コピー禁止)。monorepo カットオーバー(#255)時に再検討

## 関連
- Epic #243 / ADR-0010〜0012(PR #242)
- griftai: Cor-Incorporated/griftai#45 / cloudia: Cor-Incorporated/cloudia#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)