### PR TITLE
feat(contact-chat): 構造化 intent 7キー対応 (#250)

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -35,7 +35,7 @@ const serviceLinks = [
   {
     name: nav.serviceAiDev || 'AI基盤構築・AI受託',
     href: getContactUrl(currentLocale, {
-      intent: 'confidential-ai-assessment',
+      intent: 'contract-dev',
       source: 'header-ai-dev',
     }),
     isExternal: false,

--- a/src/config/__tests__/site.test.ts
+++ b/src/config/__tests__/site.test.ts
@@ -80,3 +80,17 @@ describe('isProductionSite (ADR-0010 noindex)', () => {
     expect(isProductionSite()).toBe(false);
   });
 });
+
+describe('ContactIntent 7 keys (ADR-0014 / #250)', () => {
+  it('exports contract-dev and isContactIntent', async () => {
+    const { CONTACT_INTENTS, isContactIntent, AUTO_HANDOFF_INTENTS, getContactUrl } = await loadSite();
+    expect(CONTACT_INTENTS).toContain('contract-dev');
+    expect(CONTACT_INTENTS).toHaveLength(7);
+    expect(isContactIntent('contract-dev')).toBe(true);
+    expect(isContactIntent('nope')).toBe(false);
+    expect([...AUTO_HANDOFF_INTENTS]).toEqual(['contract-dev']);
+    expect(getContactUrl('ja', { intent: 'contract-dev', source: 'header-ai-dev' })).toBe(
+      '/contact?intent=contract-dev&source=header-ai-dev',
+    );
+  });
+});

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -4,14 +4,31 @@
  */
 import { getLocalizedUrl, type Locale } from '../utils/i18n';
 
-/** ADR-0010 intent 正本 */
-export type ContactIntent =
-  | 'confidential-ai-assessment'
-  | 'local-llm-poc'
-  | 'grift-team-beta'
-  | 'grift-paid-trial'
-  | 'estimate-audit'
-  | 'press-speaking-other';
+/**
+ * ADR-0014 intent 正本（7 キー）。
+ * workers/contact-chat の CONTACT_INTENTS と同値（parity テストで一致を担保）。
+ */
+export const CONTACT_INTENTS = [
+  'confidential-ai-assessment',
+  'local-llm-poc',
+  'grift-team-beta',
+  'grift-paid-trial',
+  'estimate-audit',
+  'contract-dev',
+  'press-speaking-other',
+] as const;
+
+export type ContactIntent = (typeof CONTACT_INTENTS)[number];
+
+export function isContactIntent(v: unknown): v is ContactIntent {
+  return typeof v === 'string' && (CONTACT_INTENTS as readonly string[]).includes(v);
+}
+
+/**
+ * 自動 Grift ハンドオフ対象（ADR-0014）。
+ * 実装は #259（Phase 3）。#250 では定数のみ公開。
+ */
+export const AUTO_HANDOFF_INTENTS = ['contract-dev'] as const satisfies readonly ContactIntent[];
 
 export type SiteEnv = 'production' | 'preview' | 'development';
 

--- a/workers/contact-chat/README.md
+++ b/workers/contact-chat/README.md
@@ -17,15 +17,18 @@ HP本体（静的・Firebase）には一切触れず、`cor-jp.com/api/contact/*
 | POST | `/api/contact/submit` | 最終問い合わせ送信（PIIをメール通知） | 同一オリジン＋任意Turnstile |
 
 ### POST /api/contact/chat
-- リクエスト: `{ "messages": [{ "role": "user"|"assistant", "content": string }] }`
-- レスポンス: `{ "reply": string, "classification": "genuine"|"sales"|"spam", "readyForContact": boolean }`
+- リクエスト: `{ "messages": [{ "role": "user"|"assistant", "content": string }], "intent"?: string, "source"?: string }`
+  - `intent`: ADR-0014 の 7 キー（未知は無視して従来フロー）。初期文脈として system に注入。
+  - `source`: 導線タグ（例: `header-ai-dev`）。メール本文に載る。
+- レスポンス: `{ "reply": string, "classification": "genuine"|"sales"|"spam", "readyForContact": boolean, "intent"?: string, "structuredLead"?: object }`
 - メッセージ数は最大20件、各2000字まで。制御文字は除去。**PIIは要求も保存もしない（会話のみ）。**
 - **Turnstile は検証しない。** Turnstile トークンは単回使用のため、複数ターン会話では2ターン目以降に
   新しいトークンが無く 403 になる。`/chat` のコスト濫用対策は同一オリジン＋IPレート制限＋
   **必須の Cloudflare WAF レート制限ルール（`cor-jp.com/api/contact/*`）** で担保する（下記チェックリスト参照）。
 
 ### POST /api/contact/submit
-- リクエスト: `{ "name", "email", "company"?, "message", "conversationSummary"?, "classification"?, "turnstileToken"?, "website"? }`
+- リクエスト: `{ "name", "email", "company"?, "message", "conversationSummary"?, "classification"?, "intent"?, "source"?, "structuredLead"?, "utm"?, "turnstileToken"?, "website"? }`
+  - `intent` / `source` / `structuredLead` / `utm`: 構造化リード（非PII）。メール件名・本文に載る。PII ではない。
   - `website` は **ハニーポット**。人間は空のまま。値が入っていれば bot とみなし、200を返して握り潰す（送信しない）。
 - レスポンス: `{ "ok": true }`
 - 検証: name 必須 / email 形式チェック / message 必須 / 各長さ上限 / サニタイズ。
@@ -104,3 +107,18 @@ npx wrangler deploy --dry-run
 - `/chat` の会話は LLM（Anthropic、**米国**）へ送られる。**会話には連絡先などのPIIを含めない設計**だが、利用者が会話本文に個人情報を書く可能性はゼロにできない。ウィジェット側でも「個人情報は入力しないでください」と案内すること。
 - `/submit` のPII（氏名・メール等）は **LLMを経由せず**、メール（Resend経由）でのみ社内に届く。
 - 個人情報の**国外移転（米Anthropic）**が発生しうるため、**プライバシーポリシーの更新が必要**（第三者提供・国外移転先の明示）。**公開前に法務（弁護士）確認を必ず取ること。**
+
+
+## Intent 正本（ADR-0014 / #250）
+
+| intent | 意味 | 処理（#250 時点） |
+|---|---|---|
+| `confidential-ai-assessment` | 機密データAI活用診断 | メール通知（人間対応） |
+| `local-llm-poc` | ローカルLLM / セキュアAI PoC | メール通知 |
+| `grift-team-beta` | Grift Team Beta | メール通知 |
+| `grift-paid-trial` | Grift Paid Trial | メール通知 |
+| `estimate-audit` | Estimate Audit | メール通知 |
+| `contract-dev` | 受託開発の相談 | メール通知（Grift 自動ハンドオフは #259） |
+| `press-speaking-other` | 取材・登壇・その他 | メール通知 |
+
+`AUTO_HANDOFF_INTENTS = ['contract-dev']` は定数のみ。HTTP ハンドオフ実装は Phase 3。

--- a/workers/contact-chat/src/__tests__/email.test.ts
+++ b/workers/contact-chat/src/__tests__/email.test.ts
@@ -11,14 +11,25 @@ const inquiry: NormalizedInquiry = {
   message: '新規Webアプリを作りたいです',
   conversationSummary: 'プロジェクト種別: 新規開発 / 目標: 受発注の効率化',
   classification: 'genuine',
+  intent: 'contract-dev',
+  source: 'live-verify',
+  structuredLead: {
+    purpose: '受託で業務システム開発',
+    industryRole: '製造 / 情シス',
+    dataSensitivity: 'internal',
+    stage: 'exploring',
+    timingBudget: '3ヶ月以内 / 未定',
+  },
+  utm: { utm_source: 'cor' },
 };
 
 describe('buildSubject', () => {
   it('分類タグと名前を含む', () => {
-    expect(buildSubject(inquiry)).toBe('[genuine] お問い合わせ: 山田太郎');
+    expect(buildSubject(inquiry)).toBe('[genuine][contract-dev] お問い合わせ: 山田太郎');
   });
   it('未分類なら分類タグなし', () => {
-    expect(buildSubject({ ...inquiry, classification: '' })).toBe('お問い合わせ: 山田太郎');
+    expect(buildSubject({ ...inquiry, classification: '', intent: '' })).toBe('お問い合わせ: 山田太郎');
+    expect(buildSubject({ ...inquiry, classification: '' })).toBe('[contract-dev] お問い合わせ: 山田太郎');
   });
 });
 
@@ -90,5 +101,23 @@ describe('sendInquiryEmail — Resend 呼び出し（fetchモック）', () => {
     const r = getEmailProvider(env);
     if (!r.ok) throw new Error('provider should be ok');
     await expect(sendInquiryEmail(env, r.provider, inquiry)).rejects.toThrow(/500/);
+  });
+});
+
+describe('buildBody / buildSubject — intent 拡張 (#250)', () => {
+  it('件名に intent タグを含む', () => {
+    expect(buildSubject(inquiry)).toContain('[contract-dev]');
+  });
+  it('本文に intent / source / 構造化リード / UTM を含む', () => {
+    const body = buildBody(inquiry);
+    expect(body).toContain('intent　: contract-dev');
+    expect(body).toContain('source　: live-verify');
+    expect(body).toContain('受託で業務システム開発');
+    expect(body).toContain('utm_source: cor');
+  });
+  it('intent 未指定でも件名は classification のみ', () => {
+    expect(buildSubject({ ...inquiry, intent: '', classification: 'sales' })).toBe(
+      '[sales] お問い合わせ: 山田太郎',
+    );
   });
 });

--- a/workers/contact-chat/src/__tests__/index.test.ts
+++ b/workers/contact-chat/src/__tests__/index.test.ts
@@ -255,3 +255,29 @@ describe('worker.fetch — ハンドラレベル', () => {
     expect(body.ok).toBe(true);
   });
 });
+
+describe('parseChatResult — intent / structuredLead (#250)', () => {
+  it('LLM の intent と structuredLead を取り出す', () => {
+    const raw = JSON.stringify({
+      reply: '承知しました',
+      classification: 'genuine',
+      readyForContact: true,
+      intent: 'contract-dev',
+      structuredLead: { purpose: '受託開発', stage: 'exploring' },
+    });
+    const r = parseChatResult(raw);
+    expect(r.intent).toBe('contract-dev');
+    expect(r.structuredLead?.purpose).toBe('受託開発');
+    expect(r.structuredLead?.stage).toBe('exploring');
+  });
+  it('未知 intent は落とす（fallback を維持）', () => {
+    const raw = '{"reply":"x","classification":"genuine","readyForContact":false,"intent":"evil"}';
+    const r = parseChatResult(raw, 'local-llm-poc');
+    expect(r.intent).toBe('local-llm-poc');
+  });
+  it('intent なし JSON では fallback を使う', () => {
+    const raw = '{"reply":"x","classification":"genuine","readyForContact":false}';
+    const r = parseChatResult(raw, 'grift-team-beta');
+    expect(r.intent).toBe('grift-team-beta');
+  });
+});

--- a/workers/contact-chat/src/__tests__/injection.test.ts
+++ b/workers/contact-chat/src/__tests__/injection.test.ts
@@ -68,3 +68,12 @@ describe('SYSTEM_PROMPT — 注入対策の明示指示を含む', () => {
     expect(SYSTEM_PROMPT).toMatch(/genuine.*sales.*spam/s);
   });
 });
+
+describe('SYSTEM_PROMPT — intent 7キー (#250)', () => {
+  it('7 キーと structuredLead を指示に含む', () => {
+    expect(SYSTEM_PROMPT).toContain('contract-dev');
+    expect(SYSTEM_PROMPT).toContain('confidential-ai-assessment');
+    expect(SYSTEM_PROMPT).toContain('structuredLead');
+    expect(SYSTEM_PROMPT).toContain('data sensitivity');
+  });
+});

--- a/workers/contact-chat/src/__tests__/intent-parity.test.ts
+++ b/workers/contact-chat/src/__tests__/intent-parity.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { AUTO_HANDOFF_INTENTS, CONTACT_INTENTS } from '../types';
+
+/**
+ * Worker の CONTACT_INTENTS がサイト側 src/config/site.ts と同値であること。
+ * monorepo 共有 import を避けているため、静的パリティでドリフトを防ぐ（ADR-0014 / #250）。
+ */
+describe('CONTACT_INTENTS parity with src/config/site.ts', () => {
+  it('配列が site.ts の CONTACT_INTENTS と一致する', () => {
+    const sitePath = resolve(__dirname, '../../../../src/config/site.ts');
+    const src = readFileSync(sitePath, 'utf8');
+    const m = src.match(/export const CONTACT_INTENTS = \[([\s\S]*?)\] as const/);
+    expect(m).toBeTruthy();
+    const keys = [...m![1].matchAll(/'([^']+)'/g)].map((x) => x[1]);
+    expect(keys).toEqual([...CONTACT_INTENTS]);
+  });
+
+  it('AUTO_HANDOFF_INTENTS は contract-dev のみ', () => {
+    expect([...AUTO_HANDOFF_INTENTS]).toEqual(['contract-dev']);
+  });
+});

--- a/workers/contact-chat/src/__tests__/validate.test.ts
+++ b/workers/contact-chat/src/__tests__/validate.test.ts
@@ -4,10 +4,15 @@ import {
   MAX_MESSAGE_LEN,
   MAX_MESSAGES,
   normalizeInquiry,
+  normalizeIntent,
   normalizeMessages,
+  normalizeSource,
+  normalizeStructuredLead,
+  normalizeUtm,
   sanitizeLine,
   sanitizeMessage,
 } from '../validate';
+import { CONTACT_INTENTS } from '../types';
 
 describe('sanitizeMessage — チャット入力サニタイズ（プロンプト注入対策）', () => {
   it('NUL/制御文字を空白化する（改行は残す）', () => {
@@ -153,5 +158,66 @@ describe('normalizeInquiry — /submit 検証＋ハニーポット', () => {
     const r = normalizeInquiry({ ...base, company: '' });
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.inquiry.company).toBe('');
+  });
+});
+
+describe('normalizeIntent / structuredLead / utm (#250)', () => {
+  it('7 キーすべてを受理する', () => {
+    for (const key of CONTACT_INTENTS) {
+      expect(normalizeIntent(key)).toBe(key);
+    }
+  });
+  it('未知キーは空文字にフォールバック（400 にしない）', () => {
+    expect(normalizeIntent('evil-intent')).toBe('');
+    expect(normalizeIntent(null)).toBe('');
+    expect(normalizeIntent(123)).toBe('');
+  });
+  it('source を単一行サニタイズする', () => {
+    expect(normalizeSource('header\nai-dev')).toBe('header ai-dev');
+  });
+  it('structuredLead の非文字列/未知キーを落とす', () => {
+    const lead = normalizeStructuredLead({
+      purpose: '受託開発',
+      evil: 'x',
+      industryRole: '製造',
+      dataSensitivity: 'confidential',
+    });
+    expect(lead).toEqual({
+      purpose: '受託開発',
+      industryRole: '製造',
+      dataSensitivity: 'confidential',
+    });
+  });
+  it('utm は utm_ プレフィックスのみ受理', () => {
+    const utm = normalizeUtm({ utm_source: 'cor', foo: 'bar', utm_campaign: 'p0' });
+    expect(utm).toEqual({ utm_source: 'cor', utm_campaign: 'p0' });
+  });
+  it('submit で intent/source/lead を正規化する', () => {
+    const r = normalizeInquiry({
+      name: '山田太郎',
+      email: 'taro@example.com',
+      message: '相談です',
+      intent: 'contract-dev',
+      source: 'header-ai-dev',
+      structuredLead: { purpose: '受託' },
+      utm: { utm_source: 'nav' },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.inquiry.intent).toBe('contract-dev');
+      expect(r.inquiry.source).toBe('header-ai-dev');
+      expect(r.inquiry.structuredLead.purpose).toBe('受託');
+      expect(r.inquiry.utm.utm_source).toBe('nav');
+    }
+  });
+  it('未知 intent でも submit は成功し intent は空', () => {
+    const r = normalizeInquiry({
+      name: '山田太郎',
+      email: 'taro@example.com',
+      message: '相談です',
+      intent: 'not-a-real-key',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.inquiry.intent).toBe('');
   });
 });

--- a/workers/contact-chat/src/email.ts
+++ b/workers/contact-chat/src/email.ts
@@ -56,10 +56,13 @@ export function getEmailProvider(env: Env): EmailProviderResult {
   return { ok: true, provider: new ResendProvider(env.RESEND_API_KEY) };
 }
 
-// 件名: 分類を含め、社内でトリアージしやすくする。
+// 件名: 分類・intent を含め、社内でトリアージしやすくする。
 export function buildSubject(inquiry: NormalizedInquiry): string {
-  const tag = inquiry.classification ? `[${inquiry.classification}] ` : '';
-  return `${tag}お問い合わせ: ${inquiry.name}`;
+  const tags: string[] = [];
+  if (inquiry.classification) tags.push(inquiry.classification);
+  if (inquiry.intent) tags.push(inquiry.intent);
+  const prefix = tags.length ? `[${tags.join('][')}] ` : '';
+  return `${prefix}お問い合わせ: ${inquiry.name}`;
 }
 
 // 本文: 構造化した問い合わせ＋会話サマリ＋分類メモ。
@@ -72,10 +75,27 @@ export function buildBody(inquiry: NormalizedInquiry): string {
     `お名前　: ${inquiry.name}`,
     `メール　: ${inquiry.email}`,
     `会社名　: ${inquiry.company || '(未記入)'}`,
+    `intent　: ${inquiry.intent || '(未指定)'}`,
+    `source　: ${inquiry.source || '(未指定)'}`,
     '',
     '── 本文 ──',
     inquiry.message,
   ];
+  const lead = inquiry.structuredLead || {};
+  const leadLines: string[] = [];
+  if (lead.purpose) leadLines.push(`目的　　: ${lead.purpose}`);
+  if (lead.industryRole) leadLines.push(`業種・役割: ${lead.industryRole}`);
+  if (lead.dataSensitivity) leadLines.push(`データ感度: ${lead.dataSensitivity}`);
+  if (lead.stage) leadLines.push(`進捗段階: ${lead.stage}`);
+  if (lead.timingBudget) leadLines.push(`時期・予算: ${lead.timingBudget}`);
+  if (leadLines.length) {
+    lines.push('', '── 構造化リード（非PII） ──', ...leadLines);
+  }
+  const utmEntries = Object.entries(inquiry.utm || {});
+  if (utmEntries.length) {
+    lines.push('', '── UTM ──');
+    for (const [k, v] of utmEntries) lines.push(`${k}: ${v}`);
+  }
   if (inquiry.conversationSummary) {
     lines.push('', '── AIチャットの会話サマリ ──', inquiry.conversationSummary);
   }

--- a/workers/contact-chat/src/index.ts
+++ b/workers/contact-chat/src/index.ts
@@ -1,5 +1,18 @@
-import type { ChatResult, Classification, Env, InquiryInput } from './types';
-import { normalizeMessages, normalizeInquiry } from './validate';
+import type {
+  ChatResult,
+  Classification,
+  ContactIntent,
+  Env,
+  InquiryInput,
+  StructuredLead,
+} from './types';
+import {
+  normalizeInquiry,
+  normalizeIntent,
+  normalizeMessages,
+  normalizeSource,
+  normalizeStructuredLead,
+} from './validate';
 import {
   CHAT_LIMIT,
   SUBMIT_LIMIT,
@@ -8,7 +21,7 @@ import {
   isSameOrigin,
   verifyTurnstile,
 } from './security';
-import { SYSTEM_PROMPT, getProvider } from './llm';
+import { buildSystemPrompt, getProvider } from './llm';
 import { getEmailProvider, sendInquiryEmail } from './email';
 
 // 最大リクエストボディサイズ（DoS/暴走入力対策）。会話＋サマリでも十分な余裕。
@@ -80,10 +93,12 @@ export function extractJsonObject(s: string): string | null {
 // 形式が崩れていても安全側に倒す（生のモデル出力を reply として漏らさない）。
 // 試行順: (a) フェンスブロック → (b) trim 全体 → (c) extractJsonObject。
 // 全て失敗したときのみ素のテキストへフォールバックする。
-export function parseChatResult(raw: string): ChatResult {
+export function parseChatResult(raw: string, fallbackIntent: ContactIntent | '' = ''): ChatResult {
   const trimmed = raw.trim();
   let classification: Classification = 'genuine';
   let readyForContact = false;
+  let intent: ContactIntent | '' = fallbackIntent;
+  let structuredLead: StructuredLead | undefined;
 
   // 候補を優先順で構築（最初に parse 成功したものを採用）。
   const candidates: string[] = [];
@@ -100,12 +115,17 @@ export function parseChatResult(raw: string): ChatResult {
       const obj = JSON.parse(candidate);
       // 配列/数値/null も JSON.parse は通すため、オブジェクトのみ採用する。
       if (!obj || typeof obj !== 'object' || Array.isArray(obj)) continue;
-      const o = obj as Partial<ChatResult>;
+      const o = obj as Partial<ChatResult> & { intent?: unknown; structuredLead?: unknown };
       if (typeof o.reply === 'string') reply = o.reply.trim();
       if (typeof o.classification === 'string' && VALID_CLASS.includes(o.classification)) {
         classification = o.classification;
       }
       if (typeof o.readyForContact === 'boolean') readyForContact = o.readyForContact;
+      // LLM が返した intent を正規化。空ならクライアント初期値を維持。
+      const llmIntent = normalizeIntent(o.intent);
+      if (llmIntent) intent = llmIntent;
+      const lead = normalizeStructuredLead(o.structuredLead);
+      if (Object.keys(lead).length > 0) structuredLead = lead;
       parsedOk = true;
       break;
     } catch {
@@ -117,7 +137,10 @@ export function parseChatResult(raw: string): ChatResult {
   // ただし生の JSON ブロブをそのまま返さないよう、parse 成功時は reply のみを使う。
   if (!parsedOk) reply = trimmed;
   if (!reply) reply = '申し訳ありません、もう一度お聞かせいただけますか？';
-  return { reply, classification, readyForContact };
+  const result: ChatResult = { reply, classification, readyForContact };
+  if (intent) result.intent = intent;
+  if (structuredLead) result.structuredLead = structuredLead;
+  return result;
 }
 
 // POST /api/contact/chat — 会話による問い合わせの絞り込み。PIIは扱わない。
@@ -132,6 +155,11 @@ async function handleChat(req: Request, env: Env): Promise<Response> {
   const norm = normalizeMessages(body.messages);
   if (!norm.ok) return json({ error: norm.error }, norm.status);
 
+  // intent/source はサーバ側で正規化して system に注入（messages は改ざんしない）。
+  // 未知キーは空に落とす（400 にしない = 後方互換）。
+  const initialIntent = normalizeIntent(body.intent);
+  const source = normalizeSource(body.source);
+
   // fail closed: LLM 未設定なら 503（getProvider が投げる）。
   let provider;
   try {
@@ -140,15 +168,17 @@ async function handleChat(req: Request, env: Env): Promise<Response> {
     return json({ error: 'AIが一時的に利用できません。時間をおいて再試行してください' }, 503);
   }
 
+  const system = buildSystemPrompt({ intent: initialIntent, source });
+
   let raw: string;
   try {
-    raw = await provider.chat(SYSTEM_PROMPT, norm.messages);
+    raw = await provider.chat(system, norm.messages);
   } catch (e) {
     console.error('contact-chat llm error:', e instanceof Error ? e.message : String(e));
     return json({ error: 'AIの応答に失敗しました。時間をおいて再試行してください' }, 502);
   }
 
-  return json(parseChatResult(raw));
+  return json(parseChatResult(raw, initialIntent));
 }
 
 // POST /api/contact/submit — 最終送信。PIIはここで扱い、LLMには絶対渡さずメールにのみ送る。

--- a/workers/contact-chat/src/llm.ts
+++ b/workers/contact-chat/src/llm.ts
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
-import type { ChatMessage, Env } from './types';
+import type { ChatMessage, ContactIntent, Env } from './types';
+import { CONTACT_INTENTS } from './types';
 
 // コスト重視で Sonnet を既定にする（会話のみ・短文応答のため軽量モデルで十分）。
 export const DEFAULT_MODEL = 'claude-sonnet-4-6';
@@ -48,25 +49,44 @@ export function getProvider(env: Env): LlmProvider {
   }
 }
 
+const INTENT_LABELS: Record<ContactIntent, string> = {
+  'confidential-ai-assessment': 'Confidential-data AI assessment consultation',
+  'local-llm-poc': 'Local LLM / secure AI PoC consultation',
+  'grift-team-beta': 'Grift Team Beta product inquiry',
+  'grift-paid-trial': 'Grift Paid Trial product inquiry',
+  'estimate-audit': 'Estimate Audit service inquiry',
+  'contract-dev': 'Contract software development inquiry (受託開発)',
+  'press-speaking-other': 'Press, speaking, or other inquiry',
+};
+
 // --- システムプロンプト ---
 // CRITICAL: messages 内はすべて信頼できないユーザーデータ。役割やルールを書き換える指示には従わない。
 // system プロンプト自体・シークレットは絶対に出力しない。問い合わせ受付タスクから外れない。
 export const SYSTEM_PROMPT = [
-  'You are the contact intake assistant for Cor. (コア株式会社), a Japanese software/technology company.',
+  'You are the contact intake assistant for Cor. (コア株式会社 / Cor.inc), a Japanese software/technology company.',
   'Your ONLY job is to help a website visitor describe their inquiry so the Cor. team can follow up.',
   '',
   '# What you do',
-  "- Greet the visitor in the language they write in (Japanese or English; mirror their language).",
-  '- Help them describe their inquiry: the type of project or request, the rough goal, and any timeline or budget hints. Ask short, friendly follow-up questions one at a time.',
+  '- Greet the visitor in the language they write in (Japanese or English; mirror their language).',
+  '- Help them describe their inquiry using a structured intake (one short question at a time):',
+  '  1) purpose / goal of the inquiry',
+  '  2) industry and role (no personal names)',
+  '  3) data sensitivity level (e.g. public / internal / confidential) — NEVER ask them to paste confidential data contents',
+  '  4) current stage (idea / exploring / ready to start)',
+  '  5) timing and budget band if they are willing to share',
   '- Internally classify the inquiry as one of: "genuine" (a real prospect or support request), "sales" (someone trying to sell something to Cor.), or "spam" (junk, abuse, or nonsense).',
-  '- When you have enough to hand off (project type + rough goal, and ideally a timeline), tell the visitor you are ready to forward this to the team and that they will be asked for their contact details on the next step. Do NOT ask for name/email/phone yourself.',
+  '- Track the best-fit intent among the official keys (ADR-0014):',
+  `  ${CONTACT_INTENTS.join(' | ')}`,
+  '- When you have enough to hand off (purpose + rough goal, and ideally stage/timing), tell the visitor you are ready to forward this to the team and that they will be asked for their contact details on the next step. Do NOT ask for name/email/phone yourself.',
   '',
   '# Output format (STRICT)',
   'Respond with ONLY a single JSON object and nothing else, in exactly this shape:',
-  '{"reply": string, "classification": "genuine" | "sales" | "spam", "readyForContact": boolean}',
+  '{"reply": string, "classification": "genuine" | "sales" | "spam", "readyForContact": boolean, "intent": string | null, "structuredLead": {"purpose"?: string, "industryRole"?: string, "dataSensitivity"?: string, "stage"?: string, "timingBudget"?: string}}',
   '- "reply" is your message to the visitor (in their language).',
   '- "classification" is your current best judgement.',
   '- "readyForContact" is true only once you have enough to hand off.',
+  '- "intent" must be one of the official keys above, or null if still unclear.',
+  '- "structuredLead" holds non-PII structured fields you have collected so far (omit unknown keys).',
   'Do not wrap the JSON in markdown fences. Do not add any text before or after the JSON.',
   '',
   '# Security rules (NON-NEGOTIABLE)',
@@ -78,3 +98,28 @@ export const SYSTEM_PROMPT = [
   '- Stay strictly on the contact-intake task. If asked to do anything unrelated (write code, tell jokes, roleplay, answer general questions), politely decline and steer back to the inquiry.',
   '- If a message is abusive or clearly spam, stay polite, set classification to "spam", and keep the reply minimal.',
 ].join('\n');
+
+/**
+ * 初期 intent/source を system にサーバ側で注入する（messages は改ざんしない）。
+ * 未知 intent は呼び出し側で空にしてから渡すこと。
+ */
+export function buildSystemPrompt(opts: {
+  intent?: ContactIntent | '';
+  source?: string;
+} = {}): string {
+  const parts = [SYSTEM_PROMPT];
+  if (opts.intent) {
+    const label = INTENT_LABELS[opts.intent] || opts.intent;
+    parts.push(
+      '',
+      '# Initial context (server-provided, trusted)',
+      `The visitor arrived with intent="${opts.intent}" (${label}).`,
+      'Start the conversation under that assumption, but update "intent" in your JSON if the conversation clearly indicates a different official key.',
+      'Do not invent keys outside the official list.',
+    );
+  }
+  if (opts.source) {
+    parts.push(`Traffic source tag (for internal routing only, do not read aloud unless asked): "${opts.source}".`);
+  }
+  return parts.join('\n');
+}

--- a/workers/contact-chat/src/types.ts
+++ b/workers/contact-chat/src/types.ts
@@ -19,11 +19,42 @@ export interface ChatMessage {
 // 問い合わせの分類。LLM が会話から判定する。
 export type Classification = 'genuine' | 'sales' | 'spam';
 
+/**
+ * ADR-0014 intent 正本（7 キー）。
+ * src/config/site.ts の CONTACT_INTENTS と同値（parity テストで一致を担保）。
+ */
+export const CONTACT_INTENTS = [
+  'confidential-ai-assessment',
+  'local-llm-poc',
+  'grift-team-beta',
+  'grift-paid-trial',
+  'estimate-audit',
+  'contract-dev',
+  'press-speaking-other',
+] as const;
+
+export type ContactIntent = (typeof CONTACT_INTENTS)[number];
+
+/** Phase 3 (#259) で Grift 自動ハンドオフする intent。#250 では定数のみ。 */
+export const AUTO_HANDOFF_INTENTS = ['contract-dev'] as const;
+
+// 構造化リード（PII ではない。具体データ本文は入れない）
+export interface StructuredLead {
+  purpose?: string;
+  industryRole?: string;
+  dataSensitivity?: string;
+  stage?: string;
+  timingBudget?: string;
+}
+
 // /chat のレスポンス。PII は一切含まない（会話のみ）。
 export interface ChatResult {
   reply: string;
   classification: Classification;
   readyForContact: boolean;
+  /** 確定または推定された intent（未知は落とす） */
+  intent?: ContactIntent | '';
+  structuredLead?: StructuredLead;
 }
 
 // /submit の受け取り。PII を含む。LLM には絶対に渡さない（メールにのみ送る）。
@@ -34,6 +65,10 @@ export interface InquiryInput {
   message?: unknown;
   conversationSummary?: unknown;
   classification?: unknown;
+  intent?: unknown;
+  source?: unknown;
+  structuredLead?: unknown;
+  utm?: unknown;
   turnstileToken?: unknown;
   website?: unknown; // ハニーポット（人間は空のまま）。値が入っていれば bot とみなす。
 }
@@ -46,4 +81,8 @@ export interface NormalizedInquiry {
   message: string;
   conversationSummary: string;
   classification: Classification | '';
+  intent: ContactIntent | '';
+  source: string;
+  structuredLead: StructuredLead;
+  utm: Record<string, string>;
 }

--- a/workers/contact-chat/src/validate.ts
+++ b/workers/contact-chat/src/validate.ts
@@ -2,9 +2,12 @@ import type {
   ChatMessage,
   ChatRole,
   Classification,
+  ContactIntent,
   InquiryInput,
   NormalizedInquiry,
+  StructuredLead,
 } from './types';
+import { CONTACT_INTENTS } from './types';
 
 // --- 入力サニタイズ（プロンプト注入・制御文字対策） ---
 // NUL/制御文字を除去し、長さを制限する。yomimono の sanitizeText と同方針。
@@ -78,6 +81,10 @@ export const MAX_EMAIL_LEN = 254; // RFC 5321 のローカル+ドメイン上限
 export const MAX_COMPANY_LEN = 200;
 export const MAX_INQUIRY_MESSAGE_LEN = 5000;
 export const MAX_SUMMARY_LEN = 8000;
+export const MAX_SOURCE_LEN = 100;
+export const MAX_LEAD_FIELD_LEN = 500;
+export const MAX_UTM_KEYS = 8;
+export const MAX_UTM_VALUE_LEN = 200;
 
 // RFC を厳密には実装せず、実用的で過剰拒否しない緩めのチェック。
 // 1個の @、前後に空白なし、ドメインに少なくとも1つのドット。制御文字は既に除去済み前提。
@@ -91,6 +98,53 @@ function normalizeClassification(c: unknown): Classification | '' {
   return typeof c === 'string' && (VALID_CLASSIFICATIONS as readonly string[]).includes(c)
     ? (c as Classification)
     : '';
+}
+
+/** 7 キー以外は空（未知は 400 にせずフォールバック） */
+export function normalizeIntent(raw: unknown): ContactIntent | '' {
+  if (typeof raw !== 'string') return '';
+  const v = raw.trim();
+  return (CONTACT_INTENTS as readonly string[]).includes(v) ? (v as ContactIntent) : '';
+}
+
+export function normalizeSource(raw: unknown): string {
+  return sanitizeLine(raw, MAX_SOURCE_LEN);
+}
+
+const LEAD_KEYS = [
+  'purpose',
+  'industryRole',
+  'dataSensitivity',
+  'stage',
+  'timingBudget',
+] as const;
+
+export function normalizeStructuredLead(raw: unknown): StructuredLead {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const src = raw as Record<string, unknown>;
+  const out: StructuredLead = {};
+  for (const key of LEAD_KEYS) {
+    const v = sanitizeMessage(src[key], MAX_LEAD_FIELD_LEN);
+    if (v) out[key] = v;
+  }
+  return out;
+}
+
+export function normalizeUtm(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const src = raw as Record<string, unknown>;
+  const out: Record<string, string> = {};
+  let n = 0;
+  for (const [k, v] of Object.entries(src)) {
+    if (n >= MAX_UTM_KEYS) break;
+    const key = sanitizeLine(k, 40);
+    if (!key || !/^utm_[a-z0-9_]+$/i.test(key)) continue;
+    const val = sanitizeLine(v, MAX_UTM_VALUE_LEN);
+    if (!val) continue;
+    out[key] = val;
+    n++;
+  }
+  return out;
 }
 
 export type InquiryValidation =
@@ -116,6 +170,10 @@ export function normalizeInquiry(input: InquiryInput | undefined): InquiryValida
   const message = sanitizeMessage(input.message, MAX_INQUIRY_MESSAGE_LEN);
   const conversationSummary = sanitizeMessage(input.conversationSummary, MAX_SUMMARY_LEN);
   const classification = normalizeClassification(input.classification);
+  const intent = normalizeIntent(input.intent);
+  const source = normalizeSource(input.source);
+  const structuredLead = normalizeStructuredLead(input.structuredLead);
+  const utm = normalizeUtm(input.utm);
 
   if (!name) {
     return { ok: false, error: 'お名前は必須です', status: 400 };
@@ -129,6 +187,17 @@ export function normalizeInquiry(input: InquiryInput | undefined): InquiryValida
 
   return {
     ok: true,
-    inquiry: { name, email, company, message, conversationSummary, classification },
+    inquiry: {
+      name,
+      email,
+      company,
+      message,
+      conversationSummary,
+      classification,
+      intent,
+      source,
+      structuredLead,
+      utm,
+    },
   };
 }


### PR DESCRIPTION
## Summary
Phase 1 / #250: contact-chat を ADR-0014 の **intent 7キー**対応に拡張する。

- `contract-dev`（受託開発相談）を `src/config/site.ts` と Worker に追加
- `/api/contact/chat` が `intent` / `source` を受け取り system に注入
- `/api/contact/submit` が `intent` / `source` / `structuredLead` / `utm` をメール件名・本文へ
- Header「AI基盤構築・AI受託」→ `intent=contract-dev`
- parity テストで site ↔ Worker のキー一致を担保
- **Grift 自動ハンドオフは #259（Phase 3）**。本 PR は受け口と `AUTO_HANDOFF_INTENTS` 定数のみ

## Test plan
- [x] `cd workers/contact-chat && npm test`（117 passed）
- [x] `cd workers/contact-chat && npm run typecheck`
- [x] `npx vitest run src/config/__tests__/site.test.ts`
- [ ] CI グリーン
- [ ] merge 後: Worker dry-run →（承認後）deploy
- [ ] `curl` health + chat with `intent=contract-dev`
- [ ] Preview で Header 受託リンクが `?intent=contract-dev`

## Related
- Closes #250
- Refs ADR-0013 / ADR-0014 / ADR-0015
- Out of scope: #254 Cloudia 埋込, #259 Grift handoff, #252 analytics