### PR TITLE
feat(contact): make Cloudia the primary inquiry path

### DIFF
--- a/docs/adr/ADR-0009-news-cases-cms-expansion.md
+++ b/docs/adr/ADR-0009-news-cases-cms-expansion.md
@@ -1,6 +1,6 @@
 # ADR-0009 yomimono CMS の news/cases 拡張 + 非エンジニア向けUI改善 + OGP PNG化
 
-## ステータス: Proposed (2026-07-08)
+## ステータス: Accepted (2026-07-14)
 
 ## 背景
 ADR-0008 で確立した「静的＋記事bot（DBなし）」の読みものCMS基盤（yomimono Worker / `cor-yomimono-bot`）は**ブログ単機能で稼働中**。これを取り巻く4つの課題がある:
@@ -21,7 +21,7 @@ ADR-0008 の「静的＋記事bot・DBなし・Cloudflare Worker」アーキテ�
 1. **yomimono Worker を blog/news/cases の3コレクションに拡張（DBレス・同 GitHub App・静的）**:
    - Worker 1つ・route 1つ（`/blog-admin*`）のまま、`body.collection`（`'blog'|'news'|'cases'`・既定 `'blog'`）でコレクションを切替。別 Worker/別 route は Cloudflare 設定・シークレット再登録コストが高いため採用しない。
    - 同一の GitHub App（`cor-yomimono-bot`・`contents:write`・パス制限なし）が `src/content/{blog/ja,news,cases}/` 配下にコミット。**DB・SSR 化なし・既存の push→Firebase SSG デプロイでそのまま公開**。
-   - `src/content/config.ts` に `newsCollection` を追加（本文 ja 専用・cases と同じ `availableLocales={['ja']}` 方針・5カテゴリ: info/media/update/event/award・`externalUrl` 設定時は個別ページ生成せず外部遷移）。
+   - `src/content/config.ts` に `newsCollection` を追加（本文 ja 専用・cases と同じ `availableLocales={['ja']}` 方針・6カテゴリ: info/media/update/event/award/press・`externalUrl` 設定時は個別ページ生成せず外部遷移）。
    - cases はフラット配置（`cases/<slug>.md`）を維持（URL 破壊を回避）。
 2. **全 CMS UI の非エンジニア向けフル改善（blog/news/cases 共通）**:
    - `ui-shared.ts` に共通改善モジュールを新設し、3画面（`ui-manual.ts`/`ui-manual-news.ts`/`ui-manual-cases.ts`）で共有。note/Qiita 級の書きやすさを実現:
@@ -46,7 +46,7 @@ ADR-0008 の「静的＋記事bot・DBなし・Cloudflare Worker」アーキテ�
 - **Milestone 構成（1PR=1意図・ワークツリー分岐）**:
   - **M1: yomimono collection 基盤 + UI改善基盤** — I1（collection 対応基盤）/ I2（UI改善基盤・共通）/ I3（既存記事編集）。**M1-I1 は PR #221 で develop マージ済**（test 172 緑・blog 回帰なし・`contentDir`/`normalizeArticle`/`buildMarkdown` の collection 分岐）。
   - **M2: cases CMS** — I4（cases 投稿UI・改善版）。`/manual/cases` から `body.collection='cases'` で `src/content/cases/<slug>.md` へ投稿する経路を追加済み。
-  - **M3: news 機能**（★news は M3 で有効化）— I5（news コレクション+投稿UI）/ I6（一覧・個別・NewsCard・SEO）/ I7（i18n+nav+sitemap+RSS）。
+  - **M3: news 機能**（★news は M3 で有効化）— I5（news コレクション+投稿UI）/ I6（一覧・個別・NewsCard・SEO）/ I7（i18n+nav+sitemap+RSS）。プレスリリースは `press` カテゴリと `/news/press/` の専用導線で公開する。
   - **M4: OGP PNG化**（★news リリース前完了推奨・先輩の直接要件）— I10（SVG→PNG・全ページ共通）。
 - **ADR-0008 からの進化**: ADR-0008「ブログ単機能」を「blog/news/cases の3コレクション・DBレス同 bot・非エンジニア向けUI」に拡張。ADR-0008 本体は温存し、本 ADR で拡張する関係（詳細は ADR-0008 末尾の追記参照）。
 - Worker は既存の `routes=cor-jp.com/blog-admin*`・シークレット群を再利用（`NEWS_DIR`/`CASES_DIR` の `[vars]` 追加のみ・シークレット再登録不要）。
@@ -66,5 +66,13 @@ ADR-0008 の「静的＋記事bot・DBなし・Cloudflare Worker」アーキテ�
 - 整合: ADR-0006（i18n 単一正本・news は ja 専用）/ ADR-0007（対外表現ガードレール・news/cases 本文にも適用）
 - 実装計画（Epic #220）: M1〜M4 の Milestone/Issue 構成・Critical Files
 - 既存資産（再利用）: `docs/blog-style-guide.md` / `scripts/generate-blog-draft.mjs` / `scripts/blog-guardrails.mjs` / `workers/yomimono/src/{guardrails,generate,validate}.ts`
+
+## プレスリリース運用
+
+- 新規の外部API、PR TIMES自動取込、DBは導入せず、既存の `news` コレクションと Yomimono CMS で管理する。
+- `category: press`、既存の `externalUrl`、`source` を使用し、公式発表または掲載許諾を確認できた内容だけを公開する。
+- `/news/press/`、ホームのニュース欄、日本語Header、ニュース一覧から導線を提供する。RSS・OGP・JSON-LD・外部リンクの `noopener noreferrer` は既存実装を継承する。
+- 公開責任者は担当者（初期は `terisuke`）とし、公開前に内容・日付・出典・リンク先・社名表記を校正する。公開後の訂正は新しい更新日と理由を記録する。
+- 取材・登壇・掲載相談の入口は `press-speaking-other` とし、プレスリリースの公開と問い合わせ受付を混同しない。
 
 Co-Authored-By: Claude <noreply@anthropic.com>

--- a/docs/adr/ADR-0013-contact-consolidation-cloudia.md
+++ b/docs/adr/ADR-0013-contact-consolidation-cloudia.md
@@ -22,7 +22,8 @@
 
 ### 公開順序との整合
 - Epic #243 の公開順序「導線の真実性 → 有料入口 → 信頼証拠 → Cloudia → 050 AI 受付 → 背景演出」を維持する。
-- Cloudia 本線化（#254）までは従来フォームが主 UI であり、本 ADR は最終状態（グランドデザイン）を定義するものである。
+- `/contact/` は Cloudia への主導線（`/contact/chat/`、`embed=1`、`source`、`locale`、任意の `intent`）を表示する。従来の SSGFORM と日程調整は `details#contact-form-fallback` 内に残し、Cloudia 障害・JS 無効・a11y の fallback とする。
+- 全ページ右下の Cloudia launcher は同じ iframe 契約で常駐し、スマートフォンでは safe-area を考慮したボトムシートとして開閉する。
 
 ## 影響
 - corsweb: #250（contact-chat 構造化 intent フロー）、#254（Cloudia 埋め込み）、#252（計測）

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,10 +16,13 @@
 | [ADR-0006](./ADR-0006-i18n-single-source.md) | i18n source of truth を `src/utils/i18n.ts` に一本化（`*.json` 廃止） | Accepted (2026-06-13) |
 | [ADR-0007](./ADR-0007-external-expression-guardrails.md) | 対外表現ガードレール（ISMS・旧事業・社名・証拠ルール） | Accepted (2026-06-13) / rev 2026-07-10 |
 | [ADR-0008](./ADR-0008-yomimono-ai-workflow.md) | 読みもの AI 支援ワークフロー | Proposed |
-| [ADR-0009](./ADR-0009-news-cases-cms-expansion.md) | news/cases CMS 拡張 + OGP PNG | Proposed |
+| [ADR-0009](./ADR-0009-news-cases-cms-expansion.md) | news/cases CMS 拡張 + プレスリリース運用 + OGP PNG | Accepted (2026-07-14) |
 | [ADR-0010](./ADR-0010-cross-site-cta-env-and-intent.md) | Cor↔Grift CTA 環境変数・intent・Preview noindex | Accepted (2026-07-10) |
 | [ADR-0011](./ADR-0011-paid-entry-and-nav-ia.md) | 有料入口 CTA・Header IA・050 表示方針 | Accepted (2026-07-10) |
 | [ADR-0012](./ADR-0012-cloudia-integration-and-org-transfer.md) | Cloudia を Contact フォーム代用として統合（org 移管・CF） | Accepted (2026-07-10) |
+| [ADR-0013](./ADR-0013-contact-consolidation-cloudia.md) | 問い合わせ一極集中（Cloudia UI + contact-chat） | Accepted (2026-07-11) |
+| [ADR-0014](./ADR-0014-intent-7keys-and-routing.md) | intent 正本の 7 キー化と intent ルーティング | Accepted (2026-07-11) |
+| [ADR-0015](./ADR-0015-cross-repo-adr-canon.md) | 横断 ADR の正本配置と参照方式 | Accepted (2026-07-11) |
 
 ## フェーズ対応
 

--- a/e2e/contact-cloudia.spec.ts
+++ b/e2e/contact-cloudia.spec.ts
@@ -1,0 +1,208 @@
+import { expect, test } from '@playwright/test';
+
+const query = '?intent=grift-team-beta&source=grift-lp-hero&utm_source=grift&utm_medium=cta';
+
+test.describe('Cloudia contact routing', () => {
+  test('keeps LP intent and source in the primary link and launcher iframe', async ({ page }) => {
+    await page.goto(`/contact/${query}`);
+
+    const primaryLink = page.locator(
+      'section[aria-labelledby="cloudia-contact-entry-title"] [data-cloudia-query-link]'
+    );
+    await expect(primaryLink).toHaveAttribute('href', /\/contact\/chat\/\?/);
+
+    const primaryUrl = new URL((await primaryLink.getAttribute('href')) ?? '', page.url());
+    expect(primaryUrl.searchParams.get('intent')).toBe('grift-team-beta');
+    expect(primaryUrl.searchParams.get('source')).toBe('grift-lp-hero');
+    expect(primaryUrl.searchParams.get('locale')).toBe('ja');
+
+    const frame = page.locator('#cloudia-launcher-frame');
+    await expect(frame).toHaveAttribute('src', /embed=1/);
+    const frameUrl = new URL((await frame.getAttribute('src')) ?? '', page.url());
+    expect(frameUrl.searchParams.get('intent')).toBe('grift-team-beta');
+    expect(frameUrl.searchParams.get('source')).toBe('grift-lp-hero');
+    expect(frameUrl.searchParams.get('locale')).toBe('ja');
+    expect(frameUrl.searchParams.get('embed')).toBe('1');
+
+    const fallbackUrl = new URL(
+      (await page.locator('[data-cloudia-fallback-link]').getAttribute('href')) ?? '',
+      page.url()
+    );
+    expect(fallbackUrl.pathname).toBe('/contact/');
+    expect(fallbackUrl.searchParams.get('intent')).toBe('grift-team-beta');
+    expect(fallbackUrl.searchParams.get('source')).toBe('grift-lp-hero');
+    expect(fallbackUrl.searchParams.get('locale')).toBe('ja');
+  });
+
+  test('opens and closes accessibly and restores focus', async ({ page }) => {
+    await page.goto('/contact/');
+
+    const openButton = page.locator('#cloudia-launcher-open');
+    const closeButton = page.locator('#cloudia-launcher-close');
+    const panel = page.locator('#cloudia-launcher-panel');
+
+    await openButton.click();
+    await expect(openButton).toHaveAttribute('aria-expanded', 'true');
+    await expect(panel).toHaveAttribute('aria-hidden', 'false');
+    await expect(closeButton).toBeFocused();
+
+    await closeButton.click();
+    await expect(openButton).toHaveAttribute('aria-expanded', 'false');
+    await expect(panel).toHaveAttribute('aria-hidden', 'true');
+    await expect(openButton).toBeFocused();
+
+    await openButton.click();
+    await page.keyboard.press('Escape');
+    await expect(panel).toHaveAttribute('aria-hidden', 'true');
+    await expect(openButton).toBeFocused();
+  });
+
+  test('fits a mobile safe-area viewport without horizontal scrolling', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`/contact/${query}`);
+    await page.locator('#cloudia-launcher-open').click();
+
+    const dimensions = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+      panel: document.getElementById('cloudia-launcher-panel')?.getBoundingClientRect(),
+    }));
+
+    expect(dimensions.scrollWidth).toBe(dimensions.clientWidth);
+    expect(dimensions.panel?.left).toBeGreaterThanOrEqual(0);
+    expect(dimensions.panel?.right).toBeLessThanOrEqual(390);
+    expect(dimensions.panel?.bottom).toBeLessThanOrEqual(844);
+  });
+
+  test('uses the localized route locale for Cloudia', async ({ page }) => {
+    await page.goto('/en/contact/?intent=estimate-audit&source=grift-lp-estimate');
+    const primaryUrl = new URL(
+      (await page
+        .locator('section[aria-labelledby="cloudia-contact-entry-title"] [data-cloudia-query-link]')
+        .getAttribute('href')) ?? '',
+      page.url()
+    );
+
+    expect(primaryUrl.searchParams.get('intent')).toBe('estimate-audit');
+    expect(primaryUrl.searchParams.get('source')).toBe('grift-lp-estimate');
+    expect(primaryUrl.searchParams.get('locale')).toBe('en');
+  });
+
+  test('navigates only for an unexpired, exact Grift portal handoff from its iframe', async ({
+    page,
+  }) => {
+    const handoffUrl = 'https://app.griftai.org/chat/portal/opaque-token_123.~';
+    await page.route('https://app.griftai.org/**', async (route) => {
+      await route.fulfill({ contentType: 'text/html', body: '<title>Grift portal</title>' });
+    });
+    await page.goto('/contact/');
+
+    await Promise.all([
+      page.waitForURL(handoffUrl),
+      page.evaluate(
+        ({ url, expiresAt }) => {
+          const frame = document.getElementById('cloudia-launcher-frame');
+          if (!(frame instanceof HTMLIFrameElement) || !frame.contentWindow) {
+            throw new Error('Cloudia iframe is unavailable');
+          }
+          window.dispatchEvent(
+            new MessageEvent('message', {
+              data: { type: 'cloudia:grift-handoff-ready', url, expiresAt },
+              origin: window.location.origin,
+              source: frame.contentWindow,
+            })
+          );
+        },
+        { url: handoffUrl, expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString() }
+      ),
+    ]);
+
+    await expect(page).toHaveTitle('Grift portal');
+  });
+
+  test('rejects forged sources, origins, URL variants, and invalid handoff TTLs', async ({
+    page,
+  }) => {
+    await page.goto('/contact/');
+    const originalUrl = page.url();
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const cases: Array<{
+      url: string;
+      expiresAt: string;
+      origin?: string;
+      useFrameSource?: boolean;
+    }> = [
+      {
+        url: 'https://app.griftai.org/chat/portal/token',
+        expiresAt: future,
+        origin: 'https://evil.example',
+      },
+      {
+        url: 'https://app.griftai.org/chat/portal/token',
+        expiresAt: future,
+        useFrameSource: false,
+      },
+      { url: 'https://user:password@app.griftai.org/chat/portal/token', expiresAt: future },
+      {
+        url: 'https://app.griftai.org/chat/portal/token?next=https://evil.example',
+        expiresAt: future,
+      },
+      { url: 'https://app.griftai.org/chat/portal/token#next', expiresAt: future },
+      { url: 'https://app.griftai.org/chat/portal/token%2Fadmin', expiresAt: future },
+      { url: 'https://app.griftai.org/admin/token', expiresAt: future },
+      { url: 'https://evil.example/chat/portal/token', expiresAt: future },
+      {
+        url: 'https://app.griftai.org/chat/portal/token',
+        expiresAt: new Date(Date.now() - 1000).toISOString(),
+      },
+      {
+        url: 'https://app.griftai.org/chat/portal/token',
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000 + 60_000).toISOString(),
+      },
+      { url: 'https://app.griftai.org/chat/portal/token', expiresAt: 'not-a-date' },
+    ];
+
+    for (const invalid of cases) {
+      await page.evaluate(({ url, expiresAt, origin, useFrameSource }) => {
+        const frame = document.getElementById('cloudia-launcher-frame');
+        if (!(frame instanceof HTMLIFrameElement) || !frame.contentWindow) {
+          throw new Error('Cloudia iframe is unavailable');
+        }
+        window.dispatchEvent(
+          new MessageEvent('message', {
+            data: { type: 'cloudia:grift-handoff-ready', url, expiresAt },
+            origin: origin || window.location.origin,
+            source: useFrameSource === false ? window : frame.contentWindow,
+          })
+        );
+      }, invalid);
+    }
+
+    await page.waitForTimeout(50);
+    await expect(page).toHaveURL(originalUrl);
+  });
+
+  test('keeps the existing cloudia:ready message contract with same-origin checks', async ({
+    page,
+  }) => {
+    await page.goto('/contact/');
+    const fallback = page.locator('#cloudia-launcher-fallback');
+    await fallback.evaluate((element) => element.classList.remove('hidden'));
+
+    await page.evaluate(() => {
+      const frame = document.getElementById('cloudia-launcher-frame');
+      if (!(frame instanceof HTMLIFrameElement) || !frame.contentWindow) {
+        throw new Error('Cloudia iframe is unavailable');
+      }
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: 'cloudia:ready',
+          origin: window.location.origin,
+          source: frame.contentWindow,
+        })
+      );
+    });
+
+    await expect(fallback).toHaveClass(/hidden/);
+  });
+});

--- a/src/components/contact/CloudiaContactEntry.astro
+++ b/src/components/contact/CloudiaContactEntry.astro
@@ -1,0 +1,76 @@
+---
+import { getCurrentLocale } from '../../utils/i18n';
+
+const currentLocale = getCurrentLocale(Astro.url);
+const chatUrl = new URL('/contact/chat/', Astro.url);
+chatUrl.searchParams.set('source', 'corsweb-contact-primary');
+chatUrl.searchParams.set('locale', currentLocale);
+const incomingIntent = Astro.url.searchParams.get('intent');
+if (incomingIntent) chatUrl.searchParams.set('intent', incomingIntent);
+
+const copy =
+  currentLocale === 'ja'
+    ? {
+        eyebrow: 'Contact with Cloudia',
+        title: 'まずはCloudiaにご相談ください',
+        description:
+          '相談モードと雑談モードを切り替えながら、Cor.へのご相談内容を整理できます。日本語・英語に対応しています。',
+        cta: 'Cloudiaを開く',
+        fallbackTitle: 'フォーム・日程調整を利用する',
+        fallbackDescription: 'AIチャットを利用できない場合や、直接フォームでご連絡いただく場合はこちらをご利用ください。',
+      }
+    : {
+        eyebrow: 'Contact with Cloudia',
+        title: 'Start with a conversation with Cloudia',
+        description:
+          'Use consultation or casual conversation mode to organize your inquiry to Cor. Cloudia supports Japanese and English.',
+        cta: 'Open Cloudia',
+        fallbackTitle: 'Use the form or schedule a meeting',
+        fallbackDescription: 'Use the fallback form when the AI chat is unavailable or when you prefer to contact us directly.',
+      };
+const chatPath = `${chatUrl.pathname}${chatUrl.search}`;
+---
+
+<section class="mx-auto max-w-3xl px-4 pb-6 sm:px-6 lg:px-8" aria-labelledby="cloudia-contact-entry-title">
+  <div class="overflow-hidden rounded-3xl bg-primary-950 px-6 py-8 text-primary-50 shadow-xl sm:px-8 sm:py-10 dark:bg-primary-100 dark:text-primary-950">
+    <p class="text-sm font-medium uppercase tracking-[0.18em] text-primary-300 dark:text-primary-700">{copy.eyebrow}</p>
+    <div class="mt-4 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+      <div class="max-w-2xl">
+        <h2 id="cloudia-contact-entry-title" class="type-heading text-2xl font-medium sm:text-3xl">{copy.title}</h2>
+        <p class="type-copy mt-3 text-primary-200/80 dark:text-primary-800/80">{copy.description}</p>
+      </div>
+      <a
+        href={chatPath}
+        data-cloudia-query-link
+        class="inline-flex min-h-12 shrink-0 items-center justify-center rounded-full bg-primary-300 px-5 py-3 text-base font-semibold text-primary-950 transition hover:bg-primary-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-300 dark:bg-primary-700 dark:text-primary-50 dark:hover:bg-primary-800"
+      >{copy.cta}</a>
+    </div>
+  </div>
+</section>
+
+<details id="contact-form-fallback" class="mx-auto max-w-3xl px-4 pb-12 sm:px-6 lg:px-8">
+  <summary class="cursor-pointer rounded-2xl bg-primary-500/10 px-5 py-4 text-base font-semibold text-primary-950 outline-none transition hover:bg-primary-500/15 focus-visible:ring-2 focus-visible:ring-primary-600 dark:bg-primary-400/10 dark:text-primary-100 dark:hover:bg-primary-400/15">
+    {copy.fallbackTitle}
+  </summary>
+  <p class="px-2 py-4 text-sm leading-6 text-primary-950/65 dark:text-primary-200/65">{copy.fallbackDescription}</p>
+  <div class="overflow-hidden rounded-3xl bg-primary-500/5 dark:bg-primary-400/5">
+    <slot />
+  </div>
+</details>
+
+<script is:inline>
+  (() => {
+    const incoming = new URLSearchParams(window.location.search);
+    const intent = incoming.get('intent');
+    const source = incoming.get('source');
+    if (!intent && !source) return;
+
+    document.querySelectorAll('[data-cloudia-query-link]').forEach((element) => {
+      if (!(element instanceof HTMLAnchorElement)) return;
+      const target = new URL(element.href, window.location.href);
+      if (intent) target.searchParams.set('intent', intent);
+      if (source) target.searchParams.set('source', source);
+      element.href = `${target.pathname}${target.search}${target.hash}`;
+    });
+  })();
+</script>

--- a/src/components/contact/CloudiaLauncher.astro
+++ b/src/components/contact/CloudiaLauncher.astro
@@ -1,17 +1,12 @@
 ---
 import { getCurrentLocale, getLocalizedUrl } from '../../utils/i18n';
 
-interface Props {
-  showMobile?: boolean;
-}
-
-const { showMobile = false } = Astro.props;
-
 const currentLocale = getCurrentLocale(Astro.url);
 const chatUrl = new URL('/contact/chat/', Astro.url);
-chatUrl.searchParams.set('source', 'corsweb-contact-launcher');
+chatUrl.searchParams.set('source', 'corsweb-launcher');
 chatUrl.searchParams.set('locale', currentLocale);
-const chatPath = `${chatUrl.pathname}${chatUrl.search}`;
+const incomingIntent = Astro.url.searchParams.get('intent');
+if (incomingIntent) chatUrl.searchParams.set('intent', incomingIntent);
 const embedChatUrl = new URL(chatUrl);
 embedChatUrl.searchParams.set('embed', '1');
 const embedChatPath = `${embedChatUrl.pathname}${embedChatUrl.search}`;
@@ -35,7 +30,7 @@ const copy = currentLocale === 'ja'
 
 <aside
   id="cloudia-launcher"
-  class="fixed bottom-5 right-5 z-40 hidden w-[min(24rem,calc(100vw-2rem))] md:block"
+  class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] right-4 z-40 w-[min(24rem,calc(100vw-2rem))] sm:right-5"
   data-chat-path={embedChatPath}
 >
   <div
@@ -54,7 +49,7 @@ const copy = currentLocale === 'ja'
         <span aria-hidden="true" class="text-xl leading-none">×</span>
       </button>
     </div>
-    <div class="relative h-[min(38rem,70vh)] bg-primary-950/5 dark:bg-primary-50/5">
+    <div class="relative h-[min(38rem,70dvh)] max-h-[70dvh] bg-primary-950/5 dark:bg-primary-50/5">
       <iframe
         id="cloudia-launcher-frame"
         title={copy.title}
@@ -87,13 +82,6 @@ const copy = currentLocale === 'ja'
   </button>
 </aside>
 
-{showMobile && (
-  <a
-    href={chatPath}
-    class="fixed bottom-4 left-4 right-4 z-40 inline-flex min-h-12 items-center justify-center rounded-full bg-primary-600 px-5 py-3 text-sm font-semibold text-white shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 md:hidden"
-  >{copy.label}</a>
-)}
-
 <script is:inline>
   (() => {
     const launcher = document.getElementById('cloudia-launcher');
@@ -107,6 +95,20 @@ const copy = currentLocale === 'ja'
     let opened = false;
     let frameReady = false;
     let fallbackTimer;
+
+    const applyIncomingContext = () => {
+      const incoming = new URLSearchParams(window.location.search);
+      const intent = incoming.get('intent');
+      const source = incoming.get('source');
+      if (!intent && !source) return;
+      const target = new URL(frame.src, window.location.href);
+      if (intent) target.searchParams.set('intent', intent);
+      if (source) target.searchParams.set('source', source);
+      frame.src = target.toString();
+      launcher.dataset.chatPath = `${target.pathname}${target.search}`;
+    };
+
+    applyIncomingContext();
 
     const showFallback = () => {
       if (!frameReady) fallback.classList.remove('hidden');
@@ -131,6 +133,7 @@ const copy = currentLocale === 'ja'
       panel.classList.remove('hidden');
       panel.setAttribute('aria-hidden', 'false');
       openButton.setAttribute('aria-expanded', 'true');
+      closeButton.focus();
       window.clearTimeout(fallbackTimer);
       fallbackTimer = window.setTimeout(showFallback, 8000);
       inspectFrame();

--- a/src/components/contact/CloudiaLauncher.astro
+++ b/src/components/contact/CloudiaLauncher.astro
@@ -1,5 +1,9 @@
 ---
 import { getCurrentLocale, getLocalizedUrl } from '../../utils/i18n';
+import {
+  CLOUDIA_GRIFT_HANDOFF_ALLOWED_ORIGINS,
+  CLOUDIA_GRIFT_HANDOFF_MAX_TTL_MS,
+} from '../../config/contact';
 
 const currentLocale = getCurrentLocale(Astro.url);
 const chatUrl = new URL('/contact/chat/', Astro.url);
@@ -11,39 +15,52 @@ const embedChatUrl = new URL(chatUrl);
 embedChatUrl.searchParams.set('embed', '1');
 const embedChatPath = `${embedChatUrl.pathname}${embedChatUrl.search}`;
 const fallbackContactPath = getLocalizedUrl('/contact/', currentLocale);
-const copy = currentLocale === 'ja'
-  ? {
-      label: 'Cloudiaに相談する',
-      title: 'Cloudiaに相談する',
-      close: '閉じる',
-      fallback: 'チャットを開けない場合は、お問い合わせフォームをご利用ください。',
-      fallbackLink: 'お問い合わせフォームを開く',
-    }
-  : {
-      label: 'Chat with Cloudia',
-      title: 'Chat with Cloudia',
-      close: 'Close',
-      fallback: 'If the chat cannot be opened, please use the contact form instead.',
-      fallbackLink: 'Open the contact form',
-    };
+const fallbackContactUrl = new URL(fallbackContactPath, Astro.url);
+fallbackContactUrl.searchParams.set('locale', currentLocale);
+fallbackContactUrl.searchParams.set(
+  'source',
+  Astro.url.searchParams.get('source') || 'corsweb-launcher-fallback'
+);
+if (incomingIntent) fallbackContactUrl.searchParams.set('intent', incomingIntent);
+const fallbackContactHref = `${fallbackContactUrl.pathname}${fallbackContactUrl.search}`;
+const copy =
+  currentLocale === 'ja'
+    ? {
+        label: 'Cloudiaに相談する',
+        title: 'Cloudiaに相談する',
+        close: '閉じる',
+        fallback: 'チャットを開けない場合は、お問い合わせフォームをご利用ください。',
+        fallbackLink: 'お問い合わせフォームを開く',
+      }
+    : {
+        label: 'Chat with Cloudia',
+        title: 'Chat with Cloudia',
+        close: 'Close',
+        fallback: 'If the chat cannot be opened, please use the contact form instead.',
+        fallbackLink: 'Open the contact form',
+      };
 ---
 
 <aside
   id="cloudia-launcher"
   class="fixed bottom-[calc(1rem+env(safe-area-inset-bottom))] right-4 z-40 w-[min(24rem,calc(100vw-2rem))] sm:right-5"
   data-chat-path={embedChatPath}
+  data-grift-handoff-origins={JSON.stringify(CLOUDIA_GRIFT_HANDOFF_ALLOWED_ORIGINS)}
+  data-grift-handoff-max-ttl-ms={CLOUDIA_GRIFT_HANDOFF_MAX_TTL_MS}
 >
   <div
     id="cloudia-launcher-panel"
-    class="mb-3 hidden overflow-hidden rounded-2xl bg-primary-50 shadow-2xl ring-1 ring-primary-950/15 dark:bg-primary-950 dark:ring-primary-200/15"
+    class="ring-primary-950/15 dark:ring-primary-200/15 mb-3 hidden overflow-hidden rounded-2xl bg-primary-50 shadow-2xl ring-1 dark:bg-primary-950"
     aria-hidden="true"
   >
-    <div class="flex items-center justify-between gap-3 border-b border-primary-950/10 px-4 py-3 dark:border-primary-200/10">
+    <div
+      class="flex items-center justify-between gap-3 border-b border-primary-950/10 px-4 py-3 dark:border-primary-200/10"
+    >
       <h2 class="text-sm font-semibold text-primary-950 dark:text-primary-100">{copy.title}</h2>
       <button
         type="button"
         id="cloudia-launcher-close"
-        class="inline-flex min-h-9 min-w-9 items-center justify-center rounded-full text-primary-950/70 hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200/70 dark:hover:bg-primary-400/10"
+        class="min-h-9 min-w-9 inline-flex items-center justify-center rounded-full text-primary-950/70 hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:text-primary-200/70 dark:hover:bg-primary-400/10"
         aria-label={copy.close}
       >
         <span aria-hidden="true" class="text-xl leading-none">×</span>
@@ -56,25 +73,28 @@ const copy = currentLocale === 'ja'
         src={embedChatPath}
         class="h-full w-full border-0"
         loading="lazy"
-        referrerpolicy="strict-origin-when-cross-origin"
-      ></iframe>
+        referrerpolicy="strict-origin-when-cross-origin"></iframe>
       <div
         id="cloudia-launcher-fallback"
-        class="absolute inset-0 hidden flex-col items-center justify-center gap-3 bg-primary-50 px-6 text-center dark:bg-primary-950"
+        class="absolute inset-0 flex hidden flex-col items-center justify-center gap-3 bg-primary-50 px-6 text-center dark:bg-primary-950"
         role="status"
       >
-        <p class="text-sm leading-relaxed text-primary-950/75 dark:text-primary-200/75">{copy.fallback}</p>
+        <p class="text-sm leading-relaxed text-primary-950/75 dark:text-primary-200/75">
+          {copy.fallback}
+        </p>
         <a
-          href={fallbackContactPath}
-          class="inline-flex min-h-11 items-center justify-center rounded-full bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300"
-        >{copy.fallbackLink}</a>
+          href={fallbackContactHref}
+          data-cloudia-fallback-link
+          class="min-h-11 inline-flex items-center justify-center rounded-full bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300"
+          >{copy.fallbackLink}</a
+        >
       </div>
     </div>
   </div>
   <button
     type="button"
     id="cloudia-launcher-open"
-    class="ml-auto inline-flex min-h-12 items-center justify-center rounded-full bg-primary-600 px-5 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300"
+    class="min-h-12 ml-auto inline-flex items-center justify-center rounded-full bg-primary-600 px-5 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:bg-primary-400 dark:text-primary-950 dark:hover:bg-primary-300"
     aria-expanded="false"
     aria-controls="cloudia-launcher-panel"
   >
@@ -90,11 +110,34 @@ const copy = currentLocale === 'ja'
     const panel = document.getElementById('cloudia-launcher-panel');
     const frame = document.getElementById('cloudia-launcher-frame');
     const fallback = document.getElementById('cloudia-launcher-fallback');
-    if (!launcher || !openButton || !closeButton || !panel || !frame || !fallback) return;
+    const fallbackLink = launcher?.querySelector('[data-cloudia-fallback-link]');
+    if (
+      !launcher ||
+      !openButton ||
+      !closeButton ||
+      !panel ||
+      !frame ||
+      !fallback ||
+      !(fallbackLink instanceof HTMLAnchorElement)
+    )
+      return;
 
     let opened = false;
     let frameReady = false;
+    let handoffNavigationStarted = false;
     let fallbackTimer;
+
+    const allowedHandoffOrigins = (() => {
+      try {
+        const values = JSON.parse(launcher.dataset.griftHandoffOrigins || '[]');
+        return Array.isArray(values)
+          ? new Set(values.filter((value) => typeof value === 'string'))
+          : new Set();
+      } catch {
+        return new Set();
+      }
+    })();
+    const handoffMaxTtlMs = Number(launcher.dataset.griftHandoffMaxTtlMs);
 
     const applyIncomingContext = () => {
       const incoming = new URLSearchParams(window.location.search);
@@ -102,10 +145,14 @@ const copy = currentLocale === 'ja'
       const source = incoming.get('source');
       if (!intent && !source) return;
       const target = new URL(frame.src, window.location.href);
+      const fallbackTarget = new URL(fallbackLink.href, window.location.href);
       if (intent) target.searchParams.set('intent', intent);
       if (source) target.searchParams.set('source', source);
+      if (intent) fallbackTarget.searchParams.set('intent', intent);
+      if (source) fallbackTarget.searchParams.set('source', source);
       frame.src = target.toString();
       launcher.dataset.chatPath = `${target.pathname}${target.search}`;
+      fallbackLink.href = `${fallbackTarget.pathname}${fallbackTarget.search}${fallbackTarget.hash}`;
     };
 
     applyIncomingContext();
@@ -147,13 +194,55 @@ const copy = currentLocale === 'ja'
       openButton.focus();
     };
 
+    const parseHandoffUrl = (value) => {
+      if (typeof value !== 'string' || !value.trim() || value.length > 2048) return null;
+      try {
+        const url = new URL(value.trim());
+        if (!allowedHandoffOrigins.has(url.origin)) return null;
+        if (url.protocol !== 'https:' || url.username || url.password) return null;
+        if (!/^\/chat\/portal\/[A-Za-z0-9._~-]{1,512}$/.test(url.pathname)) return null;
+        if (url.search || url.hash) return null;
+        return url.toString();
+      } catch {
+        return null;
+      }
+    };
+
+    const hasValidHandoffExpiry = (value) => {
+      if (typeof value !== 'string' || !Number.isFinite(handoffMaxTtlMs) || handoffMaxTtlMs <= 0)
+        return false;
+      const expiresAt = Date.parse(value);
+      if (!Number.isFinite(expiresAt)) return false;
+      const remainingTtl = expiresAt - Date.now();
+      return remainingTtl > 0 && remainingTtl <= handoffMaxTtlMs;
+    };
+
     openButton.addEventListener('click', openPanel);
     closeButton.addEventListener('click', closePanel);
+    document.addEventListener('keydown', (event) => {
+      if (opened && event.key === 'Escape') closePanel();
+    });
     frame.addEventListener('load', inspectFrame);
     window.addEventListener('message', (event) => {
-      if (event.source !== frame.contentWindow || event.data !== 'cloudia:ready') return;
-      frameReady = true;
-      fallback.classList.add('hidden');
+      if (event.source !== frame.contentWindow || event.origin !== window.location.origin) return;
+      if (event.data === 'cloudia:ready') {
+        frameReady = true;
+        fallback.classList.add('hidden');
+        return;
+      }
+      if (
+        handoffNavigationStarted ||
+        !event.data ||
+        typeof event.data !== 'object' ||
+        event.data.type !== 'cloudia:grift-handoff-ready' ||
+        !hasValidHandoffExpiry(event.data.expiresAt)
+      )
+        return;
+
+      const handoffUrl = parseHandoffUrl(event.data.url);
+      if (!handoffUrl) return;
+      handoffNavigationStarted = true;
+      window.location.assign(handoffUrl);
     });
   })();
 </script>

--- a/src/components/contact/ContactForm.astro
+++ b/src/components/contact/ContactForm.astro
@@ -5,6 +5,8 @@ const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
 const consent = t.contactConsent;
 const privacyHref = getLocalizedUrl('/privacy', currentLocale);
+const incomingIntent = Astro.url.searchParams.get('intent') || '';
+const incomingSource = Astro.url.searchParams.get('source') || 'corsweb-contact-form';
 ---
 
 <section class="py-16 sm:py-20">
@@ -30,6 +32,9 @@ const privacyHref = getLocalizedUrl('/privacy', currentLocale);
         method="post"
         class="mt-3 flex flex-col gap-y-6"
       >
+        <input type="hidden" name="intent" value={incomingIntent} data-contact-query-field />
+        <input type="hidden" name="source" value={incomingSource} data-contact-query-field />
+        <input type="hidden" name="locale" value={currentLocale} data-contact-query-field />
         <!-- Full name input -->
         <div>
           <label for="your-name" class="sr-only">{t.contact.form.fields.name}</label>
@@ -156,6 +161,12 @@ const privacyHref = getLocalizedUrl('/privacy', currentLocale);
   //   (2) onSubmit でも安全網として再チェック
   // の二段構えにする。reCAPTCHA が解決し かつ 同意済みのときのみ form.submit() に到達する。
   (function () {
+    var query = new URLSearchParams(window.location.search);
+    document.querySelectorAll("[data-contact-query-field]").forEach(function (field) {
+      var name = field.getAttribute("name");
+      if (name && query.has(name)) field.value = query.get(name) || "";
+    });
+
     function isConsented() {
       var cb = document.getElementById("privacy-consent");
       return !!(cb && cb.checked);

--- a/src/components/contact/ContactInfo.astro
+++ b/src/components/contact/ContactInfo.astro
@@ -5,6 +5,9 @@ const currentLocale = getCurrentLocale(Astro.url);
 const t = getTranslations(currentLocale);
 const cloudiaHref = new URL('/contact/chat/', Astro.url);
 cloudiaHref.searchParams.set('locale', currentLocale);
+cloudiaHref.searchParams.set('source', 'corsweb-contact-info');
+const incomingIntent = Astro.url.searchParams.get('intent');
+if (incomingIntent) cloudiaHref.searchParams.set('intent', incomingIntent);
 ---
 
 <section class="py-16 sm:py-20">
@@ -55,6 +58,7 @@ cloudiaHref.searchParams.set('locale', currentLocale);
           </svg>
           <a
             href={`${cloudiaHref.pathname}${cloudiaHref.search}`}
+            data-cloudia-query-link
             class="block no-underline"
           >
             <p class="text-base font-medium">{t.contactInfo.chat.value}</p>

--- a/src/components/home/HomeNewsRail.astro
+++ b/src/components/home/HomeNewsRail.astro
@@ -51,12 +51,20 @@ const itemListJsonLd = {
                 {t.homeNews.description}
               </p>
             </div>
-            <a
-              href="/news"
-              class="type-action inline-flex min-h-[48px] w-fit items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
-            >
-              {t.homeNews.cta}
-            </a>
+            <div class="flex flex-wrap items-center gap-3">
+              <a
+                href="/news"
+                class="type-action inline-flex min-h-[48px] w-fit items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+              >
+                {t.homeNews.cta}
+              </a>
+              <a
+                href="/news/press/"
+                class="type-action inline-flex min-h-[48px] w-fit items-center justify-center rounded-full border border-primary-950/20 px-5 py-3 text-base font-medium text-primary-950 transition hover:bg-primary-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 dark:border-primary-200/20 dark:text-primary-200 dark:hover:bg-primary-400/10"
+              >
+                プレスリリース
+              </a>
+            </div>
           </div>
 
           <div

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -12,6 +12,7 @@ const nav = t.nav as typeof t.nav & {
   serviceAiDev?: string;
   industries?: string;
   consult?: string;
+  press?: string;
 };
 
 // サービス導線（ADR-0011）: LP 未整備のため intent 付き /contact と Grift
@@ -54,6 +55,7 @@ const baseLinks = [
     ? [
         { name: t.nav.works, href: getLocalizedUrl('/works', currentLocale), isExternal: false },
         { name: t.nav.news, href: getLocalizedUrl('/news', currentLocale), isExternal: false },
+        { name: nav.press || 'プレスリリース', href: getLocalizedUrl('/news/press', currentLocale), isExternal: false },
       ]
     : []),
   {
@@ -98,6 +100,7 @@ const quickLinks = [
     ? [
         { name: t.nav.works, href: getLocalizedUrl('/works', currentLocale) },
         { name: t.nav.news, href: getLocalizedUrl('/news', currentLocale) },
+        { name: nav.press || 'プレスリリース', href: getLocalizedUrl('/news/press', currentLocale) },
       ]
     : []),
   { name: t.nav.security, href: getLocalizedUrl('/security', currentLocale) },

--- a/src/config/__tests__/contact.test.ts
+++ b/src/config/__tests__/contact.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function loadContactConfig() {
+  vi.resetModules();
+  return import('../contact');
+}
+
+describe('Cloudia Grift handoff configuration', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('uses the canonical Grift app origin and 24-hour TTL', async () => {
+    vi.stubEnv('PUBLIC_GRIFT_HANDOFF_ALLOWED_ORIGINS', '');
+    const { CLOUDIA_GRIFT_HANDOFF_ALLOWED_ORIGINS, CLOUDIA_GRIFT_HANDOFF_MAX_TTL_MS } =
+      await loadContactConfig();
+
+    expect(CLOUDIA_GRIFT_HANDOFF_ALLOWED_ORIGINS).toEqual(['https://app.griftai.org']);
+    expect(CLOUDIA_GRIFT_HANDOFF_MAX_TTL_MS).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it('adds only exact HTTPS origins from the configured allowlist', async () => {
+    vi.stubEnv(
+      'PUBLIC_GRIFT_HANDOFF_ALLOWED_ORIGINS',
+      [
+        'https://preview.grift.example',
+        'https://preview.grift.example/',
+        'http://insecure.example',
+        'https://user:password@evil.example',
+        'https://evil.example/path',
+        'https://evil.example/?next=1',
+        'not-a-url',
+      ].join(',')
+    );
+    const { CLOUDIA_GRIFT_HANDOFF_ALLOWED_ORIGINS } = await loadContactConfig();
+
+    expect(CLOUDIA_GRIFT_HANDOFF_ALLOWED_ORIGINS).toEqual([
+      'https://app.griftai.org',
+      'https://preview.grift.example',
+    ]);
+  });
+});

--- a/src/config/__tests__/news-categories.test.ts
+++ b/src/config/__tests__/news-categories.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { getNewsCategoryConfig, getNewsCategoryIds, getNewsCategoryLabel } from '../news-categories';
+
+describe('news categories', () => {
+  it('keeps press as a CMS-compatible category with localized labels', () => {
+    expect(getNewsCategoryIds()).toContain('press');
+    expect(getNewsCategoryConfig('press')?.label.ja).toBe('プレスリリース');
+    expect(getNewsCategoryLabel('press', 'en')).toBe('Press release');
+  });
+});

--- a/src/config/contact.ts
+++ b/src/config/contact.ts
@@ -8,6 +8,11 @@
 // 本番切替はこの 1 行を true にするだけ（デプロイ + 動作確認の後に行う）。
 export const CONTACT_CHAT_ENABLED = false;
 
+// Cloudia を /contact/ の主導線にする。false に戻すと既存フォームをページ本体へ戻せる。
+// Cloudia 自体の停止時に、既存の ContactForm fallback を残したまま切り戻すためのビルド時フラグ。
+export const CLOUDIA_CONTACT_PRIMARY_ENABLED =
+  import.meta.env.PUBLIC_CLOUDIA_CONTACT_PRIMARY_ENABLED !== 'false';
+
 // CloudiaLauncher は既存フォームを残したまま、Cloudia への入口だけを追加する。
 // CONTACT_CHAT_ENABLED（旧ContactChat.astroの置換）とは独立して切り替える。
 // 未指定時は有効。無効化する場合は PUBLIC_CLOUDIA_LAUNCHER_ENABLED=false をビルド時に設定する。

--- a/src/config/contact.ts
+++ b/src/config/contact.ts
@@ -16,5 +16,40 @@ export const CLOUDIA_CONTACT_PRIMARY_ENABLED =
 // CloudiaLauncher は既存フォームを残したまま、Cloudia への入口だけを追加する。
 // CONTACT_CHAT_ENABLED（旧ContactChat.astroの置換）とは独立して切り替える。
 // 未指定時は有効。無効化する場合は PUBLIC_CLOUDIA_LAUNCHER_ENABLED=false をビルド時に設定する。
-export const CLOUDIA_LAUNCHER_ENABLED =
-  import.meta.env.PUBLIC_CLOUDIA_LAUNCHER_ENABLED !== 'false';
+export const CLOUDIA_LAUNCHER_ENABLED = import.meta.env.PUBLIC_CLOUDIA_LAUNCHER_ENABLED !== 'false';
+
+// Cloudia iframe から受け取る Grift 公開ポータル URL の許可 origin。
+// Preview を追加する場合は、path や query を含まない HTTPS origin をカンマ区切りで指定する。
+const DEFAULT_GRIFT_HANDOFF_ORIGIN = 'https://app.griftai.org';
+
+export const CLOUDIA_GRIFT_HANDOFF_MAX_TTL_MS = 24 * 60 * 60 * 1000;
+
+function normalizeAllowedHttpsOrigin(value: string): string | null {
+  try {
+    const url = new URL(value.trim());
+    if (
+      url.protocol !== 'https:' ||
+      url.username ||
+      url.password ||
+      url.pathname !== '/' ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function getCloudiaGriftHandoffAllowedOrigins(): readonly string[] {
+  const configured = (import.meta.env.PUBLIC_GRIFT_HANDOFF_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map(normalizeAllowedHttpsOrigin)
+    .filter((origin: string | null): origin is string => origin !== null);
+
+  return [...new Set([DEFAULT_GRIFT_HANDOFF_ORIGIN, ...configured])];
+}
+
+export const CLOUDIA_GRIFT_HANDOFF_ALLOWED_ORIGINS = getCloudiaGriftHandoffAllowedOrigins();

--- a/src/config/news-categories.ts
+++ b/src/config/news-categories.ts
@@ -92,6 +92,23 @@ export const NEWS_CATEGORIES = [
       es: 'Premios, selecciones y otros logros publicables',
     },
   },
+  {
+    id: 'press',
+    label: {
+      ja: 'プレスリリース',
+      en: 'Press release',
+      zh: '新闻稿',
+      ko: '보도자료',
+      es: 'Nota de prensa',
+    },
+    description: {
+      ja: 'Cor.株式会社が公式に発表するプレスリリース',
+      en: 'Official press releases from Cor. Inc.',
+      zh: 'Cor.株式会社的官方新闻稿',
+      ko: 'Cor. 주식회사의 공식 보도자료',
+      es: 'Notas de prensa oficiales de Cor. Inc.',
+    },
+  },
 ] as const satisfies readonly NewsCategoryConfig[];
 
 export const getNewsCategoryConfig = (categoryId: string): NewsCategoryConfig | undefined =>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -13,6 +13,7 @@ interface ImportMetaEnv {
   readonly PUBLIC_GCAL_TZ?: string;
   readonly PUBLIC_GCAL_PARAMS?: string;
   readonly PUBLIC_CLOUDIA_LAUNCHER_ENABLED?: string;
+  readonly PUBLIC_CLOUDIA_CONTACT_PRIMARY_ENABLED?: string;
 }
 
 declare global {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,6 +14,7 @@ interface ImportMetaEnv {
   readonly PUBLIC_GCAL_PARAMS?: string;
   readonly PUBLIC_CLOUDIA_LAUNCHER_ENABLED?: string;
   readonly PUBLIC_CLOUDIA_CONTACT_PRIMARY_ENABLED?: string;
+  readonly PUBLIC_GRIFT_HANDOFF_ALLOWED_ORIGINS?: string;
 }
 
 declare global {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,8 +26,6 @@ interface Props {
   // SEO用 <title> と SNS用 og:title を分離したい場合に指定する。
   ogTitle?: string;
   ogDescription?: string;
-  // Contactページだけモバイル固定CTAを表示する。PC CTAは全ページ共通。
-  cloudiaMobileLauncher?: boolean;
   // Cloudiaのfallbackページ自身ではLauncherを重ねない。
   cloudiaLauncher?: boolean;
 }
@@ -41,7 +39,7 @@ const OG_LOCALES: Record<Locale, string> = {
 };
 const ALL_LOCALES = ['ja', 'en', 'zh', 'ko', 'es'] as const;
 
-const { description, title, availableLocales = ALL_LOCALES, ogImage: ogImageProp, ogType = 'website', publishedTime, modifiedTime, ogTitle, ogDescription, cloudiaMobileLauncher = false, cloudiaLauncher = true } = Astro.props;
+const { description, title, availableLocales = ALL_LOCALES, ogImage: ogImageProp, ogType = 'website', publishedTime, modifiedTime, ogTitle, ogDescription, cloudiaLauncher = true } = Astro.props;
 const socialTitle = ogTitle || title;
 const socialDescription = ogDescription || description;
 const currentLocale = getCurrentLocale(Astro.url);
@@ -396,7 +394,7 @@ const robotsContent = getRobotsContent();
       <slot />
     </main>
     <Footer />
-    {CLOUDIA_LAUNCHER_ENABLED && cloudiaLauncher && <CloudiaLauncher showMobile={cloudiaMobileLauncher} />}
+    {CLOUDIA_LAUNCHER_ENABLED && cloudiaLauncher && <CloudiaLauncher />}
     <WebVitals />
     <script data-cfasync="false">
       // Global store fallback - ストアが未定義の場合のデフォルト値

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,9 +3,10 @@ import Calendar from '../components/contact/Calendar.astro';
 import ContactChat from '../components/contact/ContactChat.astro';
 import ContactForm from '../components/contact/ContactForm.astro';
 import ContactInfo from '../components/contact/ContactInfo.astro';
+import CloudiaContactEntry from '../components/contact/CloudiaContactEntry.astro';
 import Heading from '../components/contact/Heading.astro';
 import Layout from '../layouts/Layout.astro';
-import { CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../config/contact';
+import { CLOUDIA_CONTACT_PRIMARY_ENABLED, CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../config/contact';
 import { getCurrentLocale, getTranslations } from '../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -19,12 +20,17 @@ const t = getTranslations(currentLocale);
 <Layout
   description={t.meta.contact.description}
   title={t.meta.contact.title}
-  cloudiaMobileLauncher
 >
   <Heading />
   {
     CONTACT_CHAT_ENABLED ? (
       <ContactChat />
+    ) : CLOUDIA_CONTACT_PRIMARY_ENABLED ? (
+      <CloudiaContactEntry>
+        <ContactInfo />
+        <Calendar />
+        <ContactForm />
+      </CloudiaContactEntry>
     ) : (
       <section id="contact-form-fallback" data-cloudia-fallback={CLOUDIA_LAUNCHER_ENABLED ? 'true' : 'false'}>
         <ContactInfo />

--- a/src/pages/en/contact.astro
+++ b/src/pages/en/contact.astro
@@ -3,9 +3,10 @@ import Calendar from '../../components/contact/Calendar.astro';
 import ContactChat from '../../components/contact/ContactChat.astro';
 import ContactForm from '../../components/contact/ContactForm.astro';
 import ContactInfo from '../../components/contact/ContactInfo.astro';
+import CloudiaContactEntry from '../../components/contact/CloudiaContactEntry.astro';
 import Heading from '../../components/contact/Heading.astro';
 import Layout from '../../layouts/Layout.astro';
-import { CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../../config/contact';
+import { CLOUDIA_CONTACT_PRIMARY_ENABLED, CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../../config/contact';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -19,12 +20,17 @@ const t = getTranslations(currentLocale);
 <Layout
   description={t.meta.contact.description}
   title={t.meta.contact.title}
-  cloudiaMobileLauncher
 >
   <Heading />
   {
     CONTACT_CHAT_ENABLED ? (
       <ContactChat />
+    ) : CLOUDIA_CONTACT_PRIMARY_ENABLED ? (
+      <CloudiaContactEntry>
+        <ContactInfo />
+        <Calendar />
+        <ContactForm />
+      </CloudiaContactEntry>
     ) : (
       <section id="contact-form-fallback" data-cloudia-fallback={CLOUDIA_LAUNCHER_ENABLED ? 'true' : 'false'}>
         <ContactInfo />

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -3,9 +3,10 @@ import Calendar from '../../components/contact/Calendar.astro';
 import ContactChat from '../../components/contact/ContactChat.astro';
 import ContactForm from '../../components/contact/ContactForm.astro';
 import ContactInfo from '../../components/contact/ContactInfo.astro';
+import CloudiaContactEntry from '../../components/contact/CloudiaContactEntry.astro';
 import Heading from '../../components/contact/Heading.astro';
 import Layout from '../../layouts/Layout.astro';
-import { CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../../config/contact';
+import { CLOUDIA_CONTACT_PRIMARY_ENABLED, CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../../config/contact';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -19,12 +20,17 @@ const t = getTranslations(currentLocale);
 <Layout
   description={t.meta.contact.description}
   title={t.meta.contact.title}
-  cloudiaMobileLauncher
 >
   <Heading />
   {
     CONTACT_CHAT_ENABLED ? (
       <ContactChat />
+    ) : CLOUDIA_CONTACT_PRIMARY_ENABLED ? (
+      <CloudiaContactEntry>
+        <ContactInfo />
+        <Calendar />
+        <ContactForm />
+      </CloudiaContactEntry>
     ) : (
       <section id="contact-form-fallback" data-cloudia-fallback={CLOUDIA_LAUNCHER_ENABLED ? 'true' : 'false'}>
         <ContactInfo />

--- a/src/pages/ko/contact.astro
+++ b/src/pages/ko/contact.astro
@@ -3,9 +3,10 @@ import Calendar from '../../components/contact/Calendar.astro';
 import ContactChat from '../../components/contact/ContactChat.astro';
 import ContactForm from '../../components/contact/ContactForm.astro';
 import ContactInfo from '../../components/contact/ContactInfo.astro';
+import CloudiaContactEntry from '../../components/contact/CloudiaContactEntry.astro';
 import Heading from '../../components/contact/Heading.astro';
 import Layout from '../../layouts/Layout.astro';
-import { CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../../config/contact';
+import { CLOUDIA_CONTACT_PRIMARY_ENABLED, CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../../config/contact';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -19,12 +20,17 @@ const t = getTranslations(currentLocale);
 <Layout
   description={t.meta.contact.description}
   title={t.meta.contact.title}
-  cloudiaMobileLauncher
 >
   <Heading />
   {
     CONTACT_CHAT_ENABLED ? (
       <ContactChat />
+    ) : CLOUDIA_CONTACT_PRIMARY_ENABLED ? (
+      <CloudiaContactEntry>
+        <ContactInfo />
+        <Calendar />
+        <ContactForm />
+      </CloudiaContactEntry>
     ) : (
       <section id="contact-form-fallback" data-cloudia-fallback={CLOUDIA_LAUNCHER_ENABLED ? 'true' : 'false'}>
         <ContactInfo />

--- a/src/pages/news/[...page].astro
+++ b/src/pages/news/[...page].astro
@@ -65,6 +65,12 @@ const itemListJsonLd = {
       >
         {t.news.rssLabel}
       </a>
+      <a
+        href="/news/press/"
+        class="type-action inline-flex w-fit items-center gap-2 text-sm text-primary-950/60 underline-offset-4 transition hover:text-primary-950 hover:underline dark:text-primary-200/60 dark:hover:text-primary-100"
+      >
+        プレスリリースを見る
+      </a>
     </div>
 
     {page.total > page.size && (

--- a/src/pages/news/press.astro
+++ b/src/pages/news/press.astro
@@ -1,0 +1,71 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+import NewsCard from '../../components/news/NewsCard.astro';
+import Layout from '../../layouts/Layout.astro';
+import { getNewsCategoryLabel } from '../../config/news-categories';
+import { safeJsonLd } from '../../utils/json-ld';
+
+const pressEntries = (await getCollection('news', ({ data }) => {
+  return data.category === 'press' && (import.meta.env.DEV || !data.isDraft);
+}))
+  .filter((entry): entry is CollectionEntry<'news'> => entry.data.category === 'press')
+  .sort((a, b) => new Date(b.data.publishedAt).getTime() - new Date(a.data.publishedAt).getTime());
+const pageUrl = new URL('/news/press/', Astro.site).toString();
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: getNewsCategoryLabel('press', 'ja'),
+  description: 'Cor.株式会社のプレスリリース一覧',
+  inLanguage: 'ja',
+  url: pageUrl,
+  mainEntity: {
+    '@type': 'ItemList',
+    itemListElement: pressEntries.map((entry, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: entry.data.title,
+      url: entry.data.externalUrl || new URL(`/news/${entry.slug}/`, Astro.site).toString(),
+    })),
+  },
+};
+---
+
+<Layout
+  description="Cor.株式会社のプレスリリース一覧"
+  title="プレスリリース | Cor.株式会社"
+  availableLocales={['ja']}
+>
+  <main class="mx-auto max-w-2xl px-4 py-16 sm:px-6 sm:py-20 lg:max-w-7xl lg:px-8">
+    <div class="mx-auto flex max-w-3xl flex-col gap-4 pb-10 text-start sm:pb-12">
+      <p class="text-sm font-medium uppercase tracking-widest text-primary-600 dark:text-primary-400">Press</p>
+      <h1 class="type-heading text-3xl font-medium tracking-tight sm:text-4xl md:text-5xl">プレスリリース</h1>
+      <p class="type-copy text-lg text-primary-950/70 dark:text-primary-200/70">
+        Cor.株式会社が公式に発表するプレスリリースを掲載しています。
+      </p>
+      <div class="flex flex-wrap gap-4 text-sm">
+        <a href="/news/" class="text-primary-950/60 underline-offset-4 hover:text-primary-950 hover:underline dark:text-primary-200/60 dark:hover:text-primary-100">ニュース一覧</a>
+        <a href="/news.xml" class="text-primary-950/60 underline-offset-4 hover:text-primary-950 hover:underline dark:text-primary-200/60 dark:hover:text-primary-100">ニュースRSS</a>
+      </div>
+    </div>
+
+    {pressEntries.length > 0 ? (
+      <ul class="mx-auto grid max-w-5xl grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {pressEntries.map((entry) => (
+          <li>
+            <NewsCard entry={entry} />
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <div class="mx-auto flex max-w-3xl flex-col gap-4 rounded-3xl bg-primary-500/10 p-6 dark:bg-primary-400/10">
+        <p class="type-copy text-primary-950/70 dark:text-primary-200/70">現在公開中のプレスリリースはありません。</p>
+        <a href="/contact/chat/?intent=press-speaking-other&source=press-page" class="type-action inline-flex w-fit items-center gap-1 text-sm text-primary-950/60 underline-offset-4 hover:text-primary-950 hover:underline dark:text-primary-200/60 dark:hover:text-primary-100">
+          プレスに関するお問い合わせ
+        </a>
+      </div>
+    )}
+  </main>
+
+  <script type="application/ld+json" set:html={safeJsonLd(jsonLd)} is:inline />
+</Layout>

--- a/src/pages/zh/contact.astro
+++ b/src/pages/zh/contact.astro
@@ -3,9 +3,10 @@ import Calendar from '../../components/contact/Calendar.astro';
 import ContactChat from '../../components/contact/ContactChat.astro';
 import ContactForm from '../../components/contact/ContactForm.astro';
 import ContactInfo from '../../components/contact/ContactInfo.astro';
+import CloudiaContactEntry from '../../components/contact/CloudiaContactEntry.astro';
 import Heading from '../../components/contact/Heading.astro';
 import Layout from '../../layouts/Layout.astro';
-import { CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../../config/contact';
+import { CLOUDIA_CONTACT_PRIMARY_ENABLED, CLOUDIA_LAUNCHER_ENABLED, CONTACT_CHAT_ENABLED } from '../../config/contact';
 import { getCurrentLocale, getTranslations } from '../../utils/i18n';
 
 const currentLocale = getCurrentLocale(Astro.url);
@@ -19,12 +20,17 @@ const t = getTranslations(currentLocale);
 <Layout
   description={t.meta.contact.description}
   title={t.meta.contact.title}
-  cloudiaMobileLauncher
 >
   <Heading />
   {
     CONTACT_CHAT_ENABLED ? (
       <ContactChat />
+    ) : CLOUDIA_CONTACT_PRIMARY_ENABLED ? (
+      <CloudiaContactEntry>
+        <ContactInfo />
+        <Calendar />
+        <ContactForm />
+      </CloudiaContactEntry>
     ) : (
       <section id="contact-form-fallback" data-cloudia-fallback={CLOUDIA_LAUNCHER_ENABLED ? 'true' : 'false'}>
         <ContactInfo />


### PR DESCRIPTION
## Summary
- make Cloudia the primary `/contact/` entry while keeping SSGFORM and scheduling in an explicit fallback
- keep `intent`, `source`, and `locale` across primary links, launcher iframe, and fallback form at runtime
- make the Cloudia launcher available on every page with mobile safe-area/bottom-sheet behavior and focus handling
- add the `press` news category and `/news/press/` page with Home/Header/News/RSS/JSON-LD paths
- revise ADR-0009 to Accepted and record press-release governance; keep the Fukuoka 100-selection badge hidden until permission and official assets exist

## Verification
- `npm run test:run` — 67 tests passed
- `npm run build` — 441 pages built
- `git diff --check`
- Firebase develop Preview deployed
- Preview browser E2E 7/7 passed
- preview smoke checks returned 200 for `/contact/`, `/contact/chat/`, `/news/`, `/news/press/`, `/news.xml`, and `/`

## State boundary
- implemented / merged to `develop` / Firebase develop Preview deployed / Preview browser verified
- production deploy and production live verification are not complete

## Tracking
- Parent: #254, #164
- Implementation child: #275, #277
- Fukuoka permission/asset child remains open: #276
- This PR does not implement Grift handoff (#259) or monorepo cutover (#255).