### PR TITLE
fix(contact-chat): enforce short company name in ordinary replies

### DIFF
--- a/workers/contact-chat/src/__tests__/index.test.ts
+++ b/workers/contact-chat/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
-import worker, { extractJsonObject, parseChatResult } from '../index';
+import worker, { extractJsonObject, normalizeCompanyNameReply, parseChatResult } from '../index';
 import { resetRateLimits } from '../security';
 import type { Env } from '../types';
 import { decryptText, encryptText } from '../storage';
@@ -542,5 +542,19 @@ describe('parseChatResult — intent / structuredLead (#250)', () => {
     const raw = '{"reply":"x","classification":"genuine","readyForContact":false}';
     const r = parseChatResult(raw, 'grift-team-beta');
     expect(r.intent).toBe('grift-team-beta');
+  });
+});
+
+describe('normalizeCompanyNameReply — 通常表示は短く、質問時だけ詳細', () => {
+  it('通常の相談文に混ざった読み方・ブランド名の括弧を除去する', () => {
+    const reply = 'Cor.株式会社（コー株式会社）の導入支援についてご案内します。';
+    expect(normalizeCompanyNameReply(reply, [{ role: 'user', content: '導入方法を相談したいです' }]))
+      .toBe('Cor.株式会社の導入支援についてご案内します。');
+  });
+
+  it('読み方を明示的に尋ねた場合は詳細を保持する', () => {
+    const reply = 'Cor.株式会社（コー株式会社、ブランド名：Cor.inc）です。';
+    expect(normalizeCompanyNameReply(reply, [{ role: 'user', content: '会社名の読み方とブランド名を教えてください。' }]))
+      .toBe(reply);
   });
 });

--- a/workers/contact-chat/src/index.ts
+++ b/workers/contact-chat/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   ChatLocale,
+  ChatMessage,
   ChatMode,
   ChatResult,
   Classification,
@@ -103,6 +104,23 @@ function isSafeChatSummary(candidate: string): boolean {
     && !SUMMARY_ROLE_LINE.test(candidate)
     && !SUMMARY_SECRET_RE.test(candidate)
     && candidate === maskSensitiveContent(candidate);
+}
+
+const COMPANY_DETAIL_TERMS = /(?:コー株式会社|Cor\.inc|ブランド|読み|ふりがな|正式名称|read\s+as|pronounc|legal\s+name|brand)/i;
+const COMPANY_DETAIL_QUESTION = /(?:[?？]|教えて|知りたい|とは|どう読む|読み方|what|how|which|tell me)/i;
+
+/**
+ * Keep ordinary model replies on the short company name even when the model
+ * volunteers a parenthetical reading/brand explanation. Details remain
+ * available when the visitor explicitly asks about the company name.
+ */
+export function normalizeCompanyNameReply(reply: string, messages: ChatMessage[]): string {
+  const latestUser = [...messages].reverse().find((message) => message.role === 'user')?.content || '';
+  const allowsDetail = COMPANY_DETAIL_TERMS.test(latestUser) && COMPANY_DETAIL_QUESTION.test(latestUser);
+  if (allowsDetail) return reply;
+  return reply.replace(/\bCor(?:\.株式会社|\.\s*Inc\.?)\s*[（(]([^）)]{0,180})[）)]/gi, (whole, detail: string) => {
+    return COMPANY_DETAIL_TERMS.test(detail) ? 'Cor.株式会社' : whole;
+  });
 }
 
 // 文字列リテラルを尊重しながら、最初のトップレベル `{...}` を抜き出す。
@@ -322,6 +340,7 @@ async function handleChat(req: Request, env: Env, forceStart = false): Promise<R
   }
 
   const result = parseChatResult(raw, initialIntent, locale);
+  result.reply = normalizeCompanyNameReply(result.reply, norm.messages);
   const sessionId = normalizeSessionId(body.sessionId) || newSessionId();
   result.sessionId = sessionId;
   result.missingFields = leadMissingFields(result.structuredLead);


### PR DESCRIPTION
## Summary\n- sanitize unsolicited parenthetical pronunciation/brand details in normal model replies\n- preserve details when the visitor explicitly asks about reading or brand\n- add contract tests for both paths\n\n## Verification\n- 181 Worker tests passed\n- npm run typecheck passed