### PR TITLE
fix(contact-chat): expose handoff after complete intake

### DIFF
--- a/workers/contact-chat/src/__tests__/index.test.ts
+++ b/workers/contact-chat/src/__tests__/index.test.ts
@@ -199,6 +199,49 @@ describe('worker.fetch — ハンドラレベル', () => {
     expect(gatewayFetch).toHaveBeenCalledTimes(1);
   });
 
+  it('all structured intake fields trigger the contact step even if the model under-reports readiness', async () => {
+    const gatewayFetch = vi.fn(async () => new Response(JSON.stringify({
+      candidates: [{
+        content: {
+          parts: [{
+            text: JSON.stringify({
+              reply: '内容を確認しました。連絡先入力へ進めます。',
+              summary: '社内向けAI基盤のPoCについて、目的・体制・機密性・時期を確認済み',
+              classification: 'genuine',
+              readyForContact: false,
+              intent: 'local-llm-poc',
+              structuredLead: {
+                purpose: '社内向けAI基盤のPoC',
+                industryRole: '広告会社の企画担当',
+                dataSensitivity: '機密',
+                stage: 'exploring',
+                timingBudget: '3か月以内',
+              },
+            }),
+          }],
+        },
+      }],
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', gatewayFetch);
+    const env = {
+      ...ENV,
+      LLM_PROVIDER: 'vertex-gemini',
+      VERTEX_GATEWAY_URL: 'https://gateway.example/generateContent',
+      VERTEX_GATEWAY_SECRET: 'secret',
+    } as Env;
+    const res = await worker.fetch(post('/api/contact/chat', {
+      mode: 'intake',
+      locale: 'ja',
+      intent: 'local-llm-poc',
+      messages: [{ role: 'user', content: '必要な情報はまとめてお伝えします。' }],
+    }), env);
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.readyForContact).toBe(true);
+    expect(body.stage).toBe('ready');
+    expect(body.missingFields).toEqual([]);
+  });
+
   it('VertexリクエストへPIIをそのまま渡さない', async () => {
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(JSON.stringify({
       candidates: [{ content: { parts: [{ text: '{"reply":"ok","readyForContact":false}' }] } }],

--- a/workers/contact-chat/src/index.ts
+++ b/workers/contact-chat/src/index.ts
@@ -324,8 +324,20 @@ async function handleChat(req: Request, env: Env, forceStart = false): Promise<R
   const result = parseChatResult(raw, initialIntent, locale);
   const sessionId = normalizeSessionId(body.sessionId) || newSessionId();
   result.sessionId = sessionId;
-  result.stage = resultStage(result);
   result.missingFields = leadMissingFields(result.structuredLead);
+  // Keep the model free to choose its questioning path, but do not leave the
+  // visitor stranded when every non-PII intake field is already present and
+  // the model under-reports readiness. This is a completeness gate, not a
+  // fixed question count; press-specific flows can still hand off earlier.
+  if (
+    !result.readyForContact
+    && Boolean(initialIntent)
+    && Boolean(result.structuredLead && Object.keys(result.structuredLead).length > 0)
+    && result.missingFields.length === 0
+  ) {
+    result.readyForContact = true;
+  }
+  result.stage = resultStage(result);
   try {
     await upsertContactSession(env, {
       sessionId,


### PR DESCRIPTION
## Summary
- apply a completeness gate after the AI response when all non-PII intake fields are present
- keep question order and turn count model-driven
- add a regression test for an under-reported `readyForContact` response

## Validation
- 174 Worker tests passed
- Worker typecheck passed
