### PR TITLE
chore: disable claude-review auto-trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,9 @@
 name: Claude Code Review
 
+# Disabled 2026-08-16: empty credentials made this job fail without reviewing
+# (Cor-Incorporated/persona-village-v2#801). Restore pull_request after secrets exist.
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"


### PR DESCRIPTION
## Summary
- `claude-review` ジョブだけを止める。`pull_request` 自動発火を外し、`workflow_dispatch` のみ残す。
- 実装用 CI と `Claude Code`（@claude mention）は変更しない。
- 認証空でレビュー 0 件のまま赤になっていた無駄な発火を止める（Cor-Incorporated/persona-village-v2#801）。

## Evidence / ADR
- 一次資料: https://github.com/Cor-Incorporated/persona-village-v2/issues/801
- 変更ファイル: `.github/workflows/claude-code-review.yml` の `on:` のみ

## Verification
- [x] 該当なし（実装コードなし / workflow trigger の形式変更のみ）

## 実環境貫通（C11 / Track B B1）
- [x] **該当なし**（実環境を持たない変更 / docs のみ / 人間ゲート待ち）。理由: workflow の trigger を外すだけ。GitHub 上で `Claude Code Review` を `disabled_manually` にした実測で代替。

## 未知の依存・API（C16 / Track B B4）
- [x] **該当なし**（初出の依存・API を使っていない）

## 完了条件の形式（Track B B2）
- [x] **該当なし**（docs のみ / 形式変更のみ 等）。理由: trigger 削除のみ。他ジョブ定義は無変更。

## H5 admission
H5-NEGATIVE: known-bad empty-auth path: persona-village-v2 PR #800 run 31878934025 failed in 29s with ANTHROPIC_API_KEY empty, AWS_BEARER_TOKEN_BEDROCK empty, is_error:true, and zero review comments. Same fail on #798/#799. After this change the job must not start on pull_request.
H5-LEDGER: N/A no new hook or block-capable guard; this PR only removes the pull_request trigger. Repo-level `gh workflow disable` already recorded disabled_manually. No guard-ledger.jsonl wiring is added because no hook fires.
H5-RETIRE: restore the pull_request trigger after CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY is set and a review body is measured on a live PR; otherwise keep disabled if 90 days of zero useful fires.
H5-SUBTRACTION: N/A
